### PR TITLE
Bruk ny systemressurs `altinn_system_user_overview` for at klientadmin skal kunne laste systembrukere

### DIFF
--- a/src/Authentication/AuthenticationHost.cs
+++ b/src/Authentication/AuthenticationHost.cs
@@ -209,6 +209,8 @@ internal static class AuthenticationHost
                 policy.Requirements.Add(new ResourceAccessRequirement("write", "altinn_access_management")))
             .AddPolicy(AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ, policy =>
                 policy.Requirements.Add(new ResourceAccessRequirement("read", "altinn_system_user_overview")))
+            .AddPolicy(AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_WRITE, policy =>
+                policy.Requirements.Add(new ResourceAccessRequirement("write", "altinn_system_user_overview")))
             .AddPolicy(AuthzConstants.POLICY_SCOPE_SYSTEMUSERREQUEST_WRITE, policy =>
                 policy.RequireScopeAnyOf(AuthzConstants.SCOPE_SYSTEMUSER_REQUEST_WRITE))
             .AddPolicy(AuthzConstants.POLICY_SCOPE_SYSTEMUSERLOOKUP, policy =>

--- a/src/Authentication/AuthenticationHost.cs
+++ b/src/Authentication/AuthenticationHost.cs
@@ -207,9 +207,9 @@ internal static class AuthenticationHost
                 policy.Requirements.Add(new ResourceAccessRequirement("read", "altinn_access_management")))
             .AddPolicy(AuthzConstants.POLICY_ACCESS_MANAGEMENT_WRITE, policy =>
                 policy.Requirements.Add(new ResourceAccessRequirement("write", "altinn_access_management")))
