### PR TITLE
Feature/sessionid implementation

### DIFF
--- a/src/Authentication/Helpers/AuthenticationHelper.cs
+++ b/src/Authentication/Helpers/AuthenticationHelper.cs
@@ -83,6 +83,12 @@ namespace Altinn.Platform.Authentication.Helpers
                     continue;
                 }
 
+                if (claim.Type.Equals("jti"))
+                {
+                    userAuthenticationModel.ExternalSessionId = claim.Value;
+                    continue;
+                }
+
                 if (!string.IsNullOrEmpty(provider.ExternalIdentityClaim) && claim.Type.Equals(provider.ExternalIdentityClaim))
                 {
                     userAuthenticationModel.ExternalIdentity = claim.Value;

--- a/src/Authentication/Helpers/EventlogHelper.cs
+++ b/src/Authentication/Helpers/EventlogHelper.cs
@@ -24,8 +24,18 @@ namespace Altinn.Platform.Authentication.Helpers
         /// </summary>
         /// <param name="jwtToken">authenticated token</param>
         /// <param name="eventType">authentication event type</param>
+        /// <param name="context">the http context</param>
+        /// <param name="currentDateTime">the timestamp of the event</param>
+        /// <param name="externalSessionId">the external session id</param>
+        /// <param name="isAuthenticated">true when the request is authenticated</param>
         /// <returns>authentication event</returns>
-        public static AuthenticationEvent MapAuthenticationEvent(string jwtToken, AuthenticationEventType eventType, HttpContext context, DateTime currentDateTime, bool isAuthenticated = true)
+        public static AuthenticationEvent MapAuthenticationEvent(
+            string jwtToken, 
+            AuthenticationEventType eventType, 
+            HttpContext context, 
+            DateTime currentDateTime,
+            string? externalSessionId,
+            bool isAuthenticated = true)
         {
             JwtSecurityTokenHandler tokenHandler = new JwtSecurityTokenHandler();
             AuthenticationEvent authenticationEvent = null;
@@ -66,13 +76,17 @@ namespace Altinn.Platform.Authentication.Helpers
                             case "acr":
                                 authenticationEvent.AuthenticationLevel = AuthenticationHelper.GetAuthenticationLevelForIdPorten(claim.Value);
                                 break;
+                            case "jti":
+                                authenticationEvent.SessionId = claim.Value;
+                                break;
                         }
                     }
 
                     authenticationEvent.Created = currentDateTime;
                     authenticationEvent.EventType = eventType;
                     authenticationEvent.IpAddress = GetClientIpAddress(context);
-                    authenticationEvent.IsAuthenticated = isAuthenticated;                    
+                    authenticationEvent.IsAuthenticated = isAuthenticated;
+                    authenticationEvent.ExternalSessionId = externalSessionId;
                 }
 
                 return authenticationEvent;
@@ -86,6 +100,8 @@ namespace Altinn.Platform.Authentication.Helpers
         /// </summary>
         /// <param name="authenticatedUser">authenticated user</param>
         /// <param name="eventType">type of authentication event</param>
+        /// <param name="context">the http context</param>
+        /// <param name="currentDateTime">the date time of the event</param>
         /// <returns>authentication event</returns>
         public static AuthenticationEvent MapAuthenticationEvent(UserAuthenticationModel authenticatedUser, AuthenticationEventType eventType, HttpContext context, DateTime currentDateTime)
         {
@@ -99,7 +115,9 @@ namespace Altinn.Platform.Authentication.Helpers
                 authenticationEvent.UserId = authenticatedUser.UserID;
                 authenticationEvent.EventType = eventType;
                 authenticationEvent.IpAddress = GetClientIpAddress(context);
-                authenticationEvent.IsAuthenticated = authenticatedUser.IsAuthenticated;                
+                authenticationEvent.IsAuthenticated = authenticatedUser.IsAuthenticated;
+                authenticationEvent.SessionId = authenticatedUser.SessionId;
+                authenticationEvent.ExternalSessionId = authenticatedUser.ExternalSessionId;
             }
 
             return authenticationEvent;

