### PR TITLE
Add a check for portal scope in session refresh

### DIFF
--- a/src/Authentication/Services/OidcServerService.cs
+++ b/src/Authentication/Services/OidcServerService.cs
@@ -418,6 +418,7 @@ namespace Altinn.Platform.Authentication.Services
         {
             Claim? sidClaim = principal.Claims.FirstOrDefault(c => c.Type == "sid");
             Claim? scopeClaim = principal.Claims.FirstOrDefault(c => c.Type == "scope");
+            
             // Disable code that forces presence of sid claim. Enable when all users have new token
             //if (sidClaim == null && _generalSettings.ForceOidc)
             //{


### PR DESCRIPTION
Fixed so stuff work for end user system using token exchange.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session refreshes now run only when the authentication context includes the end-user portal scope, preventing unnecessary refreshes and improving session reliability for portal users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->