### PR TITLE
Fix/delete systems

### DIFF
--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Altinn.Platform.Authentication.SystemIntegrationTests.csproj
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Altinn.Platform.Authentication.SystemIntegrationTests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Altinn.Platform.Authentication.SystemIntegrationTests.csproj
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Altinn.Platform.Authentication.SystemIntegrationTests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Clients/SystemRegisterClient.cs
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Clients/SystemRegisterClient.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Text.Json;
+using Altinn.Platform.Authentication.SystemIntegrationTests.Domain;
 using Altinn.Platform.Authentication.SystemIntegrationTests.Tests;
 using Altinn.Platform.Authentication.SystemIntegrationTests.Utils;
 using Xunit;
@@ -30,4 +32,24 @@ public class SystemRegisterClient
 
         return response;
     }
+
+    public async Task<List<SystemDto>> GetSystemsAsync(string token)
+    {
+        var response = await _platformClient.GetAsync("v1/systemregister/", token);
+
+        // Assert the response status is OK
+        Assert.True(HttpStatusCode.OK == response.StatusCode,
+            $"{response.StatusCode}  {await response.Content.ReadAsStringAsync()}");
+
+        // Deserialize the JSON content to a list of SystemDto
+        var jsonContent = await response.Content.ReadAsStringAsync();
+        var systems = JsonSerializer.Deserialize<List<SystemDto>>(jsonContent, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true // Allows matching JSON properties in different casing
+        });
+
+        return systems ?? new List<SystemDto>();
+    }
+    
+    
 }

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Domain/SystemDto.cs
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Domain/SystemDto.cs
@@ -1,0 +1,14 @@
+namespace Altinn.Platform.Authentication.SystemIntegrationTests.Domain;
+
+// DTO Classes
+public class SystemDto
+{
+    public string SystemId { get; set; }
+    public string SystemVendorOrgNumber { get; set; }
+    public string SystemVendorOrgName { get; set; }
+}
+
+public class SystemsDto
+{
+    public List<SystemDto> Systems { get; set; }
+}

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Tests/SystemRegisterTests.cs
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Tests/SystemRegisterTests.cs
@@ -80,7 +80,7 @@ public class SystemRegisterTests
         // Act
         var response =
             await _platformClient.GetAsync("v1/systemregister", maskinportenToken);
-        
+
 
         // Assert
         Assert.True(response.IsSuccessStatusCode, response.ReasonPhrase);
@@ -182,5 +182,26 @@ public class SystemRegisterTests
 
         //More asserts should be added, but there are known bugs right now regarding validation of rights 
         Assert.Equal(HttpStatusCode.OK, get.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteEverySystemCreatedByEndToEndTests()
+    {
+        var maskinportenToken = await _platformClient.GetMaskinportenToken();
+        var systemIds = await _systemRegisterClient.GetSystemsAsync(maskinportenToken);
+
+        var idsToDelete = systemIds.FindAll(system => system.SystemVendorOrgNumber.Equals(_platformClient.EnvironmentHelper.Vendor));
+        
+        foreach (var systemDto in idsToDelete)
+        {
+            _outputHelper.WriteLine("Attempting to delete system with id: " + systemDto.SystemId);
+            // Act
+            var respons = await _platformClient.Delete(
+                $"v1/systemregister/vendor/{systemDto.SystemId}", maskinportenToken);
+        
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, respons.StatusCode);
+        }
+        
     }
 }


### PR DESCRIPTION
For our system integration api tests we (mostly me) some times spam Systemregister with new systems, manually running tests setting "isVisible" to true for manual cases.. this test will function as a cleanup method / test for those systems. 