--- a/src/Authentication/Model/AuthenticationEvent.cs
+++ b/src/Authentication/Model/AuthenticationEvent.cs
@@ -11,6 +11,16 @@ namespace Altinn.Platform.Authentication.Model
     public class AuthenticationEvent
     {
         /// <summary>
+        /// Session Id of the authentication request
+        /// </summary>
+        public string? SessionId { get; set; }
+
+        /// <summary>
+        /// External Session Id of the authentication request if found
+        /// </summary>
+        public string? ExternalSessionId { get; set; }
+
+        /// <summary>
         /// Date, time of the authentication event. Set by producer of logevents
         /// </summary>
         public DateTime Created { get; set; }
@@ -54,5 +64,10 @@ namespace Altinn.Platform.Authentication.Model
         /// The authentication result
         /// </summary>
         public bool IsAuthenticated { get; set; }
+
+        /// <summary>
+        /// Subscription key of the app that triggered the authentiation request
+        /// </summary>
+        public string? SubscriptionKey { get; set; }
     }
 }

--- a/src/Authentication/Model/UserAuthenticationModel.cs
+++ b/src/Authentication/Model/UserAuthenticationModel.cs
@@ -73,5 +73,15 @@ namespace Altinn.Platform.Authentication.Model
         /// The external identity
         /// </summary>
         public string ExternalIdentity { get; internal set; }
+
+        /// <summary>
+        /// The session identity
+        /// </summary>
+        public string? SessionId { get; internal set; }
+
+        /// <summary>
+        /// The external session identity (jti)
+        /// </summary>
+        public string ExternalSessionId { get; internal set; }
     }
 }

--- a/src/Authentication/Program.cs
+++ b/src/Authentication/Program.cs
@@ -234,6 +234,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     services.AddSingleton<IEventsQueueClient, EventsQueueClient>();
     services.AddSingleton<IEventLog, EventLogService>();
     services.AddSingleton<ISystemClock, SystemClock>();
