### PR TITLE
fix: do not prepend selfregistered-email to upstream acr_values on ACR upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:7d98d5883675c6bca25b1db91f393b24b85125b5b00b405e55404fd6b8d2aead AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:5c559aa5d99337e400d39ab4fa1f6979d126c29b20939d53658ed38300571e74 AS build
 WORKDIR /app
 
 # Copy everything and build
@@ -6,7 +6,7 @@ COPY . .
 RUN dotnet build ./src/Authentication/Altinn.Platform.Authentication.csproj -c Release -o app_output \
     && dotnet publish ./src/Authentication/Altinn.Platform.Authentication.csproj -c Release -r linux-x64 -o app_output --no-self-contained
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine@sha256:049f2d7d7acfcbf09e1d15eb4faccec6453b0a98f0cb54d53bcbdc3ed91e96c8 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine@sha256:1e37a8236c558ae31bd6bc8144e38e6036b73cf1b0616fe56d79e60babb9d93b AS final
 EXPOSE 5040 
 WORKDIR /app
 COPY --from=build /app/app_output .

--- a/src/Authentication/Altinn.Platform.Authentication.csproj
+++ b/src/Authentication/Altinn.Platform.Authentication.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Altinn.Common.AccessToken" Version="5.1.0" />
     <PackageReference Include="Altinn.Common.PEP" Version="4.2.2" />
     <PackageReference Include="Altinn.Register.Contracts" Version="1.4.1" />
-    <PackageReference Include="AutoMapper" Version="15.1.0" />
+    <PackageReference Include="AutoMapper" Version="15.1.1" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.FeatureManagement" Version="4.4.0" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.4.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.15.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.0" />
     <PackageReference Include="Npgsql" Version="10.0.1" />

--- a/src/Authentication/Services/OidcServerService.cs
+++ b/src/Authentication/Services/OidcServerService.cs
@@ -211,16 +211,22 @@ namespace Altinn.Platform.Authentication.Services
             (OidcProvider provider, string upstreamState, string upstreamNonce, string upstreamPkceChallenge) = await CreateUpstreamLoginTransaction(request, tx, cancellationToken);
 
             // ========= 8) Build upstream authorize URL =========
-            // existingSession is null here only when the user is not logged in (anonymous flow).
-            // When we have a session (even one that needs an ACR upgrade) we know the user, so
-            // we must not silently widen the requested acr_values with selfregistered-email.
+            // A live (non-expired) session means the user is logged in and the request is an ACR
+            // upgrade — in that case we know the user and must not silently widen the requested
+            // acr_values with selfregistered-email. An expired session row counts as anonymous:
+            // session-handle / Altinn-2-ticket lookups above do not check expiry, so we mirror the
+            // validity check from the session-reuse branch.
+            bool hasLiveSession = existingSession is not null
+                && existingSession.ExpiresAt.HasValue
+                && _timeProvider.GetUtcNow() < existingSession.ExpiresAt.Value;
+
             Uri authorizeUrl = BuildUpstreamAuthorizeUrl(
                 provider,
                 upstreamState,
                 upstreamNonce,
                 upstreamPkceChallenge,
                 request,
-                hasExistingSession: existingSession is not null);
+                hasExistingSession: hasLiveSession);
 
             // ========= 9) Return redirect upstream =========
             return AuthorizeResult.RedirectUpstream(authorizeUrl, upstreamState, tx.RequestId);

--- a/src/Authentication/Services/OidcServerService.cs
+++ b/src/Authentication/Services/OidcServerService.cs
@@ -211,12 +211,16 @@ namespace Altinn.Platform.Authentication.Services
             (OidcProvider provider, string upstreamState, string upstreamNonce, string upstreamPkceChallenge) = await CreateUpstreamLoginTransaction(request, tx, cancellationToken);
 
             // ========= 8) Build upstream authorize URL =========
