### PR TITLE
L5 Refactoring bugfix

### DIFF
--- a/src/Authentication/Services/RequestSystemUserService.cs
+++ b/src/Authentication/Services/RequestSystemUserService.cs
@@ -526,7 +526,7 @@ public class RequestSystemUserService(
         }
 
         // Logs the change in the Request Repository
-        _ = await requestRepository.ApproveAndCreateSystemUser(requestId, new Guid(systemUser.Value.Id), userId, cancellationToken);
+        _ = await requestRepository.SetRequestApproved(requestId, new Guid(systemUser.Value.Id), userId, cancellationToken);
 
         return true;
     }
@@ -568,14 +568,13 @@ public class RequestSystemUserService(
             return toBeInserted.Problem;
         }
 
-        bool systemUserInserted = await requestRepository.ApproveAndCreateSystemUser(requestId, new Guid(toBeInserted.Value.Id), userId, cancellationToken);
-
         Result<SystemUser> res = await systemUserService.CreateSystemUserFromApprovedVendorRequest(systemUserRequest, partyId.ToString(), userId, cancellationToken);
-
-        if (systemUserInserted is false || res.IsProblem)
+        if (res.IsProblem)
         {
-            return Problem.SystemUser_FailedToCreate;
+            return res.Problem;
         }
+
+        _ = await requestRepository.SetRequestApproved(requestId, new Guid(toBeInserted.Value.Id), userId, cancellationToken);
 
         return true;
     }

--- a/src/Authentication/Services/RequestSystemUserService.cs
+++ b/src/Authentication/Services/RequestSystemUserService.cs
@@ -526,7 +526,11 @@ public class RequestSystemUserService(
         }
 
         // Logs the change in the Request Repository
-        _ = await requestRepository.SetRequestApproved(requestId, new Guid(systemUser.Value.Id), userId, cancellationToken);
+        bool sat = await requestRepository.SetRequestApproved(requestId, new Guid(systemUser.Value.Id), userId, cancellationToken);
+        if (!sat)
+        {
+            return Problem.RequestCouldNotBeUpdated;
+        }
 
         return true;
     }
@@ -574,7 +578,11 @@ public class RequestSystemUserService(
             return res.Problem;
         }
 
-        _ = await requestRepository.SetRequestApproved(requestId, new Guid(toBeInserted.Value.Id), userId, cancellationToken);
+        bool sat = await requestRepository.SetRequestApproved(requestId, new Guid(toBeInserted.Value.Id), userId, cancellationToken);
+        if (!sat)
+        {
+            return Problem.RequestCouldNotBeUpdated;
+        }
 
         return true;
     }

--- a/src/Authentication/Services/SystemUserService.cs
+++ b/src/Authentication/Services/SystemUserService.cs
@@ -502,7 +502,8 @@ namespace Altinn.Platform.Authentication.Services
                 SystemId = systemId,
                 PartyId = partyId,
                 UserType = systemUserType,
-                ExternalRef = string.IsNullOrEmpty(externalRef) ? party.OrgNumber : externalRef
+                ExternalRef = string.IsNullOrEmpty(externalRef) ? party.OrgNumber : externalRef,
+                AccessPackages = 
             };
 
             return await InsertNewSystemUser(newSystemUser, userId, regSystem, delegationCheckFinalResult, partyId, accessPackageDelegationCheckResult, partyUuid, cancellationToken);

