### PR TITLE
Replace PBKDF2 with HMAC-SHA256 for refresh token storage hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ msbuild.wrn
 TestResults
 /test/Altinn.Platform.Authentication.SystemIntegrationTests/Resources/Environment/environment.json
 /test/Altinn.Platform.Authentication.SystemIntegrationTests/Resources/Jwks/jwks.json
+/.claude/settings.local.json

--- a/src/Authentication/Helpers/ClientSecrets.cs
+++ b/src/Authentication/Helpers/ClientSecrets.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using Altinn.Platform.Authentication.Core.Helpers;
 
 namespace Altinn.Platform.Authentication.Helpers
@@ -9,16 +9,17 @@ namespace Altinn.Platform.Authentication.Helpers
     public static class ClientSecrets
     {
         /// <summary>
-        /// verifies a presented secret against a stored hash.
+        /// Verifies a presented secret against a stored hash.
+        /// Supports legacy PBKDF2 hashes and new HMAC-SHA256 hashes; the verifier dispatches on prefix.
         /// </summary>
-        public static bool Verify(string? storedHash, string presentedSecret)
+        public static bool Verify(string? storedHash, string presentedSecret, byte[] serverPepper)
         {
             if (string.IsNullOrWhiteSpace(storedHash) || string.IsNullOrWhiteSpace(presentedSecret))
             {
                 return false;
             }
 
-            return Pbkdf2SecretVerifier.Verify(presentedSecret, storedHash);
+            return Pbkdf2SecretVerifier.Verify(presentedSecret, storedHash, serverPepper);
         }
     }
 }

--- a/src/Authentication/Services/TokenService.cs
+++ b/src/Authentication/Services/TokenService.cs
@@ -371,9 +371,34 @@ namespace Altinn.Platform.Authentication.Services
                         return (null, TokenResult.InvalidClient("Client not allowed to use client_secret"));
                     }
 
-                    if (!ClientSecrets.Verify(client.ClientSecretHash, auth.ClientSecret!))
+                    byte[] clientSecretPepper;
+                    try
+                    {
+                        clientSecretPepper = Convert.FromBase64String(_generalSettings.OidcRefreshTokenPepper);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Client secret pepper is not configured or invalid.");
+                        return (null, TokenResult.InvalidClient("Server configuration error"));
+                    }
+
+                    if (!ClientSecrets.Verify(client.ClientSecretHash, auth.ClientSecret!, clientSecretPepper))
                     {
                         return (null, TokenResult.InvalidClient("Invalid client secret"));
+                    }
+
+                    if (Pbkdf2SecretVerifier.IsLegacy(client.ClientSecretHash))
+                    {
+                        try
+                        {
+                            string rehashed = ClientSecretHasher.HashHmac(auth.ClientSecret!, clientSecretPepper);
+                            await clientRepo.UpdateClientSecretHashAsync(client.ClientId, rehashed, ct);
+                        }
+                        catch (Exception ex)
+                        {
+                            // Auth already succeeded — rehash failure must not fail the request.
+                            _logger.LogWarning(ex, "Opportunistic client secret rehash failed for client_id={ClientId}", client.ClientId);
+                        }
                     }
 
                     break;

--- a/src/Authentication/Services/TokenService.cs
+++ b/src/Authentication/Services/TokenService.cs
@@ -106,7 +106,7 @@ namespace Altinn.Platform.Authentication.Services
             // 7) Rotate refresh token (every use)
             string newRefreshToken = CryptoHelpers.RandomBase64Url(48);
             byte[] newLookupKey = RefreshTokenCrypto.ComputeLookupKey(newRefreshToken, serverPepper);
-            var (newHash, newSalt, newIters) = RefreshTokenCrypto.HashForStorage(newRefreshToken, iterations: row.Iterations);
+            var (newHash, newSalt, newIters) = RefreshTokenCrypto.HashForStorage(newRefreshToken, serverPepper);
 
             var newRow = new RefreshTokenRow
             {
@@ -215,7 +215,7 @@ namespace Altinn.Platform.Authentication.Services
                 return (Value: TokenResult.InvalidGrant("Invalid refresh_token"), null, null, null, null);
             }
 
