### PR TITLE
Environment specific SBL auth cookie name

### DIFF
--- a/src/Authentication/Configuration/GeneralSettings.cs
+++ b/src/Authentication/Configuration/GeneralSettings.cs
@@ -10,6 +10,11 @@ namespace Altinn.Platform.Authentication.Configuration
         /// <summary>
         /// Gets or sets the name of the SBL authentication cookie.
         /// </summary>
+        public string SblAuthCookieEnvSpecificName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the SBL authentication cookie. Only used until SblAuthCookieEnvSpecificName
+        /// is rolled out in all environments.
         public string SblAuthCookieName { get; set; }
 
         /// <summary>

--- a/src/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/Controllers/AuthenticationController.cs
@@ -237,14 +237,15 @@ namespace Altinn.Platform.Authentication.Controllers
             }
             else
             {
-                if (Request.Cookies[_generalSettings.SblAuthCookieName] == null)
+                if (Request.Cookies[_generalSettings.SblAuthCookieName] == null && Request.Cookies[_generalSettings.SblAuthCookieEnvSpecificName] == null)
                 {
                     return Redirect(sblRedirectUrl);
                 }
 
                 try
                 {
-                    string encryptedTicket = Request.Cookies[_generalSettings.SblAuthCookieName];
+                    string cookieName = Request.Cookies[_generalSettings.SblAuthCookieEnvSpecificName] != null ? _generalSettings.SblAuthCookieEnvSpecificName : _generalSettings.SblAuthCookieName;
+                    string encryptedTicket = Request.Cookies[cookieName];
                     userAuthentication = await _cookieDecryptionService.DecryptTicket(encryptedTicket);
                 }
                 catch (SblBridgeResponseException sblBridgeException)

--- a/src/Authentication/appsettings.Development.json
+++ b/src/Authentication/appsettings.Development.json
@@ -2,6 +2,7 @@
   "GeneralSettings": {
     "HostName": "altinnlocal",
     "SblAuthCookieName": ".ASPXAUTH",
+    "SblAuthCookieEnvSpecificName": ".ASPXAUTH",
     "JwtCookieName": "AltinnStudioRuntime",
     "BaseUrl": "http://localhost",
     "BridgeAuthnApiEndpoint": "https://at22.altinn.cloud/sblbridge/authentication/api/",

--- a/src/Authentication/appsettings.json
+++ b/src/Authentication/appsettings.json
@@ -2,6 +2,7 @@
   "GeneralSettings": {
     "HostName": "altinnlocal",
     "SblAuthCookieName": ".ASPXAUTH",
+    "SblAuthCookieEnvSpecificName": ".ASPXAUTH",
     "JwtCookieName": "AltinnStudioRuntime",
     "BaseUrl": "http://localhost",
     "BridgeAuthnApiEndpoint": "https://at22.altinn.cloud/sblbridge/authentication/api/",


### PR DESCRIPTION
## Description
- Introduced SblAuthCookieEnvSpecificName to be able to support that sbl has different auth cookie names in different environments.
- The ops project must also be updated with the new variable

## Related Issue(s)
- #{issue number}
- https://dev.azure.com/digdir/Altinn/_workitems/edit/64448
- https://dev.azure.com/digdir/Altinn/_git/Altinn/pullrequest/6998
- https://dev.azure.com/digdir/Altinn/_git/Altinn/pullrequest/6999

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