--- a/src/Authentication/Services/SystemUserService.cs
+++ b/src/Authentication/Services/SystemUserService.cs
@@ -465,7 +465,7 @@ namespace Altinn.Platform.Authentication.Services
 
             if (rights is not null && rights.Count > 0)
             {
-                delegationCheckFinalResult = await delegationHelper.UserDelegationCheckForReportee(int.Parse(partyId), regSystem.Id, [], true, cancellationToken);
+                delegationCheckFinalResult = await delegationHelper.UserDelegationCheckForReportee(int.Parse(partyId), regSystem.Id, [], fromBff:false, cancellationToken);
 
                 if (delegationCheckFinalResult?.RightResponses is null)
                 {
@@ -482,7 +482,7 @@ namespace Altinn.Platform.Authentication.Services
 
             if (accessPackages is not null && accessPackages.Count > 0)
             {
-                var accessPackageCheckResult = await delegationHelper.ValidateDelegationRightsForAccessPackages(partyUuid, regSystem.Id, accessPackages, true, cancellationToken);
+                var accessPackageCheckResult = await delegationHelper.ValidateDelegationRightsForAccessPackages(partyUuid, regSystem.Id, accessPackages, fromBff:false, cancellationToken);
                 if (accessPackageCheckResult.IsProblem)
                 {
                     return accessPackageCheckResult.Problem;

--- a/src/Authentication/Services/SystemUserService.cs
+++ b/src/Authentication/Services/SystemUserService.cs
@@ -532,7 +532,7 @@ namespace Altinn.Platform.Authentication.Services
                 return Problem.SystemUser_FailedToCreate;
             }
 
-            if (regSystem.Rights is not null && regSystem.Rights.Count > 0 && delegationCheckFinalResult is not null && delegationCheckFinalResult.CanDelegate)
+            if (newSystemUser.UserType == SystemUserType.Standard && regSystem.Rights is not null && regSystem.Rights.Count > 0 && delegationCheckFinalResult is not null && delegationCheckFinalResult.CanDelegate)
             {
                 Result<bool> delegationSucceeded = await _accessManagementClient.DelegateRightToSystemUser(partyId.ToString(), inserted, delegationCheckFinalResult.RightResponses!);
                 if (delegationSucceeded.IsProblem)
@@ -542,7 +542,7 @@ namespace Altinn.Platform.Authentication.Services
                 }
             }
 
-            if (accessPackageDelegationCheckResult is not null && accessPackageDelegationCheckResult.CanDelegate && accessPackageDelegationCheckResult.AccessPackages is not null && accessPackageDelegationCheckResult.AccessPackages.Count > 0)
+            if (newSystemUser.UserType == SystemUserType.Standard && accessPackageDelegationCheckResult is not null && accessPackageDelegationCheckResult.CanDelegate && accessPackageDelegationCheckResult.AccessPackages is not null && accessPackageDelegationCheckResult.AccessPackages.Count > 0)
             {
                 Result<bool> accessPackageDelegationSucceeded = await DelegateAccessPackagesToSystemUser(partyUuid, inserted, accessPackageDelegationCheckResult.AccessPackages, cancellationToken);
                 if (accessPackageDelegationSucceeded.IsProblem)

--- a/src/Authentication/Services/SystemUserService.cs
+++ b/src/Authentication/Services/SystemUserService.cs
@@ -503,7 +503,7 @@ namespace Altinn.Platform.Authentication.Services
                 PartyId = partyId,
                 UserType = systemUserType,
                 ExternalRef = string.IsNullOrEmpty(externalRef) ? party.OrgNumber : externalRef,
-                AccessPackages = 
+                AccessPackages = accessPackageDelegationCheckResult?.AccessPackages ?? []
             };
 
             return await InsertNewSystemUser(newSystemUser, userId, regSystem, delegationCheckFinalResult, partyId, accessPackageDelegationCheckResult, partyUuid, cancellationToken);

--- a/src/Authentication/Services/SystemUserService.cs
+++ b/src/Authentication/Services/SystemUserService.cs
@@ -532,9 +532,9 @@ namespace Altinn.Platform.Authentication.Services
                 return Problem.SystemUser_FailedToCreate;
             }
 
-            if (newSystemUser.UserType == SystemUserType.Standard && regSystem.Rights is not null && regSystem.Rights.Count > 0 && delegationCheckFinalResult is not null && delegationCheckFinalResult.CanDelegate)
+            if (IsStandardSystemUserDelegatgeSingleRights(newSystemUser, regSystem, delegationCheckFinalResult))
             {
-                Result<bool> delegationSucceeded = await _accessManagementClient.DelegateRightToSystemUser(partyId.ToString(), inserted, delegationCheckFinalResult.RightResponses!);
+                Result<bool> delegationSucceeded = await _accessManagementClient.DelegateRightToSystemUser(partyId.ToString(), inserted, delegationCheckFinalResult!.RightResponses!);
                 if (delegationSucceeded.IsProblem)
                 {
                     await _repository.SetDeleteSystemUserById((Guid)insertedId);
@@ -542,9 +542,9 @@ namespace Altinn.Platform.Authentication.Services
                 }
             }
 
-            if (newSystemUser.UserType == SystemUserType.Standard && accessPackageDelegationCheckResult is not null && accessPackageDelegationCheckResult.CanDelegate && accessPackageDelegationCheckResult.AccessPackages is not null && accessPackageDelegationCheckResult.AccessPackages.Count > 0)
+            if (IsStandardSystemUserDelegateAccessPackage(newSystemUser, accessPackageDelegationCheckResult))
             {
-                Result<bool> accessPackageDelegationSucceeded = await DelegateAccessPackagesToSystemUser(partyUuid, inserted, accessPackageDelegationCheckResult.AccessPackages, cancellationToken);
+                Result<bool> accessPackageDelegationSucceeded = await DelegateAccessPackagesToSystemUser(partyUuid, inserted, accessPackageDelegationCheckResult!.AccessPackages!, cancellationToken);
                 if (accessPackageDelegationSucceeded.IsProblem)
                 {
                     await _repository.SetDeleteSystemUserById((Guid)insertedId);
@@ -553,6 +553,26 @@ namespace Altinn.Platform.Authentication.Services
             }
 
             return inserted;
+        }
+
+        private static bool IsStandardSystemUserDelegateAccessPackage(SystemUser newSystemUser, AccessPackageDelegationCheckResult? accessPackageDelegationCheckResult)
+        {
+            if (newSystemUser.UserType == SystemUserType.Standard && accessPackageDelegationCheckResult is not null && accessPackageDelegationCheckResult.CanDelegate && accessPackageDelegationCheckResult.AccessPackages is not null && accessPackageDelegationCheckResult.AccessPackages.Count > 0)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsStandardSystemUserDelegatgeSingleRights(SystemUser newSystemUser, RegisteredSystemResponse regSystem, DelegationCheckResult? delegationCheckFinalResult)
+        {
+            if (newSystemUser.UserType == SystemUserType.Standard && regSystem.Rights is not null && regSystem.Rights.Count > 0 && delegationCheckFinalResult is not null && delegationCheckFinalResult.CanDelegate)
+            {
+                return true;
+            }
+
+            return false;
         }
 
         /// <inheritdoc/>

--- a/src/Core/Problems/Problem.cs
+++ b/src/Core/Problems/Problem.cs
@@ -359,4 +359,10 @@ public static class Problem
     /// </summary>
     public static ProblemDescriptor SystemUser_MissingRightsOrAccessPackages { get; }
         = _factory.Create(58, HttpStatusCode.BadRequest, "No AccessPackages or Single Rights found, a SystemUser must have at least one");
+
+    /// <summary>
+    /// Gets a <see cref="ProblemDescriptor"/>.
+    /// </summary>
+    public static ProblemDescriptor RequestCouldNotBeUpdated { get; }
+        = _factory.Create(59, HttpStatusCode.NotFound, "An error occured when Updating the Request.");
 }

--- a/src/Core/RepositoryInterfaces/IRequestRepository.cs
+++ b/src/Core/RepositoryInterfaces/IRequestRepository.cs
@@ -42,7 +42,7 @@ public interface IRequestRepository
     /// <param name="userId">the logged in user</param>
     /// <param name="cancellationToken">the cancellation token</param>
     /// <returns>returns the system user id</returns>
-    Task<bool> ApproveAndCreateSystemUser(Guid requestId, Guid systemUserId, int userId, CancellationToken cancellationToken);
+    Task<bool> SetRequestApproved(Guid requestId, Guid systemUserId, int userId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Retrieves a list of Status-Response-model for all Requests that the Vendor has

--- a/src/Persistance/RepositoryImplementations/RequestRepository.cs
+++ b/src/Persistance/RepositoryImplementations/RequestRepository.cs
@@ -306,7 +306,7 @@ public class RequestRepository : IRequestRepository
     }
 
     /// <inheritdoc/>  
-    public async Task<bool> ApproveAndCreateSystemUser(Guid requestId, Guid systemUserId, int userId, CancellationToken cancellationToken = default)
+    public async Task<bool> SetRequestApproved(Guid requestId, Guid systemUserId, int userId, CancellationToken cancellationToken = default)
     {
         // TODO for refactor: add systemUserId column to the Request table
         string changed_by = "userId:" + userId.ToString();

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserControllerTest.cs
@@ -1283,10 +1283,14 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             string token = AddSystemUserRequestWriteTestTokenToClient(client);
             string endpoint = $"/authentication/api/v1/systemuser/request/vendor/agent";
 
-            AccessPackage accessPackage = new()
+            AccessPackage accessPackage1 = new()
             {
                 Urn = "urn:altinn:accesspackage:forretningsforer-eiendom"
+            };
 
+            AccessPackage accessPackage2 = new()
+            {
+                Urn = "urn:altinn:accesspackage:skattnaering"
             };
 
             // Arrange
@@ -1295,7 +1299,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 ExternalRef = "external",
                 SystemId = "991825827_the_matrix",
                 PartyOrgNo = "910493353",
-                AccessPackages = [accessPackage]
+                AccessPackages = [accessPackage1, accessPackage2]
             };
 
             HttpRequestMessage request = new(HttpMethod.Post, endpoint)

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserControllerTest.cs
@@ -44,6 +44,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
+using static Altinn.Platform.Authentication.Core.Models.SystemUsers.ClientDto;
 
 namespace Altinn.Platform.Authentication.Tests.Controllers
 {
@@ -1340,7 +1341,21 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             string systemUserId = list[0].Id;
             string delegationEndpoint = $"/authentication/api/v1/systemuser/agent/{partyId}/{systemUserId}/delegation/";
 
-            var delegationRequest = new AgentDelegationInputDto { CustomerId = Guid.NewGuid().ToString(), FacilitatorId = Guid.NewGuid().ToString() };
+            var delegationRequest = new AgentDelegationInputDto 
+            { 
+                CustomerId = Guid.NewGuid().ToString(), FacilitatorId = Guid.NewGuid().ToString(), Access = [
+                new ClientRoleAccessPackages()
+                {
+                    Role = "REGN",
+                    Packages = ["urn:altinn:accesspackage:skattnaering"]
+                },
+                                new ClientRoleAccessPackages()
+                {
+                    Role = "forretningsforer",
+                    Packages = ["urn:altinn:accesspackage:forretningsforer-eiendom"]
+                }
+                ]
+            };
 
             HttpRequestMessage delegateMessage = new(HttpMethod.Post, delegationEndpoint);
             delegateMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1337, null, 3, true));