-            if (!RefreshTokenCrypto.Verify(request.RefreshToken, row.Salt, row.Iterations, row.Hash))
+            if (!RefreshTokenCrypto.Verify(request.RefreshToken, serverPepper, row.Hash, row.Salt, row.Iterations))
             {
                 return (Value: TokenResult.InvalidGrant("Invalid refresh_token"), null, null, null, null);
             }
@@ -436,10 +436,8 @@ namespace Altinn.Platform.Authentication.Services
             // Generate opaque token
             string refreshToken = CryptoHelpers.RandomBase64Url(48);
 
-            // Fast lookup key + slow hash for storage
             byte[] lookupKey = RefreshTokenCrypto.ComputeLookupKey(refreshToken, serverPepper);
-            var (hash, salt, iters) = RefreshTokenCrypto.HashForStorage(
-                refreshToken, iterations: 600_000);
+            var (hash, salt, iters) = RefreshTokenCrypto.HashForStorage(refreshToken, serverPepper);
 
             DateTimeOffset sliding = now.AddMinutes(_generalSettings.JwtValidityMinutes);
             DateTimeOffset absolute = now.AddMinutes(_generalSettings.MaxSessionTimeInMinutes);

--- a/src/Authentication/Services/TokenService.cs
+++ b/src/Authentication/Services/TokenService.cs
@@ -392,7 +392,12 @@ namespace Altinn.Platform.Authentication.Services
                         try
                         {
                             string rehashed = ClientSecretHasher.HashHmac(auth.ClientSecret!, clientSecretPepper);
-                            await clientRepo.UpdateClientSecretHashAsync(client.ClientId, rehashed, ct);
+                            bool upgraded = await clientRepo.TryUpgradeClientSecretHashAsync(client.ClientId, client.ClientSecretHash!, rehashed, ct);
+                            if (!upgraded)
+                            {
+                                // Stored hash changed under us (concurrent rotation) — nothing to upgrade.
+                                _logger.LogDebug("Skipped opportunistic client secret rehash for client_id={ClientId}: stored hash changed", client.ClientId);
+                            }
                         }
                         catch (Exception ex)
                         {

--- a/src/Core/Helpers/ClientSecretHasher.cs
+++ b/src/Core/Helpers/ClientSecretHasher.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Cryptography;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Altinn.Platform.Authentication.Core.Helpers
 {
@@ -15,6 +16,17 @@ namespace Altinn.Platform.Authentication.Core.Helpers
                 outputLength: dkLen);
 
             return $"pbkdf2$sha256$i={iterations}${Convert.ToBase64String(salt)}${Convert.ToBase64String(hash)}";
+        }
+
+        /// <summary>
+        /// Produces a fast HMAC-SHA256 hash for a high-entropy client secret.
+        /// Format: <c>hmac$sha256$&lt;base64hash&gt;</c>. Safe for system-generated random secrets only.
+        /// </summary>
+        public static string HashHmac(string secret, byte[] serverPepper)
+        {
+            using var h = new HMACSHA256(serverPepper);
+            byte[] hash = h.ComputeHash(Encoding.UTF8.GetBytes(secret));
+            return $"{Pbkdf2SecretVerifier.HmacPrefix}{Convert.ToBase64String(hash)}";
         }
     }
 }