-            .AddPolicy(AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ, policy =>
+            .AddPolicy(AuthzConstants.POLICY_SYSTEMUSER_CLIENTDELEGATION_READ, policy =>
                 policy.Requirements.Add(new ResourceAccessRequirement("read", "altinn_system_user_overview")))
-            .AddPolicy(AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_WRITE, policy =>
+            .AddPolicy(AuthzConstants.POLICY_SYSTEMUSER_CLIENTDELEGATION_WRITE, policy =>
                 policy.Requirements.Add(new ResourceAccessRequirement("write", "altinn_system_user_overview")))
             .AddPolicy(AuthzConstants.POLICY_SCOPE_SYSTEMUSERREQUEST_WRITE, policy =>
                 policy.RequireScopeAnyOf(AuthzConstants.SCOPE_SYSTEMUSER_REQUEST_WRITE))

--- a/src/Authentication/AuthenticationHost.cs
+++ b/src/Authentication/AuthenticationHost.cs
@@ -207,9 +207,9 @@ internal static class AuthenticationHost
                 policy.Requirements.Add(new ResourceAccessRequirement("read", "altinn_access_management")))
             .AddPolicy(AuthzConstants.POLICY_ACCESS_MANAGEMENT_WRITE, policy =>
                 policy.Requirements.Add(new ResourceAccessRequirement("write", "altinn_access_management")))
-            .AddPolicy(AuthzConstants.POLICY_SYSTEMUSER_CLIENTDELEGATION_READ, policy =>
+            .AddPolicy(AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ, policy =>
                 policy.Requirements.Add(new ResourceAccessRequirement("read", "altinn_system_user_overview")))
-            .AddPolicy(AuthzConstants.POLICY_SYSTEMUSER_CLIENTDELEGATION_WRITE, policy =>
+            .AddPolicy(AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_WRITE, policy =>
                 policy.Requirements.Add(new ResourceAccessRequirement("write", "altinn_system_user_overview")))
             .AddPolicy(AuthzConstants.POLICY_SCOPE_SYSTEMUSERREQUEST_WRITE, policy =>
                 policy.RequireScopeAnyOf(AuthzConstants.SCOPE_SYSTEMUSER_REQUEST_WRITE))

--- a/src/Authentication/AuthenticationHost.cs
+++ b/src/Authentication/AuthenticationHost.cs
@@ -207,6 +207,8 @@ internal static class AuthenticationHost
                 policy.Requirements.Add(new ResourceAccessRequirement("read", "altinn_access_management")))
             .AddPolicy(AuthzConstants.POLICY_ACCESS_MANAGEMENT_WRITE, policy =>
                 policy.Requirements.Add(new ResourceAccessRequirement("write", "altinn_access_management")))
+            .AddPolicy(AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ, policy =>
+                policy.Requirements.Add(new ResourceAccessRequirement("read", "altinn_system_user_overview")))
             .AddPolicy(AuthzConstants.POLICY_SCOPE_SYSTEMUSERREQUEST_WRITE, policy =>
                 policy.RequireScopeAnyOf(AuthzConstants.SCOPE_SYSTEMUSER_REQUEST_WRITE))
             .AddPolicy(AuthzConstants.POLICY_SCOPE_SYSTEMUSERLOOKUP, policy =>

--- a/src/Authentication/Controllers/SystemUserController.cs
+++ b/src/Authentication/Controllers/SystemUserController.cs
@@ -88,7 +88,7 @@ public class SystemUserController : ControllerBase
     /// Returns the list of agent SystemUsers this PartyID has registered
     /// </summary>
     /// <returns>List of SystemUsers</returns>
-    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_CLIENTDELEGATION_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [HttpGet("agent/{party}")]
     public async Task<ActionResult<List<SystemUserInternalDTO>>> GetListOfAgentSystemUsersPartyHas(int party)
@@ -101,7 +101,7 @@ public class SystemUserController : ControllerBase
     /// Get list of delegations to this agent systemuser
     /// </summary>
     /// <returns>List of DelegationResponse</returns>
-    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_CLIENTDELEGATION_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [HttpGet("agent/{party}/{facilitator}/{systemUserId}/delegations")]
     public async Task<ActionResult<List<DelegationResponse>>> GetListOfDelegationsForAgentSystemUser(int party, Guid facilitator, Guid systemUserId)
@@ -120,7 +120,7 @@ public class SystemUserController : ControllerBase
     /// Return a single SystemUser by PartyId and SystemUserId
     /// </summary>
     /// <returns></returns>
-    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_CLIENTDELEGATION_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [HttpGet("{party}/{systemUserId}")]
@@ -393,7 +393,7 @@ public class SystemUserController : ControllerBase
     /// The endpoint is idempotent.
     /// </summary>
     /// <returns>OK</returns>    
-    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_CLIENTDELEGATION_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_WRITE)]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -540,7 +540,7 @@ public class SystemUserController : ControllerBase
     /// Delete a customer from an Agent SystemUser.
     /// </summary>
     /// <returns></returns>
-    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_CLIENTDELEGATION_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_WRITE)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [HttpDelete("agent/{party}/delegation/{delegationId}")]
@@ -579,7 +579,7 @@ public class SystemUserController : ControllerBase
     /// Get list of clients for a facilitator
     /// </summary>
     /// <returns>List of Clients</returns>
-    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_CLIENTDELEGATION_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [HttpGet("agent/{party}/clients")]
     public async Task<ActionResult<List<Customer>>> GetClientsForFacilitator([FromQuery]Guid facilitator, [FromQuery] List<string> packages = null, CancellationToken cancellationToken = default)

--- a/src/Authentication/Controllers/SystemUserController.cs
+++ b/src/Authentication/Controllers/SystemUserController.cs
@@ -88,7 +88,7 @@ public class SystemUserController : ControllerBase
     /// Returns the list of SystemUsers this PartyID has registered
     /// </summary>
     /// <returns>List of SystemUsers</returns>
