### PR TITLE
Jwt token properties IssuedAt and NotBefore adjustments

### DIFF
--- a/src/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/Controllers/AuthenticationController.cs
@@ -779,12 +779,15 @@ namespace Altinn.Platform.Authentication.Controllers
                 expires = DateTime.UtcNow.AddSeconds(tokenExpiry.TotalSeconds);
             }
 
+            DateTime now = DateTime.UtcNow.AddSeconds(-10);
             JwtSecurityTokenHandler tokenHandler = new JwtSecurityTokenHandler();
             SecurityTokenDescriptor tokenDescriptor = new SecurityTokenDescriptor
             {
                 Subject = new ClaimsIdentity(principal.Identity),
                 Expires = expires,
-                SigningCredentials = new X509SigningCredentials(certificate)
+                SigningCredentials = new X509SigningCredentials(certificate),
+                IssuedAt = now,
+                NotBefore = now,
             };
 
             SecurityToken token = tokenHandler.CreateToken(tokenDescriptor);


### PR DESCRIPTION
## Description
Setting IssuedAt and NotBefore in jwt token 10 seconds back in time to avoid users getting 401 if clocks are not perfectly syncronized or timestamps in token and validating systems have different granularity on timestamp. We get a lot if 401 in altinn-storage because of this problem. A similar fix is done in Altinn 2 when generating tokens for message box lookups.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
