### PR TITLE
Fix: return orgnrs without prefix in GET systemregister

### DIFF
--- a/src/Authentication/Controllers/SystemRegisterController.cs
+++ b/src/Authentication/Controllers/SystemRegisterController.cs
@@ -59,7 +59,7 @@ public class SystemRegisterController : ControllerBase
                     Rights = system.Rights,
                     SystemId = system.Id,
                     SystemVendorOrgName = system.SystemVendorOrgName,
-                    SystemVendorOrgNumber = system.SystemVendorOrgNumber
+                    SystemVendorOrgNumber = AuthenticationHelper.GetOrgNumber(system.SystemVendorOrgNumber)
                 });
         }
 


### PR DESCRIPTION
## Description
- Orgnrs in GET /systemregister should return orgnrs without "0192" prefix

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