--- a/src/Core/Helpers/Pbkdf2SecretVerifier.cs
+++ b/src/Core/Helpers/Pbkdf2SecretVerifier.cs
@@ -1,15 +1,61 @@
-﻿using System.Security.Cryptography;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Altinn.Platform.Authentication.Core.Helpers
 {
     public static class Pbkdf2SecretVerifier
     {
-        // Validate "pbkdf2$sha256$i=<iterations>$<saltB64>$<hashB64>"
-        public static bool Verify(string secret, string stored)
+        public const string HmacPrefix = "hmac$sha256$";
+
+        public static bool Verify(string secret, string stored, byte[] serverPepper)
         {
             if (string.IsNullOrWhiteSpace(secret) || string.IsNullOrWhiteSpace(stored))
+            {
                 return false;
+            }
 
+            if (stored.StartsWith(HmacPrefix, StringComparison.Ordinal))
+            {
+                return VerifyHmac(secret, stored, serverPepper);
+            }
+
+            return VerifyPbkdf2(secret, stored);
+        }
+
+        public static bool IsLegacy(string? stored) =>
+            !string.IsNullOrEmpty(stored) && !stored!.StartsWith(HmacPrefix, StringComparison.Ordinal);
+
+        public static bool NeedsRehash(string stored, int targetIterations)
+        {
+            if (stored.StartsWith(HmacPrefix, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var parts = stored.Split('$');
+            if (parts.Length != 5 || !parts[2].StartsWith("i=")) return true;
+            return !int.TryParse(parts[2].AsSpan(2), out int iters) || iters < targetIterations;
+        }
+
+        private static bool VerifyHmac(string secret, string stored, byte[] serverPepper)
+        {
+            byte[] expected;
+            try
+            {
+                expected = Convert.FromBase64String(stored.AsSpan(HmacPrefix.Length).ToString());
+            }
+            catch
+            {
+                return false;
+            }
+
+            using var h = new HMACSHA256(serverPepper);
+            byte[] actual = h.ComputeHash(Encoding.UTF8.GetBytes(secret));
+            return CryptographicOperations.FixedTimeEquals(actual, expected);
+        }
+
+        private static bool VerifyPbkdf2(string secret, string stored)
+        {
             var parts = stored.Split('$');
             if (parts.Length != 5 || parts[0] != "pbkdf2" || parts[1] != "sha256" || !parts[2].StartsWith("i="))
                 return false;
@@ -25,10 +71,9 @@ namespace Altinn.Platform.Authentication.Core.Helpers
             }
             catch
             {
-                return false; // bad base64
+                return false;
             }
 
-            // Derive with the same params
             byte[] actual = Rfc2898DeriveBytes.Pbkdf2(
                 password: secret,
                 salt: salt,
@@ -37,14 +82,6 @@ namespace Altinn.Platform.Authentication.Core.Helpers
                 outputLength: expected.Length);
 
             return CryptographicOperations.FixedTimeEquals(actual, expected);
-        }
-
-        // Optional: decide if you should rehash (e.g., after raising iterations)
-        public static bool NeedsRehash(string stored, int targetIterations)
-        {
-            var parts = stored.Split('$');
-            if (parts.Length != 5 || !parts[2].StartsWith("i=")) return true;
-            return !int.TryParse(parts[2].AsSpan(2), out int iters) || iters < targetIterations;
         }
     }
 }

--- a/src/Core/Helpers/RefreshTokenCrypto.cs
+++ b/src/Core/Helpers/RefreshTokenCrypto.cs
@@ -13,18 +13,33 @@ namespace Altinn.Platform.Authentication.Core.Helpers
             return h.ComputeHash(Encoding.UTF8.GetBytes(token));
         }
 
-        public static (byte[] Hash, byte[] Salt, int Iterations) HashForStorage(
-            string token, int iterations = 300_000, int saltSize = 16, int dkLen = 32)
+        /// <summary>
+        /// Returns (Hash, Salt, Iterations) for storing a new refresh token.
+        /// Uses HMAC-SHA256 with the server pepper — O(1), safe for high-entropy random tokens.
+        /// Salt is empty and Iterations is 0 for tokens stored with this method.
+        /// </summary>
+        public static (byte[] Hash, byte[] Salt, int Iterations) HashForStorage(string token, byte[] serverPepper)
         {
-            var salt = RandomNumberGenerator.GetBytes(saltSize);
-            var hash = Rfc2898DeriveBytes.Pbkdf2(token, salt, iterations, HashAlgorithmName.SHA256, dkLen);
-            return (hash, salt, iterations);
+            byte[] hash = ComputeLookupKey(token, serverPepper);
+            return (hash, Array.Empty<byte>(), 0);
         }
 
