### PR TITLE
Use correct url configured in Altinn2 for handleloggedout

### DIFF
--- a/src/Authentication/Controllers/LogoutController.cs
+++ b/src/Authentication/Controllers/LogoutController.cs
@@ -96,7 +96,7 @@ namespace Altinn.Platform.Authentication.Controllers
         /// </summary>
         [AllowAnonymous]
         [ProducesResponseType(StatusCodes.Status302Found)]
-        [HttpGet("handleloggedout")]
+        [HttpGet("logout/handleloggedout")]
         public async Task<ActionResult> HandleLoggedOut()
         {
             string logoutInfoCookie = Request.Cookies[_generalSettings.AltinnLogoutInfoCookieName];

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
@@ -272,7 +272,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Arrange
             HttpClient client = CreateClient();
 
-            HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, "/authentication/api/v1/handleloggedout");
+            HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, "/authentication/api/v1/logout/handleloggedout");
             requestMessage.Headers.Add("Cookie", "AltinnLogoutInfo=SystemuserRequestId=c0970300-005c-4784-aea6-5e7bac61b9b1");
 
             // Act
@@ -294,7 +294,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Arrange
             HttpClient client = CreateClient();
 
-            HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, "/authentication/api/v1/handleloggedout");
+            HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, "/authentication/api/v1/logout/handleloggedout");
 
             // Act
             HttpResponseMessage response = await client.SendAsync(requestMessage);


### PR DESCRIPTION
## Description
- Redirect url configured in Altinn 2 when AltinnLogoutInfo cookie is present is `authentication/api/v1/logout/handleloggedout`, not `authentication/api/v1/handleloggedout`

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
