### PR TITLE
Changed the domain on the sesssion cookie

### DIFF
--- a/src/Authentication/Services/OidcServerService.cs
+++ b/src/Authentication/Services/OidcServerService.cs
@@ -286,6 +286,7 @@ namespace Altinn.Platform.Authentication.Services
                 Secure = true,
                 Path = "/",
                 SameSite = SameSiteMode.Lax,
+                Domain = _generalSettings.HostName,
             };
 
             await _eventLog.CreateAuthenticationEventAsync(_featureManager, cookieToken, AuthenticationEventType.Authenticate, input.ClientIp);
@@ -432,6 +433,7 @@ namespace Altinn.Platform.Authentication.Services
                             Path = "/",
                             SameSite = SameSiteMode.Lax,
                             Expires = DateTimeOffset.UnixEpoch,
+                            Domain = _generalSettings.HostName,
                         }
                     }
                 };
@@ -525,6 +527,7 @@ namespace Altinn.Platform.Authentication.Services
                 Path = "/",
                 SameSite = SameSiteMode.Lax,
                 Expires = DateTimeOffset.UnixEpoch,
+                Domain = _generalSettings.HostName,
             };
             
             return new EndSessionResult
@@ -678,6 +681,7 @@ namespace Altinn.Platform.Authentication.Services
                     Secure = true,
                     Path = "/",
                     SameSite = SameSiteMode.Lax,
+                    Domain = _generalSettings.HostName,
                 };
 
                 return new AuthenticateFromAltinn2TicketResult

--- a/test/Altinn.Platform.Authentication.Tests/Utils/OidcAssertHelper.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Utils/OidcAssertHelper.cs
@@ -154,9 +154,11 @@ namespace Altinn.Platform.Authentication.Tests.Utils
             Assert.Equal("altinnsession", name);
             Assert.False(string.IsNullOrEmpty(value), "altinnsession cookie has empty value.");
 
+            // Assert that domain is set to localhost (test env) (will be altinn.no for production) Will be changed when Altinn 2 is shut off
+            Assert.Contains(parts, p => p.StartsWith("domain=localhost", StringComparison.OrdinalIgnoreCase));
+
             // ❌ Must NOT set Expires or Domain (host-only, session cookie)
             Assert.DoesNotContain(parts, p => p.StartsWith("expires=", StringComparison.OrdinalIgnoreCase));
-            Assert.DoesNotContain(parts, p => p.StartsWith("domain=", StringComparison.OrdinalIgnoreCase));
         }
 
         public static void AssertHasAltinnPartyIdCookie(HttpResponseMessage resp)


### PR DESCRIPTION
Setting cookie domain for session cookie

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication cookie handling by configuring domain attributes for session and runtime cookies to ensure consistent session behavior across services.

* **Tests**
  * Updated cookie domain validation tests to align with new authentication cookie configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->