+            // existingSession is null here only when the user is not logged in (anonymous flow).
+            // When we have a session (even one that needs an ACR upgrade) we know the user, so
+            // we must not silently widen the requested acr_values with selfregistered-email.
             Uri authorizeUrl = BuildUpstreamAuthorizeUrl(
                 provider,
                 upstreamState,
                 upstreamNonce,
                 upstreamPkceChallenge,
-                request);
+                request,
+                hasExistingSession: existingSession is not null);
 
             // ========= 9) Return redirect upstream =========
             return AuthorizeResult.RedirectUpstream(authorizeUrl, upstreamState, tx.RequestId);
@@ -1372,7 +1376,8 @@ namespace Altinn.Platform.Authentication.Services
                 string upstreamState,
                 string upstreamNonce,
                 string upstreamCodeChallenge,
-                AuthorizeRequest incoming)
+                AuthorizeRequest incoming,
+                bool hasExistingSession)
         {
             var q = System.Web.HttpUtility.ParseQueryString(string.Empty);
             q["response_type"] = string.IsNullOrWhiteSpace(p.ResponseType) ? "code" : p.ResponseType;
@@ -1390,7 +1395,11 @@ namespace Altinn.Platform.Authentication.Services
                 q["acr_values"] = string.Join(' ', incoming.AcrValues);
             }
 
-            if (q["acr_values"] != null && !q["acr_values"]!.Contains(AuthzConstants.CLAIM_ACR_IDPORTEN_EMAIL))
+            // Only widen acr_values with selfregistered-email when the user is anonymous.
+            // On an ACR upgrade for an already-logged-in user the requested LoA must be sent as-is.
+            if (!hasExistingSession
+                && q["acr_values"] != null
+                && !q["acr_values"]!.Contains(AuthzConstants.CLAIM_ACR_IDPORTEN_EMAIL))
             {
                 q["acr_values"] = AuthzConstants.CLAIM_ACR_IDPORTEN_EMAIL + " " + q["acr_values"];
             }

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
@@ -1537,8 +1537,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             // First /authorize is anonymous (no existing session): upstream acr_values must be widened with
             // selfregistered-email so the user can still pick e-mail login at ID-porten.
             string initialUpstreamAcr = HttpUtility.ParseQueryString(authorizationRequestResponse.Headers.Location!.Query)["acr_values"] ?? string.Empty;
-            Assert.Contains("selfregistered-email", initialUpstreamAcr);
-            Assert.Contains("idporten-loa-substantial", initialUpstreamAcr);
+            Assert.Equal("selfregistered-email idporten-loa-substantial", initialUpstreamAcr);
 
             // Assume it takes 1 minute for the user to authenticate at the upstream provider
             _fakeTime.Advance(TimeSpan.FromMinutes(1)); // 08:01
@@ -1619,8 +1618,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             // must be exactly what the downstream client asked for — selfregistered-email must NOT be
             // appended on top of the higher LoA. See issue #1988.
             string upgradeUpstreamAcr = HttpUtility.ParseQueryString(authorizationUpgradeRequestResponse.Headers.Location!.Query)["acr_values"] ?? string.Empty;
-            Assert.DoesNotContain("selfregistered-email", upgradeUpstreamAcr);
-            Assert.Contains("idporten-loa-high", upgradeUpstreamAcr);
+            Assert.Equal("idporten-loa-high", upgradeUpstreamAcr);
 
             // Assume it takes 1 minute for the user to authenticate at the upstream provider. Now with BankID level 4
             _fakeTime.Advance(TimeSpan.FromMinutes(1)); // 08:01

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
@@ -1534,6 +1534,12 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             (string upstreamState, UpstreamLoginTransaction createdUpstreamLogingTransaction) = await AssertAutorizeRequestResult(testScenario, authorizationRequestResponse, _fakeTime.GetUtcNow());
             Debug.Assert(createdUpstreamLogingTransaction != null);
 
+            // First /authorize is anonymous (no existing session): upstream acr_values must be widened with
+            // selfregistered-email so the user can still pick e-mail login at ID-porten.
+            string initialUpstreamAcr = HttpUtility.ParseQueryString(authorizationRequestResponse.Headers.Location!.Query)["acr_values"] ?? string.Empty;
+            Assert.Contains("selfregistered-email", initialUpstreamAcr);
+            Assert.Contains("idporten-loa-substantial", initialUpstreamAcr);
+
             // Assume it takes 1 minute for the user to authenticate at the upstream provider
             _fakeTime.Advance(TimeSpan.FromMinutes(1)); // 08:01
 