-        public static bool Verify(string token, byte[] salt, int iterations, byte[] expected)
+        /// <summary>
+        /// Verifies a refresh token against its stored hash.
+        /// Supports both legacy PBKDF2 tokens (iterations > 0) and new HMAC tokens (iterations == 0).
+        /// </summary>
+        public static bool Verify(string token, byte[] serverPepper, byte[] storedHash, byte[] storedSalt, int storedIterations)
         {
-            var actual = Rfc2898DeriveBytes.Pbkdf2(token, salt, iterations, HashAlgorithmName.SHA256, expected.Length);
-            return CryptographicOperations.FixedTimeEquals(actual, expected);
+            if (storedIterations > 0)
+            {
+                // Legacy path: token was stored with PBKDF2 before this change
+                byte[] actual = Rfc2898DeriveBytes.Pbkdf2(token, storedSalt, storedIterations, HashAlgorithmName.SHA256, storedHash.Length);
+                return CryptographicOperations.FixedTimeEquals(actual, storedHash);
+            }
+
+            // Fast HMAC path: token was stored after this change
+            byte[] hmac = ComputeLookupKey(token, serverPepper);
+            return CryptographicOperations.FixedTimeEquals(hmac, storedHash);
         }
     }
 }

--- a/src/Core/Models/Oidc/RefreshTokenRow.cs
+++ b/src/Core/Models/Oidc/RefreshTokenRow.cs
@@ -58,9 +58,11 @@ namespace Altinn.Platform.Authentication.Core.Models.Oidc
 
         /// <summary>
         /// The hash of the refresh token value.
+        /// New tokens: HMAC-SHA256 with server pepper (iterations == 0).
+        /// Legacy tokens: PBKDF2-SHA256 (iterations > 0).
         /// </summary>
-        [JsonIgnore] 
-        public byte[] Hash { get; init; } = Array.Empty<byte>();      // PBKDF2-SHA256
+        [JsonIgnore]
+        public byte[] Hash { get; init; } = Array.Empty<byte>();
 
         /// <summary>
         /// The salt used in the PBKDF2 hashing of the refresh token.

