### PR TITLE
use systemuserservice to delegate ap instead of old function in chang…

### DIFF
--- a/src/Authentication/Services/ChangeRequestSystemUserService.cs
+++ b/src/Authentication/Services/ChangeRequestSystemUserService.cs
@@ -390,7 +390,7 @@ public class ChangeRequestSystemUserService(
 
                 if (delegationResult.IsProblem)
                 {
-                    return new Result<bool>(delegationResult.Problem!);
+                    return delegationResult.Problem;
                 }
             }
         }


### PR DESCRIPTION
Fix of edge case reported, when going from single rights to accesspackage in a change request

When creating a new SystemUser we call Push to AM and Make Rights Holder,
but not when doing a change request which adds an Accesspackage to a systemuser for the first time.

Moved the logic from the old code in changerequestservice to reuse the existing method in systemuserservice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal delegation flow for system user access packages to make processing more efficient and reduce repeated operations, while preserving previous error handling and external behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->