+    services.AddSingleton<IGuidService, GuidService>();
 
     if (!string.IsNullOrEmpty(applicationInsightsConnectionString))
     {

--- a/src/Authentication/Services/EventLogService.cs
+++ b/src/Authentication/Services/EventLogService.cs
@@ -26,6 +26,7 @@ namespace Altinn.Platform.Authentication.Services
         /// Instantiation for event log servcie
         /// </summary>
         /// <param name="queueClient">queue client to store event in event log</param>
+        /// <param name="systemClock">the systemclock to get the current datetime</param>
         public EventLogService(IEventsQueueClient queueClient, ISystemClock systemClock)
         {
             _queueClient = queueClient;
@@ -58,11 +59,17 @@ namespace Altinn.Platform.Authentication.Services
         /// <param name="jwtToken">the token cookie with user information</param>
         /// <param name="eventType">authentication event type</param>
         /// <param name="context">the http context</param>
-        public async Task CreateAuthenticationEventAsync(IFeatureManager featureManager, string jwtToken, AuthenticationEventType eventType, HttpContext context)
+        /// <param name="externalSessionId">the external session id</param>
+        public async Task CreateAuthenticationEventAsync(
+            IFeatureManager featureManager, 
+            string jwtToken, 
+            AuthenticationEventType eventType, 
+            HttpContext context,
+            string? externalSessionId = null)
         {
             if (await featureManager.IsEnabledAsync(FeatureFlags.AuditLog))
             {
-                AuthenticationEvent authenticationEvent = EventlogHelper.MapAuthenticationEvent(jwtToken, eventType, context, _systemClock.UtcNow.DateTime);
+                AuthenticationEvent authenticationEvent = EventlogHelper.MapAuthenticationEvent(jwtToken, eventType, context, _systemClock.UtcNow.DateTime, externalSessionId);
                 if (authenticationEvent != null)
                 {
                     _queueClient.EnqueueAuthenticationEvent(JsonSerializer.Serialize(authenticationEvent));

--- a/src/Authentication/Services/GuidService.cs
+++ b/src/Authentication/Services/GuidService.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Altinn.Platform.Authentication.Services.Interfaces;
+
+namespace Altinn.Platform.Authentication.Services
+{
+    /// <summary>
+    /// Implementation for guid service
+    /// </summary>
+    public class GuidService : IGuidService
+    {
+        /// <inheritdoc/>
+        public string NewGuid()
+        {
+            return Guid.NewGuid().ToString();
+        }
+    }
+}

--- a/src/Authentication/Services/Interfaces/IEventLog.cs
+++ b/src/Authentication/Services/Interfaces/IEventLog.cs
@@ -25,11 +25,11 @@ namespace Altinn.Platform.Authentication.Services.Interfaces
         /// Creates an authentication event in storage queue
         /// </summary>
         /// <param name="featureManager">the feature manager handler</param>
-        /// <param name="jwttoken">the authenticated user information in token</param>
+        /// <param name="jwtToken">the authenticated user information in token</param>
         /// <param name="eventType">type of authentication event</param>
         /// <param name="context">the http context</param>
+        /// <param name="externalSessionId">the session id from the external token</param>
         /// <returns></returns>
-        public Task CreateAuthenticationEventAsync(IFeatureManager featureManager, string jwttoken, AuthenticationEventType eventType, HttpContext context);
-
+        public Task CreateAuthenticationEventAsync(IFeatureManager featureManager, string jwtToken, AuthenticationEventType eventType, HttpContext context, string? externalSessionId = null);
     }
 }

--- a/src/Authentication/Services/Interfaces/IGuidService.cs
+++ b/src/Authentication/Services/Interfaces/IGuidService.cs
@@ -1,0 +1,14 @@
+﻿namespace Altinn.Platform.Authentication.Services.Interfaces
+{
+    /// <summary>
+    /// Defines interface for generateing guid
+    /// </summary>
+    public interface IGuidService
+    {
+        /// <summary>
+        /// Generates  a new uuid
+        /// </summary>
+        /// <returns></returns>
+        public string NewGuid();
+    }
+}

--- a/test/Altinn.Platform.Authentication.Tests/Services/EventLogServiceTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Services/EventLogServiceTest.cs
@@ -27,7 +27,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
         public async Task QueueAuthenticationEvent_OK()
         {
             // Arrange            
-            UserAuthenticationModel authenticatedUser = GetAuthenticationModel(SecurityLevel.QuiteSensitive, AuthenticationMethod.AltinnPIN, AuthenticationEventType.Authenticate, 45321);
+            UserAuthenticationModel authenticatedUser = GetAuthenticationModel(SecurityLevel.QuiteSensitive, AuthenticationMethod.AltinnPIN, 45321);
 
             Mock<IEventsQueueClient> queueMock = new();
             queueMock
@@ -160,20 +160,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
             return service;
         }
 
-        private static AuthenticationEvent GetAuthenticationEvent(SecurityLevel authenticationLevel, AuthenticationMethod authenticationMethod, AuthenticationEventType eventType, int? userId)
-        {
-            AuthenticationEvent authenticationEvent = new()
-            {
-                AuthenticationLevel = authenticationLevel,
-                AuthenticationMethod = authenticationMethod,
-                EventType = eventType,
-                UserId = userId
-            };
-
-            return authenticationEvent;
-        }
-
-        private static UserAuthenticationModel GetAuthenticationModel(SecurityLevel authenticationLevel, AuthenticationMethod authenticationMethod, AuthenticationEventType eventType, int userId)
+        private static UserAuthenticationModel GetAuthenticationModel(SecurityLevel authenticationLevel, AuthenticationMethod authenticationMethod, int userId)
         {
             UserAuthenticationModel authenticatedUser = new()
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Implemented session id as a claim in the token generated by altinn. SessionId from external token will be saved as externalsessionid.

## Description
- Generated uuid as session id for tokens generated by altinn
- session id (jti) from external token is mapped as external session id
- subscription key property is added for later use
- Updated unit tests to assert for session id and external session id

## Related Issue(s)
- #345 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
