### PR TITLE
Update package version and remove preview indicator

### DIFF
--- a/src/jwtcookie/Authentication/Altinn.Common.Authentication.csproj
+++ b/src/jwtcookie/Authentication/Altinn.Common.Authentication.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <FileVersion>4.0.0.0</FileVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <FileVersion>4.0.1.0</FileVersion>
     <!-- SonarCloud needs this -->
     <ProjectGuid>{3aa4860c-e86b-488f-ae89-b0a28bc1f701}</ProjectGuid>
   </PropertyGroup>
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <!-- NuGet package properties -->
     <PackageId>JWTCookieAuthentication</PackageId>
-    <PackageVersion>4.0.0-preview.1</PackageVersion>
+    <PackageVersion>4.0.1</PackageVersion>
     <PackageTags>altinn studio, authentication, jwt, JWTCookieAuthentication</PackageTags>
     <Description>
       JWTCookieAuthentication is a package for usage of JWT token for authentication both


### PR DESCRIPTION
## Description
The changes in the preview package is now being used by Register and FileScan, and it seems to be working. However; Register doesn't have a lot of endpoints that require a bearer token, FileScan has no endpoints like that. I can spread the preview version to more applications before merging this if you think that would be the best.

## Related Issue(s)
- Patching

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

