### PR TITLE
Feature - allow system user request creation when request was previously rejected

### DIFF
--- a/src/Authentication/Controllers/RequestSystemUserController.cs
+++ b/src/Authentication/Controllers/RequestSystemUserController.cs
@@ -119,9 +119,14 @@ public class RequestSystemUserController : ControllerBase
             return ProblemInstance.Create(Altinn.Authentication.Core.Problems.Problem.SystemUser_AlreadyExists).ToActionResult();
         }
 
-        // Check to see if the Request already exists, and is still active ( Status is not Timed Out)
+        // Check to see if the Request already exists, and is still active (a New or Accepted Request).
+        // A Timed Out, Rejected or Denied Request must not be returned; instead we fall through and
+        // generate a brand new Request (the old one is soft-deleted in the service).
         Result<RequestSystemResponse> response = await _requestSystemUser.GetRequestByExternalRef(externalRequestId, vendorOrgNo);
-        if (response.IsSuccess && response.Value.Status != RequestStatus.Timedout.ToString())
+        if (response.IsSuccess
+            && response.Value.Status != RequestStatus.Timedout.ToString()
+            && response.Value.Status != RequestStatus.Rejected.ToString()
+            && response.Value.Status != RequestStatus.Denied.ToString())
         {
             response.Value.ConfirmUrl = CONFIRMURL_PREFIX + _generalSettings.HostName + CONFIRMURL_STANDARD_REQUEST + response.Value.Id + REPORTEESELECTIONPARAMETER;
             return Ok(response.Value);
@@ -172,9 +177,14 @@ public class RequestSystemUserController : ControllerBase
             return ProblemInstance.Create(Altinn.Authentication.Core.Problems.Problem.SystemUser_AlreadyExists).ToActionResult();
         }
 
-        // Check to see if the Request already exists, and is still active ( Status is not Timed Out)
+        // Check to see if the Request already exists, and is still active (a New or Accepted Request).
+        // A Timed Out, Rejected or Denied Request must not be returned; instead we fall through and
+        // generate a brand new Request (the old one is soft-deleted in the service).
         Result<AgentRequestSystemResponse> response = await _requestSystemUser.GetAgentRequestByExternalRef(externalRequestId, vendorOrgNo);
-        if (response.IsSuccess && response.Value.Status != RequestStatus.Timedout.ToString())
+        if (response.IsSuccess
+            && response.Value.Status != RequestStatus.Timedout.ToString()
+            && response.Value.Status != RequestStatus.Rejected.ToString()
+            && response.Value.Status != RequestStatus.Denied.ToString())
         {
             response.Value.ConfirmUrl = CONFIRMURL_PREFIX + _generalSettings.HostName + CONFIRMURL_AGENTREQUEST + response.Value.Id + REPORTEESELECTIONPARAMETER;
             return Ok(response.Value);

--- a/src/Authentication/Controllers/RequestSystemUserController.cs
+++ b/src/Authentication/Controllers/RequestSystemUserController.cs
@@ -120,13 +120,12 @@ public class RequestSystemUserController : ControllerBase
         }
 
         // Check to see if the Request already exists, and is still active (a New or Accepted Request).
-        // A Timed Out, Rejected or Denied Request must not be returned; instead we fall through and
+        // A Timed Out or Rejected Request must not be returned; instead we fall through and
         // generate a brand new Request (the old one is soft-deleted in the service).
         Result<RequestSystemResponse> response = await _requestSystemUser.GetRequestByExternalRef(externalRequestId, vendorOrgNo);
         if (response.IsSuccess
             && response.Value.Status != RequestStatus.Timedout.ToString()
-            && response.Value.Status != RequestStatus.Rejected.ToString()
-            && response.Value.Status != RequestStatus.Denied.ToString())
+            && response.Value.Status != RequestStatus.Rejected.ToString())
         {
             response.Value.ConfirmUrl = CONFIRMURL_PREFIX + _generalSettings.HostName + CONFIRMURL_STANDARD_REQUEST + response.Value.Id + REPORTEESELECTIONPARAMETER;
             return Ok(response.Value);
@@ -178,13 +177,12 @@ public class RequestSystemUserController : ControllerBase
         }
 
         // Check to see if the Request already exists, and is still active (a New or Accepted Request).