--- a/test/Altinn.Platform.Authentication.Tests/Data/SystemRegister/Json/SystemRegisterWithAccessPackageAgent.json
+++ b/test/Altinn.Platform.Authentication.Tests/Data/SystemRegister/Json/SystemRegisterWithAccessPackageAgent.json
@@ -17,6 +17,9 @@
   "accessPackages": [
     {
       "urn": "urn:altinn:accesspackage:forretningsforer-eiendom"
+    },
+    {
+      "urn": "urn:altinn:accesspackage:skattnaering"
     }
   ],
   "rights": [

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/AccessManagementClientMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/AccessManagementClientMock.cs
@@ -148,6 +148,7 @@ public class AccessManagementClientMock: IAccessManagementClient
         hardcodingOfAccessPackageToRole.Add("urn:altinn:accesspackage:ansvarlig-revisor", "REVI");
         hardcodingOfAccessPackageToRole.Add("urn:altinn:accesspackage:revisormedarbeider", "REVI");
         hardcodingOfAccessPackageToRole.Add("urn:altinn:accesspackage:forretningsforer-eiendom", "forretningsforer");
+        hardcodingOfAccessPackageToRole.Add("urn:altinn:accesspackage:skattnaering", "REGN");
 
         hardcodingOfAccessPackageToRole.TryGetValue(accessPackage, out string? found);        
         return found;   


### PR DESCRIPTION
- Added check for ! Agent in delegate step, only Standard delegate directly on the Approve step
- Some small fixes in method naming, and tests.
- Changes the order of setting Approved on Request and creating the Agent SystemUser
- Returning the actual Problemdetails from the Delegation Process, instead of a mixed error from Requet.