--- a/src/Core/RepositoryInterfaces/IOidcServerRepository.cs
+++ b/src/Core/RepositoryInterfaces/IOidcServerRepository.cs
@@ -58,5 +58,15 @@ namespace Altinn.Platform.Authentication.Core.RepositoryInterfaces
         /// </list>
         /// </remarks>
         Task<OidcClient> InsertClientAsync(OidcClientCreate create, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Replaces the stored <c>client_secret_hash</c> for a client. Used to opportunistically migrate
+        /// legacy PBKDF2 hashes to HMAC-SHA256 after a successful verify, without requiring the operator
+        /// to rotate the secret itself.
+        /// </summary>
+        /// <param name="clientId">The client whose stored hash should be replaced.</param>
+        /// <param name="newClientSecretHash">The new self-describing hash string (e.g. <c>hmac$sha256$...</c>).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task UpdateClientSecretHashAsync(string clientId, string newClientSecretHash, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Core/RepositoryInterfaces/IOidcServerRepository.cs
+++ b/src/Core/RepositoryInterfaces/IOidcServerRepository.cs
@@ -60,13 +60,15 @@ namespace Altinn.Platform.Authentication.Core.RepositoryInterfaces
         Task<OidcClient> InsertClientAsync(OidcClientCreate create, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Replaces the stored <c>client_secret_hash</c> for a client. Used to opportunistically migrate
-        /// legacy PBKDF2 hashes to HMAC-SHA256 after a successful verify, without requiring the operator
-        /// to rotate the secret itself.
+        /// Replaces the stored <c>client_secret_hash</c> only if it currently equals
+        /// <paramref name="expectedCurrentHash"/>. Used to opportunistically migrate legacy PBKDF2
+        /// hashes to HMAC-SHA256 after a successful verify, without clobbering a concurrent rotation.
         /// </summary>
         /// <param name="clientId">The client whose stored hash should be replaced.</param>
+        /// <param name="expectedCurrentHash">The hash value the caller just verified against; the update is a no-op if the stored hash no longer matches this.</param>
         /// <param name="newClientSecretHash">The new self-describing hash string (e.g. <c>hmac$sha256$...</c>).</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        Task UpdateClientSecretHashAsync(string clientId, string newClientSecretHash, CancellationToken cancellationToken = default);
+        /// <returns><c>true</c> if the hash was replaced; <c>false</c> if the stored hash no longer matches <paramref name="expectedCurrentHash"/> (e.g. a concurrent rotation occurred).</returns>
+        Task<bool> TryUpgradeClientSecretHashAsync(string clientId, string expectedCurrentHash, string newClientSecretHash, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Persistance/RepositoryImplementations/OidcServer/OidcServerClientRepository.cs
+++ b/src/Persistance/RepositoryImplementations/OidcServer/OidcServerClientRepository.cs
@@ -226,6 +226,44 @@ namespace Altinn.Platform.Authentication.Persistance.RepositoryImplementations.O
                 }
             }
 
+        /// <inheritdoc/>
+        public async Task UpdateClientSecretHashAsync(string clientId, string newClientSecretHash, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(clientId))
+            {
+                throw new ArgumentException("ClientId is required.", nameof(clientId));
+            }
+
+            if (string.IsNullOrWhiteSpace(newClientSecretHash))
+            {
+                throw new ArgumentException("New client secret hash is required.", nameof(newClientSecretHash));
+            }
+
+            const string SQL = /*strpsql*/ @"
+                UPDATE oidcserver.client
+                   SET client_secret_hash = @client_secret_hash,
+                       updated_at         = @updated_at
+                 WHERE client_id = @client_id;";
+
+            try
+            {
+                await using var cmd = _datasource.CreateCommand(SQL);
+                cmd.Parameters.Add(new NpgsqlParameter<string>("client_id", clientId));
+                cmd.Parameters.Add(new NpgsqlParameter<string>("client_secret_hash", newClientSecretHash));
+                cmd.Parameters.AddWithValue("updated_at", _timeProvider.GetUtcNow());
+
+                await cmd.ExecuteNonQueryAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                var sanitizedClientId = clientId.Replace(Environment.NewLine, string.Empty)
+                                                  .Replace("\r", string.Empty)
+                                                  .Replace("\n", string.Empty);
+                _logger.LogError(ex, "Authentication // OidcServerRepository // UpdateClientSecretHashAsync // client_id={ClientId}", sanitizedClientId);
+                throw;
+            }
+        }
+
         private static TEnum ParseEnum<TEnum>(string value, TEnum fallback)
             where TEnum : struct
             => Enum.TryParse<TEnum>(value, ignoreCase: true, out var parsed) ? parsed : fallback;

--- a/src/Persistance/RepositoryImplementations/OidcServer/OidcServerClientRepository.cs
+++ b/src/Persistance/RepositoryImplementations/OidcServer/OidcServerClientRepository.cs
@@ -227,11 +227,16 @@ namespace Altinn.Platform.Authentication.Persistance.RepositoryImplementations.O
             }
 
         /// <inheritdoc/>
-        public async Task UpdateClientSecretHashAsync(string clientId, string newClientSecretHash, CancellationToken cancellationToken = default)
+        public async Task<bool> TryUpgradeClientSecretHashAsync(string clientId, string expectedCurrentHash, string newClientSecretHash, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(clientId))
             {
                 throw new ArgumentException("ClientId is required.", nameof(clientId));
+            }
+
+            if (string.IsNullOrWhiteSpace(expectedCurrentHash))
+            {
+                throw new ArgumentException("Expected current hash is required.", nameof(expectedCurrentHash));
             }
 
             if (string.IsNullOrWhiteSpace(newClientSecretHash))
