### PR TITLE
remove AddSystemUserAsAgent and AddSystemUserAsRightHolder for system users

### DIFF
--- a/src/Authentication/Services/ChangeRequestSystemUserService.cs
+++ b/src/Authentication/Services/ChangeRequestSystemUserService.cs
@@ -395,13 +395,6 @@ public class ChangeRequestSystemUserService(
             }
         }
 
-        // Add the system user as right holder ( is idempotent, and there could be edge cases where the systemuser did not already have this )
-        Result<bool> result = await accessManagementClient.AddSystemUserAsRightHolder(partyUuid, Guid.Parse(toBeChanged.Id), cancellationToken);
-        if (result.IsProblem)
-        {
-            return result.Problem;
-        }
-
         // Delegate new Single Rights to the SystemUser
         if (delegationCheckFinalResult.CanDelegate && delegationCheckFinalResult.RightResponses?.Count > 0)
         {

--- a/src/Authentication/Services/SystemUserService.cs
+++ b/src/Authentication/Services/SystemUserService.cs
@@ -557,26 +557,6 @@ namespace Altinn.Platform.Authentication.Services
                 return partyCreated.Problem;
             }
 
-            // Add the new system user as a right holder in Access Management, both Standard and Agent type system users are added as right holders
-            // This is needed for the delegation of rights and access packages to work when reporting for _own_ business.
-            Result<bool> holderresult = await _accessManagementClient.AddSystemUserAsRightHolder(partyUuid, Guid.Parse(inserted.Id), cancellationToken);
-            if (holderresult.IsProblem)
-            {
-                return holderresult.Problem;
-            }
-
-            // Only Agent systemusers are added as Agents in Access Management, needed for _via_ reporting.
-            if (newSystemUser.UserType == SystemUserType.Agent)
-            {
-                {
-                    Result<bool> agentresult = await _accessManagementClient.AddSystemUserAsAgent(partyUuid, Guid.Parse(inserted.Id), cancellationToken);
-                    if (agentresult.IsProblem)
-                    {
-                        return agentresult.Problem;
-                    }
-                }
-            }
-
             if (IsStandardSystemUserDelegatgeSingleRights(newSystemUser, regSystem, delegationCheckFinalResult))
             {
                 Result<bool> delegationSucceeded = await _accessManagementClient.DelegateRightToSystemUser(partyUuid, inserted, delegationCheckFinalResult!.RightResponses!);

--- a/src/Integration/AccessManagement/AccessManagementClient.cs
+++ b/src/Integration/AccessManagement/AccessManagementClient.cs
@@ -243,7 +243,7 @@ public class AccessManagementClient : IAccessManagementClient
 
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext!, _platformSettings.JwtCookieName!)!;
             HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl, null);
-            return await HandleResponse(response, "RevokeSystemUserAsAgent");
+            return await HandleResponse(response, "AddSystemUserAsAgent");
 
         }
         catch (Exception ex)

--- a/src/Integration/AccessManagement/AccessManagementClient.cs
+++ b/src/Integration/AccessManagement/AccessManagementClient.cs
@@ -235,25 +235,6 @@ public class AccessManagementClient : IAccessManagementClient
     }
 
     /// <inheritdoc />
-    public async Task<Result<bool>> AddSystemUserAsAgent(Guid partyUuId, Guid systemUserId, CancellationToken cancellationToken)
-    {
-        try
-        {
-            string endpointUrl = $"enduser/clientdelegations/agents?party={partyUuId}&to={systemUserId}";
-
-            string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext!, _platformSettings.JwtCookieName!)!;
-            HttpResponseMessage response = await _client.PostAsync(token, endpointUrl, null);
-            return await HandleResponse(response, "AddSystemUserAsAgent");
-
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Authentication // AccessManagementClient // AddSystemUserAsRightHolder // Exception");
-            throw;
-        }
-    }
-
-    /// <inheritdoc />
     public async Task<Result<bool>> RevokeSystemUserAsAgent(Guid partyUuId, Guid systemUserId, bool cascade = false, CancellationToken cancellationToken = default)
     {
         try
@@ -262,34 +243,15 @@ public class AccessManagementClient : IAccessManagementClient
 
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext!, _platformSettings.JwtCookieName!)!;
             HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl, null);
