### PR TITLE
fix: do not use old resource format for app resource when deleting standard system user

### DIFF
--- a/src/Authentication/Services/SystemUserService.cs
+++ b/src/Authentication/Services/SystemUserService.cs
@@ -201,13 +201,6 @@ namespace Altinn.Platform.Authentication.Services
             bool isAccessPackagesDeleted = false;
             if (rights.Count > 0)
             {
-                foreach (Right right in rights)
-                {
-                    List<AttributePair> resource = DelegationHelper.ConvertAppResourceToOldResourceFormat(right.Resource);
-
-                    right.Resource = resource;
-                }
-
                 var revokeRightResult = await _accessManagementClient.RevokeDelegatedRightToSystemUser(partyUuid, systemUser, rights);
                 if (revokeRightResult.IsProblem)
                 {

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserControllerTest.cs
@@ -679,7 +679,42 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpRequestMessage request2 = new(HttpMethod.Delete, $"/authentication/api/v1/systemuser/{partyId}/{Guid.NewGuid()}");
             HttpResponseMessage response2 = await client.SendAsync(request2, HttpCompletionOption.ResponseContentRead);
             Assert.Equal(HttpStatusCode.NotFound, response2.StatusCode);
-        } 
+        }
+
+        [Fact]
+        public async Task SystemUser_Delete_WithSingleAppResource_ReturnsAccepted()
+        {
+            string dataFileName = "Data/SystemRegister/Json/SystemRegisterWithApp.json";
+            _ = await CreateSystemRegister(dataFileName);
+
+            HttpClient client = CreateClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1337, null, 3, now: TestTime));
+
+            int partyId = 500000;
+
+            SystemUserRequestDto newSystemUser = new()
+            {
+                IntegrationTitle = "IntegrationTitleValue",
+                SystemId = "991825827_system_with_app",
+            };
+
+            HttpRequestMessage createRequest = new(HttpMethod.Post, $"/authentication/api/v1/systemuser/{partyId}/create")
+            {
+                Content = JsonContent.Create<SystemUserRequestDto>(newSystemUser, new MediaTypeHeaderValue("application/json"))
+            };
+            HttpResponseMessage createResponse = await client.SendAsync(createRequest, HttpCompletionOption.ResponseContentRead);
+            Assert.Equal(HttpStatusCode.OK, createResponse.StatusCode);
+            SystemUserInternalDTO? created = await createResponse.Content.ReadFromJsonAsync<SystemUserInternalDTO>();
+            Assert.NotNull(created);
+
+            HttpRequestMessage deleteRequest = new(HttpMethod.Delete, $"/authentication/api/v1/systemuser/{partyId}/{created.Id}");
+            HttpResponseMessage deleteResponse = await client.SendAsync(deleteRequest, HttpCompletionOption.ResponseContentRead);
+            Assert.Equal(HttpStatusCode.Accepted, deleteResponse.StatusCode);
+
+            HttpRequestMessage getAfterDeleteRequest = new(HttpMethod.Get, $"/authentication/api/v1/systemuser/{partyId}/{created.Id}");
+            HttpResponseMessage getAfterDeleteResponse = await client.SendAsync(getAfterDeleteRequest, HttpCompletionOption.ResponseContentRead);
+            Assert.Equal(HttpStatusCode.NotFound, getAfterDeleteResponse.StatusCode);
+        }
 
         [Fact]
         public async Task SystemUser_CreateAndDelegate_Returns_DelegationErrorDetail()


### PR DESCRIPTION
## Description
- Send rights to be deleted as `{"resource":[{"id":"urn:altinn:resource","value":"app_brg_aarsregnskap-ideelle-202402"}]}` instead of `{"resource":[{"id":"urn:altinn:org","value":"brg"},{"id":"urn:altinn:app","value":"aarsregnskap-ideelle-202402"}]}` to AM when deleting standard system user

## Related Issue(s)
- https://github.com/Altinn/altinn-authentication/issues/1964

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined system user deletion process by removing unnecessary preprocessing of delegated rights during revocation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->