### PR TITLE
Changed where getting partyuuid from

### DIFF
--- a/src/Authentication/Services/OidcServerService.cs
+++ b/src/Authentication/Services/OidcServerService.cs
@@ -1369,7 +1369,7 @@ namespace Altinn.Platform.Authentication.Services
                 {
                     userAuthenticationModel.UserID = userProfile.UserId;
                     userAuthenticationModel.PartyID = userProfile.PartyId;
-                    userAuthenticationModel.PartyUuid = userProfile.Party.PartyUuid;
+                    userAuthenticationModel.PartyUuid = userProfile.UserUuid;
                     userAuthenticationModel.Username = userProfile.UserName;
                     userAuthenticationModel.Amr = ["SelfIdentified"];
                     userAuthenticationModel.Acr = "Selfidentified";
@@ -1386,7 +1386,7 @@ namespace Altinn.Platform.Authentication.Services
                 UserProfile userCreated = await _userProfileService.CreateUser(userToCreate);
                 userAuthenticationModel.UserID = userCreated.UserId;
                 userAuthenticationModel.PartyID = userCreated.PartyId;
-                userAuthenticationModel.PartyUuid = userCreated.Party.PartyUuid;
+                userAuthenticationModel.PartyUuid = userCreated.UserUuid;
                 userAuthenticationModel.Amr = ["SelfIdentified"];
                 userAuthenticationModel.Acr = "Selfidentified";
             }


### PR DESCRIPTION
Fix for handling self identified users from  UIDP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal user identification logic in authentication service to streamline user profile handling across multiple authentication flows (SSN-based, external identity, and new user creation scenarios). No breaking changes or public API modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->