### PR TITLE
feat: add OidcClientCreator console utility

### DIFF
--- a/src/OidcClientCreator/OidcClientCreator.csproj
+++ b/src/OidcClientCreator/OidcClientCreator.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/OidcClientCreator/OidcClientCreator.slnx
+++ b/src/OidcClientCreator/OidcClientCreator.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="OidcClientCreator.csproj" />
+</Solution>

--- a/src/OidcClientCreator/Program.cs
+++ b/src/OidcClientCreator/Program.cs
@@ -1,0 +1,30 @@
+using System.Security.Cryptography;
+
+var id = Guid.CreateVersion7();
+var clientSecret = RandomBase64Url(32);
+var hashedClientSecret = Hash(clientSecret);
+
+Console.WriteLine($"UUID v7:             {id}");
+Console.WriteLine($"Client Secret:       {clientSecret}");
+Console.WriteLine($"Hashed Client Secret:{hashedClientSecret}");
+
+static string RandomBase64Url(int byteLength = 32)
+{
+    byte[] buffer = new byte[byteLength];
+    RandomNumberGenerator.Fill(buffer);
+    string base64 = Convert.ToBase64String(buffer);
+    return base64.Replace("+", "-").Replace("/", "_").TrimEnd('=');
+}
+
+static string Hash(string secret, int iterations = 600_000, int saltSize = 16, int dkLen = 32)
+{
+    byte[] salt = RandomNumberGenerator.GetBytes(saltSize);
+    byte[] hash = Rfc2898DeriveBytes.Pbkdf2(
+        password: secret,
+        salt: salt,
+        iterations: iterations,
+        hashAlgorithm: HashAlgorithmName.SHA256,
+        outputLength: dkLen);
+
+    return $"pbkdf2$sha256$i={iterations}${Convert.ToBase64String(salt)}${Convert.ToBase64String(hash)}";
+}


### PR DESCRIPTION
## Summary
- Adds a standalone `OidcClientCreator` console app under `src/OidcClientCreator/`
- Generates a UUID v7, a random base64url OIDC client secret (32 bytes), and its PBKDF2-SHA256 hash
- Duplicates `CryptoHelpers.RandomBase64Url` and `ClientSecretHasher.Hash` logic inline so the tool has no dependencies on the main solution

## Test plan
- [ ] Run the console app and verify all three values are printed
- [ ] Confirm the hashed secret follows the `pbkdf2$sha256$i=...` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new OIDC Client Creator tool that generates secure OpenID Connect client credentials, including unique client identifiers, cryptographically-secure random client secrets, and encrypted hashed credentials for secure storage and authentication verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->