### PR TITLE
Feature/portalscope

### DIFF
--- a/src/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/Controllers/AuthenticationController.cs
@@ -14,6 +14,7 @@ using System.Web;
 
 using Altinn.Common.AccessToken.Services;
 using Altinn.Platform.Authentication.Configuration;
+using Altinn.Platform.Authentication.Core.Constants;
 using Altinn.Platform.Authentication.Enum;
 using Altinn.Platform.Authentication.Helpers;
 using Altinn.Platform.Authentication.Model;
@@ -1058,6 +1059,23 @@ namespace Altinn.Platform.Authentication.Controllers
                     {
                         claims.Add(new Claim(kvp.Key, claimvalue, ClaimValueTypes.String, issuer));
                     }
+                }
+            }
+
+            if (!claims.Any(c => c.Type == AuthzConstants.CLAIM_MASKINPORTEN_SCOPE))
+            {
+                claims.Add(new Claim(AuthzConstants.CLAIM_MASKINPORTEN_SCOPE, AuthzConstants.SCOPE_PORTAL, ClaimValueTypes.String, issuer));
+            }
+            else
+            {
+                // Find the existing claim and modify its value
+                Claim existingClaim = claims.FirstOrDefault(c => c.Type == AuthzConstants.CLAIM_MASKINPORTEN_SCOPE);
+                if (existingClaim != null)
+                {
+                    claims.Remove(existingClaim);
+
+                    // Adding portal scope to list of scopes
+                    claims.Add(new Claim(AuthzConstants.CLAIM_MASKINPORTEN_SCOPE, existingClaim.Value + " " + AuthzConstants.SCOPE_PORTAL, ClaimValueTypes.String, issuer));
                 }
             }
 

--- a/src/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/Controllers/AuthenticationController.cs
@@ -1062,20 +1062,20 @@ namespace Altinn.Platform.Authentication.Controllers
                 }
             }
 
-            if (!claims.Any(c => c.Type == AuthzConstants.CLAIM_MASKINPORTEN_SCOPE))
+            if (!claims.Any(c => c.Type == AuthzConstants.CLAIM_SCOPE))
             {
-                claims.Add(new Claim(AuthzConstants.CLAIM_MASKINPORTEN_SCOPE, AuthzConstants.SCOPE_PORTAL, ClaimValueTypes.String, issuer));
+                claims.Add(new Claim(AuthzConstants.CLAIM_SCOPE, AuthzConstants.SCOPE_PORTAL, ClaimValueTypes.String, issuer));
             }
             else
             {
                 // Find the existing claim and modify its value
-                Claim existingClaim = claims.FirstOrDefault(c => c.Type == AuthzConstants.CLAIM_MASKINPORTEN_SCOPE);
+                Claim existingClaim = claims.FirstOrDefault(c => c.Type == AuthzConstants.CLAIM_SCOPE);
                 if (existingClaim != null)
                 {
                     claims.Remove(existingClaim);
 
                     // Adding portal scope to list of scopes
-                    claims.Add(new Claim(AuthzConstants.CLAIM_MASKINPORTEN_SCOPE, existingClaim.Value + " " + AuthzConstants.SCOPE_PORTAL, ClaimValueTypes.String, issuer));
+                    claims.Add(new Claim(AuthzConstants.CLAIM_SCOPE, existingClaim.Value + " " + AuthzConstants.SCOPE_PORTAL, ClaimValueTypes.String, issuer));
                 }
             }
 

--- a/src/Core/Constants/AuthzConstants.cs
+++ b/src/Core/Constants/AuthzConstants.cs
@@ -75,5 +75,10 @@ namespace Altinn.Platform.Authentication.Core.Constants
         /// Scope set by maskinporten for system user lookup
         /// </summary>
         public const string SCOPE_SYSTEMUSER_LOOKUP = "altinn:maskinporten/systemuser.read";
+
+        /// <summary>
+        /// General scope given to everyone loging in to altinn platform 
+        /// </summary>
+        public const string SCOPE_PORTAL = "altinn:portal/enduser";
     }
 }

--- a/src/Core/Constants/AuthzConstants.cs
+++ b/src/Core/Constants/AuthzConstants.cs
@@ -29,7 +29,7 @@ namespace Altinn.Platform.Authentication.Core.Constants
         /// <summary>
         /// Claim for scopes from maskinporten token
         /// </summary>