@@ -243,23 +248,26 @@ namespace Altinn.Platform.Authentication.Persistance.RepositoryImplementations.O
                 UPDATE oidcserver.client
                    SET client_secret_hash = @client_secret_hash,
                        updated_at         = @updated_at
-                 WHERE client_id = @client_id;";
+                 WHERE client_id = @client_id
+                   AND client_secret_hash = @expected_current_hash;";
 
             try
             {
                 await using var cmd = _datasource.CreateCommand(SQL);
                 cmd.Parameters.Add(new NpgsqlParameter<string>("client_id", clientId));
+                cmd.Parameters.Add(new NpgsqlParameter<string>("expected_current_hash", expectedCurrentHash));
                 cmd.Parameters.Add(new NpgsqlParameter<string>("client_secret_hash", newClientSecretHash));
                 cmd.Parameters.AddWithValue("updated_at", _timeProvider.GetUtcNow());
 
-                await cmd.ExecuteNonQueryAsync(cancellationToken);
+                int rowsAffected = await cmd.ExecuteNonQueryAsync(cancellationToken);
+                return rowsAffected > 0;
             }
             catch (Exception ex)
             {
                 var sanitizedClientId = clientId.Replace(Environment.NewLine, string.Empty)
                                                   .Replace("\r", string.Empty)
                                                   .Replace("\n", string.Empty);
-                _logger.LogError(ex, "Authentication // OidcServerRepository // UpdateClientSecretHashAsync // client_id={ClientId}", sanitizedClientId);
+                _logger.LogError(ex, "Authentication // OidcServerRepository // TryUpgradeClientSecretHashAsync // client_id={ClientId}", sanitizedClientId);
                 throw;
             }
         }

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
@@ -162,13 +162,16 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
         [Fact]
         public async Task TC1_Auth_Aa_App_Af_App_Af_Logout_End_To_End_OK()
         {
-            // Create HttpClient with default headers for IP, UA, correlation. 
+            // Create HttpClient with default headers for IP, UA, correlation.
             using HttpClient client = CreateClientWithHeaders();
             OidcTestScenario testScenario = OidcScenarioHelper.GetScenario("Arbeidsflate_HappyFlow");
 
             // Insert a client that matches the authorize request
             OidcClientCreate create = OidcServerTestUtils.NewClientCreate(testScenario);
             _ = await Repository.InsertClientAsync(create);
+
+            // Sanity: the test scenario seeds the client with a legacy PBKDF2 hash.
+            await TokenAssertsHelper.AssertClientSecretIsLegacyPbkdf2(Repository, testScenario.DownstreamClientId);
 
             // 08:00:00 UTC — start of day: user signs in to Arbeidsflate (RP).
             // Arbeidsflate redirects the browser to the Altinn Authentication OIDC Provider’s /authorize endpoint.
@@ -207,6 +210,9 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             Assert.Equal(HttpStatusCode.OK, tokenResp.StatusCode);
             TokenResponseDto? tokenResult = await tokenResp.Content.ReadFromJsonAsync<TokenResponseDto>(jsonSerializerOptions);
             string tokenString = await tokenResp.Content.ReadAsStringAsync();
+
+            // The first successful client_secret verify must have rehashed the stored hash to HMAC-SHA256.
+            await TokenAssertsHelper.AssertClientSecretMigratedToHmac(Repository, testScenario.DownstreamClientId);
 
             // Asserts on token response structure
             string sid = TokenAssertsHelper.AssertTokenResponse(tokenResult, testScenario, _fakeTime.GetUtcNow());

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEnd_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEnd_OidcFrontChannelControllerTest.cs
@@ -170,6 +170,9 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             OidcClientCreate create = OidcServerTestUtils.NewClientCreate(testScenario);
             _ = await Repository.InsertClientAsync(create);
 
+            // Sanity: the test scenario seeds the client with a legacy PBKDF2 hash.
+            await TokenAssertsHelper.AssertClientSecretIsLegacyPbkdf2(Repository, testScenario.DownstreamClientId);
+
             // 08:00:00 UTC — start of day: user signs in to Arbeidsflate (RP).
             // Arbeidsflate redirects the browser to the Altinn Authentication OIDC Provider’s /authorize endpoint.
             string url = testScenario.GetAuthorizationRequestUrl();
@@ -206,6 +209,9 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
 
             Assert.Equal(HttpStatusCode.OK, tokenResp.StatusCode);
             TokenResponseDto? tokenResult = await tokenResp.Content.ReadFromJsonAsync<TokenResponseDto>(jsonSerializerOptions);
+
+            // The first successful client_secret verify must have rehashed the stored hash to HMAC-SHA256.
+            await TokenAssertsHelper.AssertClientSecretMigratedToHmac(Repository, testScenario.DownstreamClientId);
 
             // Asserts on token response structure
             string sid = TokenAssertsHelper.AssertTokenResponse(tokenResult, testScenario, _fakeTime.GetUtcNow());

--- a/test/Altinn.Platform.Authentication.Tests/Helpers/TokenAssertsHelper.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Helpers/TokenAssertsHelper.cs
@@ -3,8 +3,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading.Tasks;
 using Altinn.Platform.Authentication.Core.Constants;
 using Altinn.Platform.Authentication.Core.Models.Oidc;
+using Altinn.Platform.Authentication.Core.RepositoryInterfaces;
 using Altinn.Platform.Authentication.Enum;
 using Altinn.Platform.Authentication.Tests.Models;
 using Altinn.Urn;
@@ -153,6 +155,30 @@ namespace Altinn.Platform.Authentication.Tests.Helpers
             }
 
             return sid;
