### PR TITLE
Added so provider is added always. This to create a redirect from Alt…

### DIFF
--- a/src/Authentication/Helpers/ClaimsPrincipalBuilder.cs
+++ b/src/Authentication/Helpers/ClaimsPrincipalBuilder.cs
@@ -162,7 +162,7 @@ namespace Altinn.Platform.Authentication.Core.Helpers
                 claims.Add(new Claim(AltinnCoreClaimTypes.UserName, oidcSession.SubjectUserName, string.Empty));
             }
 
-            if (isAuthCookie && oidcSession.Provider != null && !oidcSession.Provider.Equals("altinn2", StringComparison.OrdinalIgnoreCase))  
+            if (isAuthCookie && oidcSession.Provider != null)  
             {
                 claims.Add(new Claim(OriginalIssClaimName, oidcSession.Provider));
             }


### PR DESCRIPTION
Added so originalISS is also added when altinn 2 is the source. To make sure Altinn 2 redirects to Altinn 3. 
Changes are also done in Altinn 2 code. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication claim handling to consistently capture original issuer information for all provider types. This enhances authorization context tracking and ensures more complete verification across authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->