### PR TITLE
Use whole urn string to get access package from metadata API

### DIFF
--- a/src/Authentication/Services/SystemRegisterService.cs
+++ b/src/Authentication/Services/SystemRegisterService.cs
@@ -189,7 +189,6 @@ namespace Altinn.Platform.Authentication.Services
             Package? package = null;
             foreach (AccessPackage accessPackage in accessPackages)
             {
-                // get the urn value from the access package f.eks get regnskapsforer-med-signeringsrettighet from urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet
                 string urnValue = accessPackage.Urn!;
                 package = await _accessManagementClient.GetAccessPackage(urnValue);
                 if (package == null || !package.IsDelegable)
@@ -229,8 +228,7 @@ namespace Altinn.Platform.Authentication.Services
                         continue;
                     }
 
-                    string urnValue = urnParts[3];
-                    Package? package = await _accessManagementClient.GetAccessPackage(urnValue);
+                    Package? package = await _accessManagementClient.GetAccessPackage(urn);
 
                     if (package == null)
                     {

--- a/src/Authentication/Services/SystemUserService.cs
+++ b/src/Authentication/Services/SystemUserService.cs
@@ -701,7 +701,6 @@ namespace Altinn.Platform.Authentication.Services
                 
                 if (found)
                 {
-                    // get the urn value from the access package f.eks get regnskapsforer-med-signeringsrettighet from urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet
                     string urnValue = accessPackage.Urn!;
                     Package package = await _accessManagementClient.GetAccessPackage(urnValue);
                     if (isAgentRequest)


### PR DESCRIPTION
## Description
- Metadata API supports the whole urn as url parameter, no need to split the urn string

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified how access package identifiers are handled during authentication checks, using the full identifier consistently for lookups. This reduces inconsistencies and improves reliability of access package validation across the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->