+        }
+
+        /// <summary>
+        /// Asserts that the client's stored secret hash is still in the legacy PBKDF2 format
+        /// (i.e. no token request has triggered the opportunistic HMAC rehash yet).
+        /// </summary>
+        public static async Task AssertClientSecretIsLegacyPbkdf2(IOidcServerClientRepository repository, string clientId)
+        {
+            OidcClient? client = await repository.GetClientAsync(clientId);
+            Assert.NotNull(client);
+            Assert.NotNull(client!.ClientSecretHash);
+            Assert.StartsWith("pbkdf2$", client.ClientSecretHash);
+        }
+
+        /// <summary>
+        /// Asserts that the client's stored secret hash has been rewritten to the HMAC-SHA256 format
+        /// by the opportunistic rehash path in TokenService after a successful client secret verify.
+        /// </summary>
+        public static async Task AssertClientSecretMigratedToHmac(IOidcServerClientRepository repository, string clientId)
+        {
+            OidcClient? client = await repository.GetClientAsync(clientId);
+            Assert.NotNull(client);
+            Assert.NotNull(client!.ClientSecretHash);
+            Assert.StartsWith("hmac$sha256$", client.ClientSecretHash);
         }
 
         private static bool IsBase64Url(string s) =>


### PR DESCRIPTION
Refresh tokens are 48-byte CSPRNG values (384-bit entropy) — PBKDF2 provides no brute-force resistance for high-entropy random tokens and was burning 300k–600k iterations per refresh request unnecessarily. Storage hash is now HMAC-SHA256 with the server pepper (same key already used for the lookup key), making hashing O(1). Legacy PBKDF2 tokens are handled via fallback in Verify (iterations > 0) until they naturally expire.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Refresh tokens and client secrets now use a stronger server-pepper HMAC verification while remaining compatible with legacy PBKDF2; client secrets are opportunistically migrated on first successful use.
* **Bug Fixes**
  * Misconfigured secret-pepper settings are detected early with clear error logging and an invalid-client response.
* **Chores**
  * Added API to conditionally upgrade stored client secret hashes; updated ignore list.
* **Tests**
  * End-to-end tests now assert legacy-to-HMAC migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->