### PR TITLE
Configuration for x-forwarded-for header

### DIFF
--- a/src/Authentication/Helpers/EventlogHelper.cs
+++ b/src/Authentication/Helpers/EventlogHelper.cs
@@ -130,8 +130,8 @@ namespace Altinn.Platform.Authentication.Helpers
         /// <returns></returns>
         public static string GetClientIpAddress(HttpContext context)
         {
-            //The first ipaddress in the header is the client ipaddress
-            string clientIp = context?.Request?.Headers["x-forwarded-for"].FirstOrDefault();        
+            // The first ipaddress in the header is the client ipaddress
+            string clientIp = context?.Request?.Headers["X-Forwarded-For"].FirstOrDefault();        
             return clientIp;
         }
     }

--- a/src/Authentication/Helpers/EventlogHelper.cs
+++ b/src/Authentication/Helpers/EventlogHelper.cs
@@ -130,8 +130,8 @@ namespace Altinn.Platform.Authentication.Helpers
         /// <returns></returns>
         public static string GetClientIpAddress(HttpContext context)
         {
-            // The first ipaddress in the header is the client ipaddress
-            string clientIp = context?.Request?.Headers["X-Forwarded-For"].FirstOrDefault();        
+            // The first ipaddress in the x-forwarded-for header is the client ipaddress. The ip from x-forwarded-for is read into remoteip depending on the forward limit
+            string clientIp = context?.Connection?.RemoteIpAddress?.ToString();
             return clientIp;
         }
     }

--- a/src/Authentication/Program.cs
+++ b/src/Authentication/Program.cs
@@ -56,10 +56,15 @@ ConfigureLogging(builder.Logging);
 
 ConfigureServices(builder.Services, builder.Configuration);
 
+// Forwardlimit is set to 2 as our infrastructure has 1 proxy forward. The 2nd value from right to left is read into remoteipaddress property which is the client ip
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders =
         ForwardedHeaders.XForwardedFor;
+    options.ForwardLimit = 2;
+    options.KnownNetworks.Clear();
+    options.KnownProxies.Clear();
+    options.RequireHeaderSymmetry = false;
 });
 
 var app = builder.Build();

--- a/src/Authentication/Program.cs
+++ b/src/Authentication/Program.cs
@@ -30,6 +30,7 @@ using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -54,6 +55,12 @@ await SetConfigurationProviders(builder.Configuration);
 ConfigureLogging(builder.Logging);
 
 ConfigureServices(builder.Services, builder.Configuration);
+
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders =
+        ForwardedHeaders.XForwardedFor;
+});
 
 var app = builder.Build();
 
@@ -293,6 +300,7 @@ static string GetXmlCommentsPathForControllers()
 
 void Configure()
 {
+    app.UseForwardedHeaders();
     if (app.Environment.IsDevelopment() || app.Environment.IsStaging())
     {
         app.UseDeveloperExceptionPage();


### PR DESCRIPTION
Added forwardedfor middleware to map the client ipadress to remoteipaddress property in httpcontext.
when not configured, the ipaddress from x-forwarded.for header is not read into the remoteipaddress property
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