-    [Authorize(Policy = AuthzConstants.POLICY_ACCESS_MANAGEMENT_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [HttpGet("agent/{party}")]
     public async Task<ActionResult<List<SystemUserInternalDTO>>> GetListOfAgentSystemUsersPartyHas(int party)
@@ -120,7 +120,7 @@ public class SystemUserController : ControllerBase
     /// Return a single SystemUser by PartyId and SystemUserId
     /// </summary>
     /// <returns></returns>
-    [Authorize(Policy = AuthzConstants.POLICY_ACCESS_MANAGEMENT_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [HttpGet("{party}/{systemUserId}")]

--- a/src/Authentication/Controllers/SystemUserController.cs
+++ b/src/Authentication/Controllers/SystemUserController.cs
@@ -85,7 +85,7 @@ public class SystemUserController : ControllerBase
     }
 
     /// <summary>
-    /// Returns the list of SystemUsers this PartyID has registered
+    /// Returns the list of agent SystemUsers this PartyID has registered
     /// </summary>
     /// <returns>List of SystemUsers</returns>
     [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ)]

--- a/src/Authentication/Controllers/SystemUserController.cs
+++ b/src/Authentication/Controllers/SystemUserController.cs
@@ -88,7 +88,7 @@ public class SystemUserController : ControllerBase
     /// Returns the list of agent SystemUsers this PartyID has registered
     /// </summary>
     /// <returns>List of SystemUsers</returns>
-    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_CLIENTDELEGATION_READ)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [HttpGet("agent/{party}")]
     public async Task<ActionResult<List<SystemUserInternalDTO>>> GetListOfAgentSystemUsersPartyHas(int party)
@@ -101,7 +101,7 @@ public class SystemUserController : ControllerBase
     /// Get list of delegations to this agent systemuser
     /// </summary>
     /// <returns>List of DelegationResponse</returns>
-    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_CLIENTDELEGATION_READ)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [HttpGet("agent/{party}/{facilitator}/{systemUserId}/delegations")]
     public async Task<ActionResult<List<DelegationResponse>>> GetListOfDelegationsForAgentSystemUser(int party, Guid facilitator, Guid systemUserId)
@@ -120,7 +120,7 @@ public class SystemUserController : ControllerBase
     /// Return a single SystemUser by PartyId and SystemUserId
     /// </summary>
     /// <returns></returns>
-    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_CLIENTDELEGATION_READ)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [HttpGet("{party}/{systemUserId}")]
@@ -393,7 +393,7 @@ public class SystemUserController : ControllerBase
     /// The endpoint is idempotent.
     /// </summary>
     /// <returns>OK</returns>    
-    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_CLIENTDELEGATION_WRITE)]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -540,7 +540,7 @@ public class SystemUserController : ControllerBase
     /// Delete a customer from an Agent SystemUser.
     /// </summary>
     /// <returns></returns>
-    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_CLIENTDELEGATION_WRITE)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [HttpDelete("agent/{party}/delegation/{delegationId}")]
@@ -579,7 +579,7 @@ public class SystemUserController : ControllerBase
     /// Get list of clients for a facilitator
     /// </summary>
     /// <returns>List of Clients</returns>
-    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_CLIENTDELEGATION_READ)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [HttpGet("agent/{party}/clients")]
     public async Task<ActionResult<List<Customer>>> GetClientsForFacilitator([FromQuery]Guid facilitator, [FromQuery] List<string> packages = null, CancellationToken cancellationToken = default)

--- a/src/Authentication/Controllers/SystemUserController.cs
+++ b/src/Authentication/Controllers/SystemUserController.cs
@@ -101,7 +101,7 @@ public class SystemUserController : ControllerBase
     /// Get list of delegations to this agent systemuser
     /// </summary>
     /// <returns>List of DelegationResponse</returns>
