### PR TITLE
Change urn:altinn:orgNumber claim type to string in exchanged tokens

### DIFF
--- a/src/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/Controllers/AuthenticationController.cs
@@ -449,7 +449,7 @@ namespace Altinn.Platform.Authentication.Controllers
                     }
                 }
 
-                claims.Add(new Claim(AltinnCoreClaimTypes.OrgNumber, orgNumber, ClaimValueTypes.Integer32, issuer));
+                claims.Add(new Claim(AltinnCoreClaimTypes.OrgNumber, orgNumber, ClaimValueTypes.String, issuer));
                 claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticateMethod, authenticatemethod, ClaimValueTypes.String, issuer));
                 claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticationLevel, "3", ClaimValueTypes.Integer32, issuer));
 


### PR DESCRIPTION
## Description
This changes the `urn:altinn:orgNumber` claim as created by token exchange in Maskinporten tokens to be of type `string` instead of `Integer32`.

This claim being an integer appears to be unintended, as most other uses of [AltinnCoreClaimTypes.OrgNumber](https://github.com/search?q=org%3AAltinn%20AltinnCoreClaimTypes.OrgNumber&type=code) assume it to be a string. 

In case of authorization, this causes issues with policies using `urn:altinn:organizationnumber` as a subject-attribute defined as a string, as this will not match when claims are [copied from the token](https://github.com/Altinn/altinn-authorization/blob/main/src/Altinn.Common.PEP/Altinn.Common.PEP/Helpers/DecisionHelper.cs#L180).  A workaround is to define both the integer and string versions of the attribute:
![image](https://github.com/Altinn/altinn-authentication/assets/723303/250b0fe3-016c-41ef-9645-cf9b050d10c7)

An alternative solution would be to override the type in Altinn.Common.PEP and roll out new packages to all consumers, if changing it in authentication would break things (this is currently unclear).

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
