### PR TITLE
Set clockskew to 10 seconds when validating tokens

### DIFF
--- a/src/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/Controllers/AuthenticationController.cs
@@ -355,7 +355,7 @@ namespace Altinn.Platform.Authentication.Controllers
                     ValidateAudience = false,
                     RequireExpirationTime = true,
                     ValidateLifetime = true,
-                    ClockSkew = TimeSpan.Zero
+                    ClockSkew = new TimeSpan(0, 0, 10)
                 };
 
                 ClaimsPrincipal originalPrincipal = _validator.ValidateToken(originalToken, validationParameters, out _);
@@ -400,7 +400,7 @@ namespace Altinn.Platform.Authentication.Controllers
                     ValidateAudience = false,
                     RequireExpirationTime = true,
                     ValidateLifetime = true,
-                    ClockSkew = TimeSpan.Zero
+                    ClockSkew = new TimeSpan(0, 0, 10)
                 };
 
                 ClaimsPrincipal originalPrincipal = GetClaimsPrincipalAndValidateMaskinportenToken(originalToken, validationParameters, alternativeSigningKeys);
@@ -916,7 +916,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 ValidateAudience = false,
                 RequireExpirationTime = true,
                 ValidateLifetime = true,
-                ClockSkew = TimeSpan.Zero
+                ClockSkew = new TimeSpan(0, 0, 10)
             };
 
             _validator.ValidateToken(originalToken, validationParameters, out _);

--- a/src/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/Controllers/AuthenticationController.cs
@@ -355,7 +355,7 @@ namespace Altinn.Platform.Authentication.Controllers
                     ValidateAudience = false,
                     RequireExpirationTime = true,
                     ValidateLifetime = true,
-                    ClockSkew = new TimeSpan(0, 0, 10)
+                    ClockSkew = TimeSpan.FromSeconds(10)
                 };
 
                 ClaimsPrincipal originalPrincipal = _validator.ValidateToken(originalToken, validationParameters, out _);
@@ -400,7 +400,7 @@ namespace Altinn.Platform.Authentication.Controllers
                     ValidateAudience = false,
                     RequireExpirationTime = true,
                     ValidateLifetime = true,
-                    ClockSkew = new TimeSpan(0, 0, 10)
+                    ClockSkew = TimeSpan.FromSeconds(10)
                 };
 
                 ClaimsPrincipal originalPrincipal = GetClaimsPrincipalAndValidateMaskinportenToken(originalToken, validationParameters, alternativeSigningKeys);
@@ -916,7 +916,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 ValidateAudience = false,
                 RequireExpirationTime = true,
                 ValidateLifetime = true,
-                ClockSkew = new TimeSpan(0, 0, 10)
+                ClockSkew = TimeSpan.FromSeconds(10)
             };
 
             _validator.ValidateToken(originalToken, validationParameters, out _);

--- a/src/Authentication/Program.cs
+++ b/src/Authentication/Program.cs
@@ -222,7 +222,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
                  ValidateAudience = false,
                  RequireExpirationTime = true,
                  ValidateLifetime = true,
-                 ClockSkew = TimeSpan.Zero
+                 ClockSkew = new TimeSpan(0, 0, 10)
              };
 
              if (builder.Environment.IsDevelopment())

--- a/src/Authentication/Program.cs
+++ b/src/Authentication/Program.cs
@@ -222,7 +222,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
                  ValidateAudience = false,
                  RequireExpirationTime = true,
                  ValidateLifetime = true,
-                 ClockSkew = new TimeSpan(0, 0, 10)
+                 ClockSkew = TimeSpan.FromSeconds(10)
              };
 
              if (builder.Environment.IsDevelopment())

--- a/src/jwtcookie/Authentication/JwtCookie/JwtCookieHandler.cs
+++ b/src/jwtcookie/Authentication/JwtCookie/JwtCookieHandler.cs
@@ -123,7 +123,7 @@ namespace AltinnCore.Authentication.JwtCookie
                                 ValidateAudience = false,
                                 RequireExpirationTime = true,
                                 ValidateLifetime = true,
-                                ClockSkew = TimeSpan.Zero
+                                ClockSkew = new TimeSpan(0, 0, 10)
                             };
 
                             OpenIdConnectConfiguration configuration = await GetOidcConfiguration(provider.Value.WellKnownConfigEndpoint);