-    [Authorize(Policy = AuthzConstants.POLICY_ACCESS_MANAGEMENT_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [HttpGet("agent/{party}/{facilitator}/{systemUserId}/delegations")]
     public async Task<ActionResult<List<DelegationResponse>>> GetListOfDelegationsForAgentSystemUser(int party, Guid facilitator, Guid systemUserId)
@@ -393,7 +393,7 @@ public class SystemUserController : ControllerBase
     /// The endpoint is idempotent.
     /// </summary>
     /// <returns>OK</returns>    
-    [Authorize(Policy = AuthzConstants.POLICY_ACCESS_MANAGEMENT_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_WRITE)]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -540,7 +540,7 @@ public class SystemUserController : ControllerBase
     /// Delete a customer from an Agent SystemUser.
     /// </summary>
     /// <returns></returns>
-    [Authorize(Policy = AuthzConstants.POLICY_ACCESS_MANAGEMENT_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_WRITE)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [HttpDelete("agent/{party}/delegation/{delegationId}")]
@@ -579,7 +579,7 @@ public class SystemUserController : ControllerBase
     /// Get list of clients for a facilitator
     /// </summary>
     /// <returns>List of Clients</returns>
-    [Authorize(Policy = AuthzConstants.POLICY_ACCESS_MANAGEMENT_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_SYSTEMUSER_OVERVIEW_READ)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [HttpGet("agent/{party}/clients")]
     public async Task<ActionResult<List<Customer>>> GetClientsForFacilitator([FromQuery]Guid facilitator, [FromQuery] List<string> packages = null, CancellationToken cancellationToken = default)

--- a/src/Core/Constants/AuthzConstants.cs
+++ b/src/Core/Constants/AuthzConstants.cs
@@ -46,7 +46,6 @@ namespace Altinn.Platform.Authentication.Core.Constants
         /// </summary>
         public const string POLICY_SYSTEMUSER_OVERVIEW_WRITE = "SystemUserOverviewWrite";
 
-
         /// <summary>
         /// Policy tag for reading access management information
         /// </summary>

--- a/src/Core/Constants/AuthzConstants.cs
+++ b/src/Core/Constants/AuthzConstants.cs
@@ -37,6 +37,11 @@ namespace Altinn.Platform.Authentication.Core.Constants
         public const string CLAIM_MASKINPORTEN_CONSUMER_PREFIX = "consumer_prefix";
 
         /// <summary>
+        /// Policy tag for reading system user overview
+        /// </summary>
+        public const string POLICY_SYSTEMUSER_OVERVIEW_READ = "SystemUserOverviewRead";
+
+        /// <summary>
         /// Policy tag for reading access management information
         /// </summary>
         public const string POLICY_ACCESS_MANAGEMENT_READ = "AccessManagementRead";

--- a/src/Core/Constants/AuthzConstants.cs
+++ b/src/Core/Constants/AuthzConstants.cs
@@ -39,12 +39,12 @@ namespace Altinn.Platform.Authentication.Core.Constants
         /// <summary>
         /// Policy tag for reading system user overview
         /// </summary>
-        public const string POLICY_SYSTEMUSER_CLIENTDELEGATION_READ = "SystemUserClientDelegationRead";
+        public const string POLICY_SYSTEMUSER_OVERVIEW_READ = "SystemUserOverviewRead";
 
         /// <summary>
         /// Policy tag for writing system user overview
         /// </summary>
-        public const string POLICY_SYSTEMUSER_CLIENTDELEGATION_WRITE = "SystemUserClientDelegationWrite";
+        public const string POLICY_SYSTEMUSER_OVERVIEW_WRITE = "SystemUserOverviewWrite";
 
         /// <summary>
         /// Policy tag for reading access management information

--- a/src/Core/Constants/AuthzConstants.cs
+++ b/src/Core/Constants/AuthzConstants.cs
@@ -39,12 +39,12 @@ namespace Altinn.Platform.Authentication.Core.Constants
         /// <summary>
         /// Policy tag for reading system user overview
         /// </summary>
-        public const string POLICY_SYSTEMUSER_OVERVIEW_READ = "SystemUserOverviewRead";
+        public const string POLICY_SYSTEMUSER_CLIENTDELEGATION_READ = "SystemUserClientDelegationRead";
 
         /// <summary>
         /// Policy tag for writing system user overview
         /// </summary>
-        public const string POLICY_SYSTEMUSER_OVERVIEW_WRITE = "SystemUserOverviewWrite";
+        public const string POLICY_SYSTEMUSER_CLIENTDELEGATION_WRITE = "SystemUserClientDelegationWrite";
 
         /// <summary>
         /// Policy tag for reading access management information

--- a/src/Core/Constants/AuthzConstants.cs
+++ b/src/Core/Constants/AuthzConstants.cs
@@ -42,6 +42,12 @@ namespace Altinn.Platform.Authentication.Core.Constants
         public const string POLICY_SYSTEMUSER_OVERVIEW_READ = "SystemUserOverviewRead";
 
         /// <summary>
+        /// Policy tag for writing system user overview
+        /// </summary>
+        public const string POLICY_SYSTEMUSER_OVERVIEW_WRITE = "SystemUserOverviewWrite";
+
+
+        /// <summary>
         /// Policy tag for reading access management information
         /// </summary>
         public const string POLICY_ACCESS_MANAGEMENT_READ = "AccessManagementRead";

--- a/test/Altinn.Platform.Authentication.Tests/Data/Xacml/3.0/ResourceRegistry/altinn_system_user_overview/policy.xml
+++ b/test/Altinn.Platform.Authentication.Tests/Data/Xacml/3.0/ResourceRegistry/altinn_system_user_overview/policy.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy xmlns:xsl="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" PolicyId="urn:altinn:resource:altinn_access_management:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides">
+  <xacml:Target/>
+  <xacml:Rule RuleId="urn:altinn:resource:altinn_system_user_overview:ruleid:1" Effect="Permit">
+    <xacml:Description>SystemResource policy for resource; altinn_system_user_overview for roles; ADMAI and HADM to have access to actions; read and write</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ADMAI</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">HADM</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+ 	<xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">KLADM</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">altinn_system_user_overview</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:resource" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:ObligationExpressions>
+    <xacml:ObligationExpression FulfillOn="Permit" ObligationId="urn:altinn:obligation:1">
+      <xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation-assignment:1" Category="urn:altinn:minimum-authenticationlevel">
+        <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">3</xacml:AttributeValue>
+      </xacml:AttributeAssignmentExpression>
+    </xacml:ObligationExpression>
+  </xacml:ObligationExpressions>
+</xacml:Policy>

--- a/test/Altinn.Platform.Authentication.Tests/Data/Xacml/3.0/ResourceRegistry/altinn_system_user_overview/policy.xml
+++ b/test/Altinn.Platform.Authentication.Tests/Data/Xacml/3.0/ResourceRegistry/altinn_system_user_overview/policy.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xacml:Policy xmlns:xsl="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" PolicyId="urn:altinn:resource:altinn_access_management:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides">
+<xacml:Policy xmlns:xsl="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" PolicyId="urn:altinn:resource:altinn_system_user_overview:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides">
   <xacml:Target/>
   <xacml:Rule RuleId="urn:altinn:resource:altinn_system_user_overview:ruleid:1" Effect="Permit">
-    <xacml:Description>SystemResource policy for resource; altinn_system_user_overview for roles; ADMAI and HADM to have access to actions; read and write</xacml:Description>
+    <xacml:Description>SystemResource policy for resource; altinn_system_user_overview for roles; ADMAI, HADM and KLADM to have access to actions; read and write</xacml:Description>
     <xacml:Target>
       <xacml:AnyOf>
         <xacml:AllOf>


### PR DESCRIPTION
## Description
- Brukere som kun er klientadministatorer må kunne se agent-systembrukere og legge til og fjerne klienter. Bruk ny systemressurs `altinn_system_user_overview` for at både klientadministratorer og tilgangsstyrere skal kunne kalle relevante endepunkt:
    - Laste liste over agent systembrukere
    - Laste en enkelt agent systembruker
    - Laste kundeliste
    - Laste delegerte kunder for agent systembruker
    - Legge til kunde
    - Fjerne kunde

## Related Issue(s)
-  https://github.com/Altinn/altinn-authentication/issues/1638

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new authorization policies for System User Overview operations with separate read and write permission levels.

* **Refactor**
  * Updated system user management endpoints to use refined authorization policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->