### PR TITLE
Added instances read scope so Arbeidsflate can check Altinn 2 API for…

### DIFF
--- a/src/Authentication/Configuration/GeneralSettings.cs
+++ b/src/Authentication/Configuration/GeneralSettings.cs
@@ -205,7 +205,7 @@ namespace Altinn.Platform.Authentication.Configuration
         /// <summary>
         /// Scopes set when there is no client id (Altinn Apps) or source is Altinn 2
         /// </summary>
-        public string DefaultPortalScopes { get; set; } = "openid digdir:dialogporten.noconsent altinn:portal/enduser";
+        public string DefaultPortalScopes { get; set; } = "openid digdir:dialogporten.noconsent altinn:portal/enduser altinn:instances.read";
 
         /// <summary>
         /// Enables the authorization server

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
@@ -223,7 +223,10 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             TokenResponseDto refreshed = JsonSerializer.Deserialize<TokenResponseDto>(refreshJson)!;
             TokenAssertsHelper.AssertTokenRefreshResponse(refreshed, testScenario, _fakeTime.GetUtcNow());
             OidcSession? refreshedSession = await OidcServerDatabaseUtil.GetOidcSessionAsync(sid, DataSource);
-            Assert.Equal(string.Join(' ', testScenario.Scopes), refreshed.scope);
+            foreach (string scope in testScenario.Scopes)
+            {
+                Assert.Contains(scope, refreshed.scope);
+            }
 
             // ====== Phase 5: Redirect to App in Altinn Apps ======
             // User select a instance in Arbeidsflate and will be redirected to Altinn Apps to work on the instance. 
@@ -443,7 +446,11 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
                 tokenResult = JsonSerializer.Deserialize<TokenResponseDto>(refreshJsonLoop)!;
                 TokenAssertsHelper.AssertTokenRefreshResponse(tokenResult, testScenario, _fakeTime.GetUtcNow());
                 OidcSession? refreshedSessionLoop = await OidcServerDatabaseUtil.GetOidcSessionAsync(sid, DataSource);
-                Assert.Equal(string.Join(' ', testScenario.Scopes), tokenResult.scope);
+                foreach (string scope in testScenario.Scopes)
+                {
+                    Assert.Contains(scope, tokenResult.scope);
+                }
+
                 _fakeTime.Advance(TimeSpan.FromMinutes(5));
             }
 
@@ -1265,7 +1272,10 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             TokenResponseDto refreshed = JsonSerializer.Deserialize<TokenResponseDto>(refreshJson)!;
             TokenAssertsHelper.AssertTokenRefreshResponse(refreshed, testScenario, _fakeTime.GetUtcNow());
             OidcSession? refreshedSession = await OidcServerDatabaseUtil.GetOidcSessionAsync(sid, DataSource);
-            Assert.Equal(string.Join(' ', testScenario.Scopes), refreshed.scope);
+            foreach (string scope in testScenario.Scopes)
+            {
+                Assert.Contains(scope, refreshed.scope);
+            }
 
             // ===== Phase 5: User has to low level to access a corresponence in arbeidsflate that requires level 4. User is redirected to /authorize again to elevate level =====
             // Update test scenario to require level4

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEnd_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEnd_OidcFrontChannelControllerTest.cs
@@ -224,7 +224,10 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             TokenResponseDto refreshed = JsonSerializer.Deserialize<TokenResponseDto>(refreshJson)!;
             TokenAssertsHelper.AssertTokenRefreshResponse(refreshed, testScenario, _fakeTime.GetUtcNow());
             OidcSession? refreshedSession = await OidcServerDatabaseUtil.GetOidcSessionAsync(sid, DataSource);
-            Assert.Equal(string.Join(' ', testScenario.Scopes), refreshed.scope);
+            foreach (string scope in testScenario.Scopes)
+            {
+                Assert.Contains(scope, refreshed.scope);
+            }
 
             // ====== Phase 5: Redirect to App in Altinn Apps ======
             // User select a instance in Arbeidsflate and will be redirected to Altinn Apps to work on the instance. 
@@ -446,7 +449,11 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
                 tokenResult = JsonSerializer.Deserialize<TokenResponseDto>(refreshJsonLoop)!;
                 TokenAssertsHelper.AssertTokenRefreshResponse(tokenResult, testScenario, _fakeTime.GetUtcNow());
                 OidcSession? refreshedSessionLoop = await OidcServerDatabaseUtil.GetOidcSessionAsync(sid, DataSource);
-                Assert.Equal(string.Join(' ', testScenario.Scopes), tokenResult.scope);
+                foreach (string scope in testScenario.Scopes)
+                {
+                    Assert.Contains(scope, tokenResult.scope);
+                }
+
                 _fakeTime.Advance(TimeSpan.FromMinutes(5));
             }
 


### PR DESCRIPTION
La til scope slik at arbeidsflate kan kalle Altinn 2 API for å informere om elementer derifra 

https://github.com/Altinn/dialogporten-frontend/issues/2977



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated default authentication scopes to include an additional scope for enhanced permissions handling.

* **Tests**
  * Improved validation logic for authentication scope verification across end-to-end test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->