### PR TITLE
Extend the redirect url length for sytsemuser request

### DIFF
--- a/src/Authentication/Altinn.Platform.Authentication.csproj
+++ b/src/Authentication/Altinn.Platform.Authentication.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Altinn.Common.AccessToken" Version="5.1.0" />
     <PackageReference Include="Altinn.Common.PEP" Version="4.2.2" />
     <PackageReference Include="Altinn.Register.Contracts" Version="1.4.1" />
-    <PackageReference Include="AutoMapper" Version="15.1.0" />
+    <PackageReference Include="AutoMapper" Version="15.1.3" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
@@ -31,6 +31,8 @@
     <PackageReference Include="Microsoft.FeatureManagement" Version="4.4.0" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.4.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.15.0" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.0" />
     <PackageReference Include="Npgsql" Version="10.0.1" />

--- a/src/Persistance/Migration/v0.27/01-alter-redirect-urls-length.sql
+++ b/src/Persistance/Migration/v0.27/01-alter-redirect-urls-length.sql
@@ -1,0 +1,16 @@
+-- Tables: business_application.request
+--         business_application.request_archive
+--         business_application.change_request
+--
+-- Widen the redirect_urls column from varchar(255) to text so that long
+-- redirect URLs (e.g. ones carrying state/query parameters) can be stored
+-- without causing a 500 on POST /authentication/api/v1/systemuser/request/vendor.
+
+ALTER TABLE business_application.request
+    ALTER COLUMN redirect_urls TYPE text;
+
+ALTER TABLE business_application.request_archive
+    ALTER COLUMN redirect_urls TYPE text;
+
+ALTER TABLE business_application.change_request
+    ALTER COLUMN redirect_urls TYPE text;

--- a/test/Altinn.Platform.Authentication.Tests/Altinn.Platform.Authentication.Tests.csproj
+++ b/test/Altinn.Platform.Authentication.Tests/Altinn.Platform.Authentication.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Altinn.Platform.Authentication.Tests/RepositoryDataAccess/ChangeRequestRepositoryTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/RepositoryDataAccess/ChangeRequestRepositoryTest.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Threading.Tasks;
+using Altinn.Platform.Authentication.Core.Models.SystemUsers;
+using Altinn.Platform.Authentication.Core.RepositoryInterfaces;
+using Altinn.Platform.Authentication.Persistance.Extensions;
+using Altinn.Platform.Persistence.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Xunit;
+
+namespace Altinn.Platform.Authentication.Tests.RepositoryDataAccess;
+
+public class ChangeRequestRepositoryTest(DbFixture dbFixture)
+    : DbTestBase(dbFixture)
+{
+    protected IChangeRequestRepository Repository => Services.GetRequiredService<IChangeRequestRepository>();
+
+    protected NpgsqlDataSource DataSource => Services.GetRequiredService<NpgsqlDataSource>();
+
+    protected override void ConfigureHost(IHostApplicationBuilder builder)
+    {
+        builder.AddPersistanceLayer();
+        base.ConfigureHost(builder);
+    }
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        services.TryAddSingleton(TimeProvider.System);
+        base.ConfigureServices(services);
+    }
+
+    [Theory]
+    [InlineData(256)]
+    [InlineData(2048)]
+    [InlineData(8192)]
+    public async Task CreateChangeRequest_WithRedirectUrlLongerThan255Characters_IsPersisted(int urlLength)
+    {
+        // Verifies migration v0.27/01-alter-redirect-urls-length.sql which widens
+        // business_application.change_request.redirect_urls from varchar(255) to text.
+        // Multiple lengths exercise that the column is effectively unbounded.
+        string longRedirectUrl = BuildLongRedirectUrl(urlLength);
+
+        ChangeRequestResponse req = new()
+        {
+            Id = Guid.NewGuid(),
+            ExternalRef = "test-change-long-url",
+            SystemId = "test",
+            SystemUserId = Guid.NewGuid(),
+            PartyOrgNo = "123456789",
+            RequiredRights = [],
+            UnwantedRights = [],
+            RequiredAccessPackages = [],
+            UnwantedAccessPackages = [],
+            Status = "new",
+            RedirectUrl = longRedirectUrl
+        };
+
+        var create = await Repository.CreateChangeRequest(req);
+        Assert.True(create.IsSuccess);
+
+        var stored = await Repository.GetChangeRequestById(req.Id);
+        Assert.NotNull(stored);
+        Assert.Equal(longRedirectUrl, stored!.RedirectUrl);
+        Assert.True(stored.RedirectUrl!.Length > 255);
+
+        Assert.Equal("text", await GetColumnDataTypeAsync("change_request", "redirect_urls"));
+    }
+
+    private static string BuildLongRedirectUrl(int length)
+    {
+        const string Prefix = "https://example.com/callback?state=";
+        return Prefix + new string('a', length - Prefix.Length);
+    }
+
+    private async Task<string> GetColumnDataTypeAsync(string tableName, string columnName)
+    {
+        const string Query = /*strpsql*/@"
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_schema = 'business_application'
+              AND table_name = @table_name
+              AND column_name = @column_name;";
+
+        await using NpgsqlCommand command = DataSource.CreateCommand(Query);
+        command.Parameters.AddWithValue("table_name", tableName);
+        command.Parameters.AddWithValue("column_name", columnName);
+
+        var result = await command.ExecuteScalarAsync();
+        Assert.NotNull(result);
+        return (string)result!;
+    }
+}

