### PR TITLE
bug: AM now requires standard systemuser push to AM also for single rights delegation

### DIFF
--- a/src/Authentication/Services/SystemUserService.cs
+++ b/src/Authentication/Services/SystemUserService.cs
@@ -548,7 +548,7 @@ namespace Altinn.Platform.Authentication.Services
             if (newSystemUser.UserType == SystemUserType.Standard)
             {
                 // Push system user to Access Management
-                Result<bool> partyCreated = await _accessManagementClient.PushSystemUserToAM(partyUuId, systemUser, cancellationToken);
+                Result<bool> partyCreated = await _accessManagementClient.PushSystemUserToAM(partyUuid, inserted, cancellationToken);
 
                 if (partyCreated.IsProblem)
                 {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2374

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standard system users now automatically sync to Access Management when created.

* **Improvements**
  * Delegation workflow refined to avoid redundant syncing and focus on adding right-holders and per-package delegations.
  * Delegation operations now surface errors/problems encountered during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->