-        public const string CLAIM_MASKINPORTEN_SCOPE = "scope";
+        public const string CLAIM_SCOPE = "scope";
 
         /// <summary>
         /// Claim for consumer prefixes from maskinporten token

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerTests.cs
@@ -791,6 +791,97 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             Assert.NotNull(platformToken);
             ClaimsPrincipal claimPrincipal = JwtTokenMock.ValidateToken(platformToken);
             Assert.NotNull(claimPrincipal);
+
+            // Validate that default Altinn Portal scope is added to the token
+            Claim scopeClaim = claimPrincipal.Claims.FirstOrDefault(c => c.Type == "scope");
+            Assert.Equal("altinn:portal/enduser", scopeClaim.Value);
+            AssertionUtil.AssertAuthenticationEvent(_eventQueue, expectedAuthenticationEvent, Times.Once());
+        }
+
+        /// <summary>
+        /// This test veryf the following Scenario (same as above but with existing scope claim)
+        /// 1. User tries to access app (http://ttd.apps.localhost/ttd/testapp)
+        /// 2. User is redirected from app to authentication component
+        /// 3. OIDC is enabled and is the default authentication component
+        /// 4. First expections: Authentication components redirects to correct OIDC provider
+        ///  In real life the ODIC provider will then authenticate user and redirect user back to authentication component
+        ///  In this test the authorization code is created in test
+        ///  5. User is redirectet back to authentication component with state and XSRF cookie
+        ///  6. Authenticaiton component verifies XSRF header and cookie
+        ///  7. Autentication component calls OIDC provider with code to exchange it to a token
+        ///  8. Authentication compoment verifies token and create authentication info
+        ///  9. Authentication component creates altinn 3 token and puts it in to a cookie
+        ///  10. Redirects back to original app
+        ///  11. Verify the authentication event is logged with expected claims and event type
+        /// </summary>
+        [Fact]
+        public async Task AuthenticateUserWithOIDC_FullProcess_RedirectsToOIDCAndBackWithValidTokenExistingScopeclaim()
+        {
+            // Arrange         
+            string gotoUrl = "http://ttd.apps.localhost/ttd/testapp";
+
+            _configuration["GeneralSettings:EnableOidc"] = "true";
+            _configuration["GeneralSettings:ForceOidc"] = "true";
+
+            //Mock<IEventsQueueClient> eventQueue = new Mock<IEventsQueueClient>();
+            _eventQueue.Setup(q => q.EnqueueAuthenticationEvent(It.IsAny<string>()));
+            AuthenticationEvent expectedAuthenticationEvent = GetAuthenticationEvent(AuthenticationMethod.BankIDMobil, SecurityLevel.VerySensitive, null, AuthenticationEventType.Authenticate, 1337, true);
+
+            //HttpClient client = GetTestClient(_cookieDecryptionService.Object, _userProfileService.Object, eventQueue.Object, timeProviderMock.Object, guidService.Object, true, true);
+
+            HttpClient client = CreateClient();
+            string redirectUri = "http://localhost/authentication/api/v1/authentication";
+
+            string url = "/authentication/api/v1/authentication?goto=" + HttpUtility.UrlEncode(gotoUrl) + "&DontChooseReportee=true";
+            HttpRequestMessage redirectToOidcProviderRequest = new HttpRequestMessage(HttpMethod.Get, url);
+
+            // Call Authentication component equalt to browsr beeing redirect from Altinn app
+            HttpResponseMessage redirectToOidcProviderResponse = await client.SendAsync(redirectToOidcProviderRequest);
+
+            // Assert that user is redirected to correct Oidc provider and a XSRF Cookie was set
+            Assert.Equal(HttpStatusCode.Redirect, redirectToOidcProviderResponse.StatusCode);
+            Uri redirectToOidcProviderUri = new Uri(redirectToOidcProviderResponse.Headers.Location.ToString());
+            Assert.Equal("idprovider.azurewebsites.net/authorize", redirectToOidcProviderUri.Host + redirectToOidcProviderUri.AbsolutePath);
+
+            // Verify that XSRF token cookie set is set. 
+            ValidateXSRFTokenPresent(redirectToOidcProviderResponse);
+
+            // Verify GoToCookie
+            ValidateGoToCookie(redirectToOidcProviderResponse, HttpUtility.UrlEncode(gotoUrl));
+
+            // Verify that all required OIDC Params are set and have the correct values
+            ValidateOidcParams(redirectToOidcProviderUri, redirectUri, "2314534634r2", out string stateParam, out string nonceParam, out string redirectUriParam);
+
+            // This part is the where we prepare the response as a OIDC Provider would do.
+            // When returned from the OIDC Provider user will have an Authorization code. This code can have
+            // different formats and this component does not need to understand it. It just exchanged code with
+            // OIDC Provider to get a JWT ID token in response. In this test we create a JWTToken as code to make
+            // the exchange in OidcProviderMock simple
+
+            List<Claim> claims = new List<Claim>();
+            claims.Add(new Claim("scope", "openid"));
+            string authorizationCode = CreateOidcCode("1337", "1337", nonceParam, claims);
+            string redirectFromOidcProviderUri = GetAuthenticationUrlWithToken(redirectUriParam, stateParam, authorizationCode, "https://idprovider.azurewebsites.net/");
+            HttpRequestMessage redirectFromOidcProviderRequest = new HttpRequestMessage(HttpMethod.Get, redirectFromOidcProviderUri);
+
+            // Act 2. This simulates the request the browser will do when user is authenticated at OIDC provider and returns to Altinn authentication.
+            HttpResponseMessage redirectFromOidcProviderResponse = await client.SendAsync(redirectFromOidcProviderRequest);
+
+            // Assert: Now the user should be redirected back to original requested app.
+            Assert.Equal(HttpStatusCode.Redirect, redirectFromOidcProviderResponse.StatusCode);
+            Assert.StartsWith(gotoUrl, redirectFromOidcProviderResponse.Headers.Location.ToString());
+
+            // Check to see if platform cookie is set with token and verify token and claims
+            redirectFromOidcProviderResponse.Headers.TryGetValues(HeaderNames.SetCookie, out IEnumerable<string> cookieHeaders);
+            Assert.NotEmpty(cookieHeaders);
+            string platformToken = GetTokenFromSetCookieHeader(cookieHeaders);
+            Assert.NotNull(platformToken);
+            ClaimsPrincipal claimPrincipal = JwtTokenMock.ValidateToken(platformToken);
+            Assert.NotNull(claimPrincipal);
+
+            // Validate that default Altinn Portal scope is added to the token
+            Claim scopeClaim = claimPrincipal.Claims.FirstOrDefault(c => c.Type == "scope");
+            Assert.Equal("openid altinn:portal/enduser", scopeClaim.Value);
             AssertionUtil.AssertAuthenticationEvent(_eventQueue, expectedAuthenticationEvent, Times.Once());
         }
 