--- a/test/Altinn.Platform.Authentication.Tests/RepositoryDataAccess/RequestRepositoryTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/RepositoryDataAccess/RequestRepositoryTest.cs
@@ -74,4 +74,99 @@ public class RequestRepositoryTest(DbFixture dbFixture)
         Assert.NotNull(archived);
         Assert.Equal(req.Id, archived.Id);
     }
+
+    [Theory]
+    [InlineData(256)]
+    [InlineData(2048)]
+    [InlineData(8192)]
+    public async Task CreateRequest_WithRedirectUrlLongerThan255Characters_IsPersisted(int urlLength)
+    {
+        // Verifies migration v0.27/01-alter-redirect-urls-length.sql which widens
+        // business_application.request.redirect_urls from varchar(255) to text.
+        // Multiple lengths exercise that the column is effectively unbounded.
+        string longRedirectUrl = BuildLongRedirectUrl(urlLength);
+
+        RequestSystemResponse req = new()
+        {
+            Id = Guid.NewGuid(),
+            ExternalRef = "test-long-url",
+            SystemId = "test",
+            PartyOrgNo = "123456789",
+            Rights = [],
+            Status = "new",
+            RedirectUrl = longRedirectUrl
+        };
+
+        var create = await Repository.CreateRequest(req);
+        Assert.True(create.IsSuccess);
+
+        var stored = await Repository.GetRequestByInternalId(req.Id);
+        Assert.NotNull(stored);
+        Assert.Equal(longRedirectUrl, stored!.RedirectUrl);
+        Assert.True(stored.RedirectUrl!.Length > 255);
+
+        Assert.Equal("text", await GetColumnDataTypeAsync("request", "redirect_urls"));
+    }
+
+    [Theory]
+    [InlineData(256)]
+    [InlineData(2048)]
+    [InlineData(8192)]
+    public async Task CopyOldRequestsToArchive_PreservesRedirectUrlLongerThan255Characters(int urlLength)
+    {
+        // Verifies migration v0.27/01-alter-redirect-urls-length.sql for the
+        // business_application.request_archive.redirect_urls column.
+        string longRedirectUrl = BuildLongRedirectUrl(urlLength);
+
+        RequestSystemResponse req = new()
+        {
+            Id = Guid.NewGuid(),
+            ExternalRef = "test-archive-long-url",
+            SystemId = "test",
+            PartyOrgNo = "123456789",
+            Rights = [],
+            Status = "new",
+            RedirectUrl = longRedirectUrl
+        };
+
+        var create = await Repository.CreateRequest(req);
+        Assert.True(create.IsSuccess);
+
+        var del = await Repository.SetDeleteTimedoutRequests(0);
+        Assert.Equal(1, del);
+
+        var copied = await Repository.CopyOldRequestsToArchive(0);
+        Assert.Equal(1, copied);
+
+        var archived = await Repository.GetArchivedRequestByInternalId(req.Id);
+        Assert.NotNull(archived);
+        Assert.Equal(longRedirectUrl, archived!.RedirectUrl);
+        Assert.True(archived.RedirectUrl!.Length > 255);
+
+        Assert.Equal("text", await GetColumnDataTypeAsync("request_archive", "redirect_urls"));
+    }
+
+    private static string BuildLongRedirectUrl(int length)
+    {
+        const string Prefix = "https://example.com/callback?state=";
+        return Prefix + new string('a', length - Prefix.Length);
+    }
+
+    private async Task<string> GetColumnDataTypeAsync(string tableName, string columnName)
+    {
+        const string Query = /*strpsql*/@"
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_schema = 'business_application'
+              AND table_name = @table_name
+              AND column_name = @column_name;";
+
+        await using NpgsqlCommand command = DataSource.CreateCommand(Query);
+        command.Parameters.AddWithValue("table_name", tableName);
+        command.Parameters.AddWithValue("column_name", columnName);
+
+        var result = await command.ExecuteScalarAsync();
+        Assert.NotNull(result);
+        return (string)result!;
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Redirect URLs now support lengths beyond the previous 255-character limit across stored requests.
* **Tests**
  * Added integration tests validating persistence and retrieval of long redirect URLs and verifying the storage type accepts extended lengths.
* **Chores**
  * Updated project dependencies to newer package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->