@@ -143,6 +143,7 @@ namespace AltinnCore.Authentication.JwtCookie
                 {
                     // Use standard configured OIDC config for JTWCookie provider from startup.
                     validationParameters = Options.TokenValidationParameters.Clone();
+                    validationParameters.ClockSkew = new TimeSpan(0, 0, 10);
                     OpenIdConnectConfiguration configuration = await Options.ConfigurationManager.GetConfigurationAsync(Context.RequestAborted);
 
                     if (configuration != null)

--- a/src/jwtcookie/Authentication/JwtCookie/JwtCookieHandler.cs
+++ b/src/jwtcookie/Authentication/JwtCookie/JwtCookieHandler.cs
@@ -123,7 +123,7 @@ namespace AltinnCore.Authentication.JwtCookie
                                 ValidateAudience = false,
                                 RequireExpirationTime = true,
                                 ValidateLifetime = true,
-                                ClockSkew = new TimeSpan(0, 0, 10)
+                                ClockSkew = TimeSpan.FromSeconds(10)
                             };
 
                             OpenIdConnectConfiguration configuration = await GetOidcConfiguration(provider.Value.WellKnownConfigEndpoint);
@@ -143,7 +143,7 @@ namespace AltinnCore.Authentication.JwtCookie
                 {
                     // Use standard configured OIDC config for JTWCookie provider from startup.
                     validationParameters = Options.TokenValidationParameters.Clone();
-                    validationParameters.ClockSkew = new TimeSpan(0, 0, 10);
+                    validationParameters.ClockSkew = TimeSpan.FromSeconds(10);
                     OpenIdConnectConfiguration configuration = await Options.ConfigurationManager.GetConfigurationAsync(Context.RequestAborted);
 
                     if (configuration != null)

--- a/test/Altinn.Platform.Authentication.Tests/JwtTokenMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/JwtTokenMock.cs
@@ -135,7 +135,7 @@ namespace Altinn.Platform.Authentication.Tests
                 ValidateAudience = false,
                 RequireExpirationTime = true,
                 ValidateLifetime = true,
-                ClockSkew = TimeSpan.Zero
+                ClockSkew = new TimeSpan(0, 0, 10)
             };
 
             JwtSecurityTokenHandler validator = new JwtSecurityTokenHandler();
@@ -159,7 +159,7 @@ namespace Altinn.Platform.Authentication.Tests
                 ValidateAudience = false,
                 RequireExpirationTime = true,
                 ValidateLifetime = true,
-                ClockSkew = TimeSpan.Zero
+                ClockSkew = new TimeSpan(0, 0, 10)
             };
 
             JwtSecurityTokenHandler validator = new JwtSecurityTokenHandler();
@@ -189,7 +189,7 @@ namespace Altinn.Platform.Authentication.Tests
                 ValidateAudience = false,
                 RequireExpirationTime = true,
                 ValidateLifetime = true,
-                ClockSkew = TimeSpan.Zero
+                ClockSkew = new TimeSpan(0, 0, 10)
             };
 
             JwtSecurityTokenHandler validator = new JwtSecurityTokenHandler();

--- a/test/Altinn.Platform.Authentication.Tests/JwtTokenMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/JwtTokenMock.cs
@@ -135,7 +135,7 @@ namespace Altinn.Platform.Authentication.Tests
                 ValidateAudience = false,
                 RequireExpirationTime = true,
                 ValidateLifetime = true,
-                ClockSkew = new TimeSpan(0, 0, 10)
+                ClockSkew = TimeSpan.FromSeconds(10)
             };
 
             JwtSecurityTokenHandler validator = new JwtSecurityTokenHandler();
@@ -159,7 +159,7 @@ namespace Altinn.Platform.Authentication.Tests
                 ValidateAudience = false,
                 RequireExpirationTime = true,
                 ValidateLifetime = true,
-                ClockSkew = new TimeSpan(0, 0, 10)
+                ClockSkew = TimeSpan.FromSeconds(10)
             };
 
             JwtSecurityTokenHandler validator = new JwtSecurityTokenHandler();
@@ -189,7 +189,7 @@ namespace Altinn.Platform.Authentication.Tests
                 ValidateAudience = false,
                 RequireExpirationTime = true,
                 ValidateLifetime = true,
-                ClockSkew = new TimeSpan(0, 0, 10)
+                ClockSkew = TimeSpan.FromSeconds(10)
             };
 
             JwtSecurityTokenHandler validator = new JwtSecurityTokenHandler();


### PR DESCRIPTION
## Description
Set clockskew to 10 seconds when validating tokens to avoid problems if the caller's clock is slightly ahead of the validator's.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