--- a/test/Altinn.Platform.Authentication.Tests/appsettings.json
+++ b/test/Altinn.Platform.Authentication.Tests/appsettings.json
@@ -29,7 +29,8 @@
       "AuthorizationEndpoint": "https://idprovider.azurewebsites.net/authorize",
       "TokenEndpoint": "https://idprovider.azurewebsites.net/api/token",
       "WellKnownConfigEndpoint": "https://idprovider.azurewebsites.net/api/v1/openid/.well-known/openid-configuration",
-      "ClientId": "2314534634r2"
+      "ClientId": "2314534634r2",
+      "ProviderClaims": [ "scope" ]
     },
     "maskinporten": {
       "Issuer": "https://mdock.maskinporten.no/",


### PR DESCRIPTION
Default Scope Added for User Logins in Altinn 3
A default scope has been added for all users logging into Altinn 3 via the portal.

This enhancement ensures that all APIs, including those used across end-user systems and the portal, can require scopes for access.

Implementation Details
APIs requiring scope validation will now accept either:
A specific use case scope.
A general portal scope.
Rationale
The general portal scope is introduced to improve the user experience. It avoids the awkwardness of asking end users to approve specific API-related scopes for Altinn when logging in. Instead, the general scope provides a seamless and intuitive approach to scope management while maintaining security and access control.