-        // A Timed Out, Rejected or Denied Request must not be returned; instead we fall through and
+        // A Timed Out or Rejected Request must not be returned; instead we fall through and
         // generate a brand new Request (the old one is soft-deleted in the service).
         Result<AgentRequestSystemResponse> response = await _requestSystemUser.GetAgentRequestByExternalRef(externalRequestId, vendorOrgNo);
         if (response.IsSuccess
             && response.Value.Status != RequestStatus.Timedout.ToString()
-            && response.Value.Status != RequestStatus.Rejected.ToString()
-            && response.Value.Status != RequestStatus.Denied.ToString())
+            && response.Value.Status != RequestStatus.Rejected.ToString())
         {
             response.Value.ConfirmUrl = CONFIRMURL_PREFIX + _generalSettings.HostName + CONFIRMURL_AGENTREQUEST + response.Value.Id + REPORTEESELECTIONPARAMETER;
             return Ok(response.Value);

--- a/src/Authentication/Services/RequestSystemUserService.cs
+++ b/src/Authentication/Services/RequestSystemUserService.cs
@@ -252,7 +252,7 @@ public class RequestSystemUserService(
     /// Validate that the combination of SystemId, PartyOrg and External ref does not currently exist in the active Request table (not soft-deleted).
     /// If a pending Request exists with the same ExternalRequestId, we return the pending Request.
     /// If an active SystemUser exists with the same ExternalRequestId, we return a Problem.
-    /// If the id's refer to a Rejected or Denied Request, we return a BadRequest, and ask to delete and renew the Request.
+    /// If the id's refer to a Rejected or Denied Request, we soft-delete the old Request so a new one can be generated.
     /// </summary>
     /// <param name="externalRequestId">Combination of SystemId, PartyOrg and External Ref</param>
     /// <returns>Result or Problem</returns>
@@ -270,14 +270,12 @@ public class RequestSystemUserService(
             return Problem.ExternalRequestIdPending;
         }
 
-        if (res is not null && res.Status == RequestStatus.Denied.ToString())
+        // A previously Rejected or Denied Request must not block the creation of a new Request for the
+        // same ExternalRequestId. Soft-delete the old Request so a fresh one can be generated, even when
+        // no ExternalRef is supplied (in which case it defaults to the PartyOrgNo).
+        if (res is not null && (res.Status == RequestStatus.Denied.ToString() || res.Status == RequestStatus.Rejected.ToString()))
         {
-            return Problem.ExternalRequestIdDenied;
-        }
-
-        if (res is not null && res.Status == RequestStatus.Rejected.ToString())
-        {
-            return Problem.ExternalRequestIdRejected;
+            await requestRepository.DeleteRequestByRequestId(res.Id);
         }
 
         return true;

--- a/src/Authentication/Services/RequestSystemUserService.cs
+++ b/src/Authentication/Services/RequestSystemUserService.cs
@@ -252,7 +252,7 @@ public class RequestSystemUserService(
     /// Validate that the combination of SystemId, PartyOrg and External ref does not currently exist in the active Request table (not soft-deleted).
     /// If a pending Request exists with the same ExternalRequestId, we return the pending Request.
     /// If an active SystemUser exists with the same ExternalRequestId, we return a Problem.
-    /// If the id's refer to a Rejected or Denied Request, we soft-delete the old Request so a new one can be generated.
+    /// If the id's refer to a Rejected Request, we soft-delete the old Request so a new one can be generated.
     /// </summary>
     /// <param name="externalRequestId">Combination of SystemId, PartyOrg and External Ref</param>
     /// <returns>Result or Problem</returns>
@@ -270,10 +270,10 @@ public class RequestSystemUserService(
             return Problem.ExternalRequestIdPending;
         }
 
-        // A previously Rejected or Denied Request must not block the creation of a new Request for the
+        // A previously Rejected Request must not block the creation of a new Request for the
         // same ExternalRequestId. Soft-delete the old Request so a fresh one can be generated, even when
         // no ExternalRef is supplied (in which case it defaults to the PartyOrgNo).
-        if (res is not null && (res.Status == RequestStatus.Denied.ToString() || res.Status == RequestStatus.Rejected.ToString()))
+        if (res is not null && res.Status == RequestStatus.Rejected.ToString())
         {
             await requestRepository.DeleteRequestByRequestId(res.Id);
         }

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/RequestControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/RequestControllerTests.cs
@@ -2903,6 +2903,73 @@ public class RequestControllerTests(
     }
 
     [Fact]
+    public async Task Request_Create_AfterReject_WithoutExternalRef_GeneratesNewRequest()
+    {
+        // Create System used for test
+        string dataFileName = "Data/SystemRegister/Json/SystemRegister.json";
+        await CreateSystemRegister(dataFileName);
+
+        HttpClient client = CreateClient();
+        AddSystemUserRequestWriteTestTokenToClient(client);
+        const string endpoint = "/authentication/api/v1/systemuser/request/vendor";
+
+        Right right = new()
+        {
+            Resource =
+            [
+                new AttributePair
+                {
+                    Id = "urn:altinn:resource",
+                    Value = "ske-krav-og-betalinger"
+                }
+            ]
+        };
+
+        // Arrange: a request WITHOUT an ExternalRef (it defaults to the PartyOrgNo)
+        CreateRequestSystemUser req = new()
+        {
+            SystemId = "991825827_the_matrix",
+            PartyOrgNo = "910493353",
+            Rights = [right]
+        };
+
+        // Act: vendor creates the first request
+        HttpRequestMessage request = new(HttpMethod.Post, endpoint)
+        {
+            Content = JsonContent.Create(req)
+        };
+        HttpResponseMessage message = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+        Assert.Equal(HttpStatusCode.Created, message.StatusCode);
+
+        RequestSystemResponse? firstRequest = await message.Content.ReadFromJsonAsync<RequestSystemResponse>();
+        Assert.NotNull(firstRequest);
+
+        // The end user rejects the first request
+        HttpClient partyClient = CreateClient();
+        partyClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1337, null, 3, true, now: TestTime));
+        int partyId = 500000;
+
+        string rejectEndpoint = $"/authentication/api/v1/systemuser/request/{partyId}/{firstRequest.Id}/reject";
+        HttpResponseMessage rejectResponseMessage = await partyClient.SendAsync(new HttpRequestMessage(HttpMethod.Post, rejectEndpoint), HttpCompletionOption.ResponseHeadersRead);
+        Assert.Equal(HttpStatusCode.OK, rejectResponseMessage.StatusCode);
+
+        // Act: vendor creates a new request again WITHOUT an ExternalRef, same System and PartyOrgNo
+        HttpRequestMessage secondRequestMessage = new(HttpMethod.Post, endpoint)
+        {
+            Content = JsonContent.Create(req)
+        };
+        HttpResponseMessage secondMessage = await client.SendAsync(secondRequestMessage, HttpCompletionOption.ResponseHeadersRead);
+
+        // Assert: a brand new request is generated, not the old rejected one returned
+        Assert.Equal(HttpStatusCode.Created, secondMessage.StatusCode);
+
+        RequestSystemResponse? secondRequest = await secondMessage.Content.ReadFromJsonAsync<RequestSystemResponse>();
+        Assert.NotNull(secondRequest);
+        Assert.NotEqual(firstRequest.Id, secondRequest.Id);
+        Assert.Equal(RequestStatus.New.ToString(), secondRequest.Status);
+    }
+
+    [Fact]
     public async Task Approve_ClientRequest_By_RequestId_Success()
     {
         // Create System used for test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vendor request resubmission after rejection is now enabled. Previously, rejected requests would prevent users from submitting new requests with the same vendor information. Users can now create fresh requests following rejection, with a new request ID assigned to track the resubmission separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->