-            return await HandleResponse(response, "AddSystemUserAsAgent");
+            return await HandleResponse(response, "RevokeSystemUserAsAgent");
 
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Authentication // AccessManagementClient // AddSystemUserAsRightHolder // Exception");
+            _logger.LogError(ex, "Authentication // AccessManagementClient // RevokeSystemUserAsAgent // Exception");
             throw;
         }
         ;
-    }
-
-    /// <inheritdoc />
-    public async Task<Result<bool>> AddSystemUserAsRightHolder(Guid partyUuId, Guid systemUserId, CancellationToken cancellationToken)
-    {
-        try
-        {
-            string endpointUrl = $"enduser/connections?party={partyUuId}&to={systemUserId}";
-
-            string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext!, _platformSettings.JwtCookieName!)!;
-            HttpResponseMessage response = await _client.PostAsync(token, endpointUrl, null);
-            return await HandleResponse(response, "AddSystemUserAsRightHolder");
-
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Authentication // AccessManagementClient // AddSystemUserAsRightHolder // Exception");
-            throw;
-        }
     }
 
     /// <inheritdoc />

--- a/src/Integration/AccessManagement/IAccessManagementClient.cs
+++ b/src/Integration/AccessManagement/IAccessManagementClient.cs
@@ -146,15 +146,6 @@ public interface IAccessManagementClient
     Task<Result<bool>> PushSystemUserToAM(Guid partyUuId, SystemUserInternalDTO systemUser, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Adds a System User as a Right Holder for the Party
-    /// </summary>
-    /// <param name="partyUuId">the identifier of the party</param>
-    /// <param name="systemUserId">the system user id</param>
-    /// <param name="cancellationToken">the cancellation token</param>
-    /// <returns></returns>
-    Task<Result<bool>> AddSystemUserAsRightHolder(Guid partyUuId, Guid systemUserId, CancellationToken cancellationToken);
-
-    /// <summary>
     /// Removes a System User as a Right Holder for the Party
     /// </summary>
     /// <param name="partyUuId">the identifier of the party</param>
@@ -209,15 +200,6 @@ public interface IAccessManagementClient
     /// <param name="partyUuid">The party id</param>
     /// <param name="resource">The resource id</param>
     Task<ResourceCheckDto?> CheckDelegationAccess(Guid partyUuid, string resource, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Adds a System User as an Agent for the Party
-    /// </summary>
-    /// <param name="partyUuid">the identifier of the via party ( the faciliator/provider )</param>
-    /// <param name="systemuser">the system user id acting as the agent</param>
-    /// <param name="cancellationToken">the cancellation token</param>
-    /// <returns></returns>
-    Task<Result<bool>> AddSystemUserAsAgent(Guid partyUuid, Guid systemuser, CancellationToken cancellationToken);
 
     /// <summary>
     /// Revokes a System User as an Agent for the Party

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/AccessManagementClientMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/AccessManagementClientMock.cs
@@ -352,11 +352,6 @@ public class AccessManagementClientMock: IAccessManagementClient
         return true;
     }
 
-    public async Task<Result<bool>> AddSystemUserAsRightHolder(Guid partyUuId, Guid systemUserId, CancellationToken cancellationToken)
-    {
-        return true;
-    }
-
     public async Task<Result<bool>> DelegateSingleAccessPackageToSystemUser(Guid partyUuId, Guid systemUserId, string urn, CancellationToken cancellationToken)
     {
         return true;
@@ -466,11 +461,6 @@ public class AccessManagementClientMock: IAccessManagementClient
                 }
             ]        
         };
-    }
-
-    public async Task<Result<bool>> AddSystemUserAsAgent(Guid partyUuid, Guid guid, CancellationToken cancellationToken)
-    {
-        return true;
     }
 
     public Task<Result<List<DelegationDto>>> DelegateCustomerToAgentSystemUser(Guid systemUserId, DelegationBatchInputDto batch, Guid provider, Guid client, CancellationToken cancellationToken)


### PR DESCRIPTION
## Description
- remove AddSystemUserAsAgent and AddSystemUserAsRightHolder for system users; this is now handled in AM on first delegation/add client instead

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3006

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the system user initialization process in access management. Consolidated multiple setup operations into a single operation to improve efficiency of system user provisioning during creation and approval workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->