### PR TITLE
fix(oidc): fail sign-in when register self-identified provisioning fails

### DIFF
--- a/src/Authentication/Exceptions/RegisterUserProvisioningException.cs
+++ b/src/Authentication/Exceptions/RegisterUserProvisioningException.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Altinn.Platform.Authentication.Exceptions
+{
+    /// <summary>
+    /// Thrown when self-identified user provisioning against register fails, so that the
+    /// OIDC sign-in flow aborts with a clear error instead of continuing with an unpopulated user.
+    /// </summary>
+    public class RegisterUserProvisioningException : Exception
+    {
+        /// <summary>
+        /// Empty constructor.
+        /// </summary>
+        public RegisterUserProvisioningException() : base()
+        {
+        }
+
+        /// <summary>
+        /// With message.
+        /// </summary>
+        public RegisterUserProvisioningException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// With message and inner exception.
+        /// </summary>
+        public RegisterUserProvisioningException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Authentication/Services/OidcServerService.cs
+++ b/src/Authentication/Services/OidcServerService.cs
@@ -22,6 +22,7 @@ using Altinn.Platform.Authentication.Core.Models.Profile.Enums;
 using Altinn.Platform.Authentication.Core.RepositoryInterfaces;
 using Altinn.Platform.Authentication.Core.Services.Interfaces;
 using Altinn.Platform.Authentication.Enum;
+using Altinn.Platform.Authentication.Exceptions;
 using Altinn.Platform.Authentication.Helpers;
 using Altinn.Platform.Authentication.Model;
 using Altinn.Platform.Authentication.Services.Interfaces;
@@ -312,7 +313,22 @@ namespace Altinn.Platform.Authentication.Services
             // ===== 2) Exchange upstream code for upstream tokens =====
             OidcProvider provider = ChooseProviderByKey(upstreamTx.Provider);
             UserAuthenticationModel userIdenity = await ExtractUserIdentityFromUpstream(input, upstreamTx, provider, cancellationToken);
-            userIdenity = await IdentifyOrCreateAltinnUser(userIdenity, provider);
+
+            try
+            {
+                userIdenity = await IdentifyOrCreateAltinnUser(userIdenity, provider);
+            }
+            catch (RegisterUserProvisioningException ex)
+            {
+                _logger.LogError(ex, "Self-identified user provisioning via register failed; aborting sign-in.");
+                return new UpstreamCallbackResult
+                {
+                    Kind = UpstreamCallbackResultKind.LocalError,
+                    StatusCode = StatusCodes.Status502BadGateway,
+                    LocalErrorMessage = "User provisioning failed. Please try again later."
+                };
+            }
+
             AddLocalScopes(userIdenity);
 
             // 3. Create or refresh Altinn session session
@@ -1520,11 +1536,6 @@ namespace Altinn.Platform.Authentication.Services
                         email: null,
                         CancellationToken.None);
 
-                    if (provisioned is null)
-                    {
-                        return userAuthenticationModel;
-                    }
-
                     userAuthenticationModel.UserID = (int)provisioned.User.Value.UserId.Value;
                     userAuthenticationModel.PartyID = (int)provisioned.PartyId.Value;
                     userAuthenticationModel.PartyUuid = provisioned.Uuid;
@@ -1576,11 +1587,6 @@ namespace Altinn.Platform.Authentication.Services
                         userAuthenticationModel.Email,
                         CancellationToken.None);
 
-                    if (provisioned is null)
-                    {
-                        return userAuthenticationModel;
-                    }
-
                     userAuthenticationModel.UserID = (int)provisioned.User.Value.UserId.Value;
                     userAuthenticationModel.PartyID = (int)provisioned.PartyId.Value;
                     userAuthenticationModel.PartyUuid = provisioned.Uuid;
@@ -1628,7 +1634,7 @@ namespace Altinn.Platform.Authentication.Services
             return userAuthenticationModel;
         }
 
-        private async Task<SelfIdentifiedUser?> GetOrCreateSelfIdentifiedUserViaRegister(
+        private async Task<SelfIdentifiedUser> GetOrCreateSelfIdentifiedUserViaRegister(
             SelfIdentifiedUserType selfIdentifiedUserType,
             string externalIdentity,
             string userName,
@@ -1647,9 +1653,8 @@ namespace Altinn.Platform.Authentication.Services
 
             if (response is null)
             {
-                _logger.LogError(
-                    "Register self-identified provisioning returned no result for externalIdentity {ExternalIdentity}; sign-in cannot complete.",
-                    externalIdentity);
+                throw new RegisterUserProvisioningException(
+                    $"Register self-identified provisioning returned no result for externalIdentity '{externalIdentity}'; sign-in cannot complete.");
             }
 
             return response;


### PR DESCRIPTION
## Summary
- A failed register self-identified provisioning call (non-200, network error, or exception — all swallowed into `null` by `RegisterUserProvisioningClient`) caused `IdentifyOrCreateAltinnUser` to return an **unpopulated** `UserAuthenticationModel` and continue building an Altinn session/cookie for **UserID 0 / PartyID 0**. The real failure was masked by a downstream session-creation error, making the actual cause hard to diagnose (the original CodeRabbit concern on #1982).
- `GetOrCreateSelfIdentifiedUserViaRegister` now returns a non-nullable `SelfIdentifiedUser` and throws a new `RegisterUserProvisioningException` when provisioning fails, instead of returning the empty model.
- `HandleUpstreamCallback` catches that exception and returns a `502 Bad Gateway` `LocalError` (register is a failed downstream dependency), so the cause is logged and surfaced rather than hidden.
- Removed the two dead `if (provisioned is null) return userAuthenticationModel;` blocks now that the helper can't return null.

## Notes
- Only the OIDC upstream-callback path exercises the register-provisioning branches. The two Altinn2-ticket paths also call `IdentifyOrCreateAltinnUser` but require `UserID > 0` and normally route to the existing-user branch; in the rare case a ticket carries an `ExternalIdentity` with the flag on and register is down, the exception propagates as an unhandled 500 — still surfacing the real cause in logs rather than masking it. Can add explicit handling there if desired.

## Test plan
- [ ] Build passes (verified locally: 0 errors)
- [ ] With flag `RegisterSelfIdentifiedUserProvisioning` on and register returning a non-200 / unreachable, OIDC sign-in returns 502 with the register failure logged (no session/cookie issued)
- [ ] With flag on and register healthy, new self-identified user (Educational and idporten-email) signs in successfully
- [ ] With flag off, behavior unchanged (SBL Bridge GetUser + CreateUser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during user registration via OIDC authentication with clearer user-facing error messages.
  * Enhanced reliability of the authentication provisioning process to gracefully handle registration failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-authentication/pull/2004?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->