@@ -1608,6 +1614,13 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             // Assert: Result of /authorize. Should be a redirect to upstream provider with code_challenge, state, etc. LoginTransaction should be persisted. UpstreamLoginTransaction should be persisted.
             (string? upstreamUpgradeState, UpstreamLoginTransaction? createdUpstreamUpgradeLogingTransaction) = await AssertAutorizeRequestResult(testScenario, authorizationUpgradeRequestResponse, _fakeTime.GetUtcNow());
             Debug.Assert(createdUpstreamUpgradeLogingTransaction != null);
+
+            // Upgrade /authorize runs with an existing session, so the user is known: upstream acr_values
+            // must be exactly what the downstream client asked for — selfregistered-email must NOT be
+            // appended on top of the higher LoA. See issue #1988.
+            string upgradeUpstreamAcr = HttpUtility.ParseQueryString(authorizationUpgradeRequestResponse.Headers.Location!.Query)["acr_values"] ?? string.Empty;
+            Assert.DoesNotContain("selfregistered-email", upgradeUpstreamAcr);
+            Assert.Contains("idporten-loa-high", upgradeUpstreamAcr);
 
             // Assume it takes 1 minute for the user to authenticate at the upstream provider. Now with BankID level 4
             _fakeTime.Advance(TimeSpan.FromMinutes(1)); // 08:01


### PR DESCRIPTION
## Summary

Fixes #1988.

When a user with an existing OIDC session triggered an authentication upgrade (e.g. downstream client asks for `idporten-loa-high`), the upstream `/authorize` URL was widened with `selfregistered-email` on top of the requested LoA. The widening should only happen for anonymous users — there we cannot yet pick an upstream login method and want ID-porten to keep e-mail as an option (Altinn Inbox sends `idporten-loa-substantial` by default even when the user might want to log in with e-mail). For a logged-in user we already know who they are, so the requested LoA must be passed through unchanged.

The detection signal is already available at the call site in `OidcServerService.Authorize`: `existingSession` is populated from the principal, session-handle cookie, or Altinn 2 ticket before the upstream-redirect path is taken. By the time we call `BuildUpstreamAuthorizeUrl`, `existingSession is not null` is exactly the upgrade case (the session-reuse short-circuit just above already returned for sessions that meet the requested ACR).

### Change

- `BuildUpstreamAuthorizeUrl(... AuthorizeRequest incoming)` gains a `bool hasExistingSession` parameter.
- The `selfregistered-email` prepend is now gated on `!hasExistingSession`.
- Call site passes `hasExistingSession: existingSession is not null`.
- The `AuthorizeUnregisteredClientRequest` overload is untouched (cookie-only JWT login, no `client_id`, separate code path).

### Behaviour

| State | `existingSession` | upstream `acr_values` |
| --- | --- | --- |
| Anonymous user, first `/authorize` | `null` | `selfregistered-email` prepended to requested LoA (unchanged) |
| Logged-in user, upgrading LoA | not `null` | requested LoA sent as-is, no widening |

## Test plan

- [x] `TC8_Auth_Level3_Aa_Level_4_Af_Logout_End_To_End_OK` extended: asserts upstream `acr_values` contains `selfregistered-email` on the initial anonymous `/authorize` and does **not** contain it on the upgrade `/authorize` (it contains only `idporten-loa-high`).
- [x] All 31 tests under `Controllers.Oidc` pass locally.
- [ ] Verify in AT22 (or equivalent) that a session ACR upgrade from a downstream client now sends a clean `acr_values` upstream to ID-porten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication now correctly differentiates new vs. existing sessions: anonymous flows include self-registered email option, while live sessions (including upgrade flows) do not add it.
* **Tests**
  * Added end-to-end assertions to verify the correct authentication request parameters for both anonymous and existing-session scenarios.
* **Chores**
  * Updated base images used for container builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-authentication/pull/1989?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->