### PR TITLE
feat: SBL Bridge cookie + enterprise-user feature toggles (#2008)

### DIFF
--- a/src/Authentication/Configuration/FeatureFlags.cs
+++ b/src/Authentication/Configuration/FeatureFlags.cs
@@ -24,12 +24,12 @@
         public const string RegisterSelfIdentifiedUserProvisioning = "RegisterSelfIdentifiedUserProvisioning";
 
         /// <summary>
-        /// When enabled, disables the SBL Bridge cookie ticket decryption call
-        /// (<c>POST authentication/api/tickets</c>). No replacement exists; the A2 cookie→token
+        /// When enabled, disables the cookie ticket decryption path (SBL Bridge
+        /// <c>POST authentication/api/tickets</c>). No replacement exists; the A2 cookie→token
         /// flow will be removed entirely after the SBL Bridge decommission (deadline 2026-06-19).
         /// Tracked in issue #2008.
         /// </summary>
-        public const string SblBridgeCookieTicketDecryption = "SblBridgeCookieTicketDecryption";
+        public const string CookieTicketDecryptionDisabled = "CookieTicketDecryptionDisabled";
 
         /// <summary>
         /// When enabled, disables the enterprise-user authentication path (SBL Bridge

--- a/src/Authentication/Configuration/FeatureFlags.cs
+++ b/src/Authentication/Configuration/FeatureFlags.cs
@@ -22,5 +22,21 @@
         /// one atomic call. Tracked under the SBL Bridge decommission (deadline 2026-06-19).
         /// </summary>
         public const string RegisterSelfIdentifiedUserProvisioning = "RegisterSelfIdentifiedUserProvisioning";
+
+        /// <summary>
+        /// When enabled, disables the SBL Bridge cookie ticket decryption call
+        /// (<c>POST authentication/api/tickets</c>). No replacement exists; the A2 cookie→token
+        /// flow will be removed entirely after the SBL Bridge decommission (deadline 2026-06-19).
+        /// Tracked in issue #2008.
+        /// </summary>
+        public const string SblBridgeCookieTicketDecryption = "SblBridgeCookieTicketDecryption";
+
+        /// <summary>
+        /// When enabled, disables the SBL Bridge enterprise-user authentication call
+        /// (<c>POST authentication/api/enterpriseuser</c>) and returns HTTP 410 Gone with a
+        /// problem-details body pointing callers to Systembruker or ID-porten. Tracked in
+        /// issue #2008 (SBL Bridge decommission, deadline 2026-06-19).
+        /// </summary>
+        public const string SblBridgeEnterpriseUserAuthentication = "SblBridgeEnterpriseUserAuthentication";
     }
 }

--- a/src/Authentication/Configuration/FeatureFlags.cs
+++ b/src/Authentication/Configuration/FeatureFlags.cs
@@ -32,11 +32,11 @@
         public const string SblBridgeCookieTicketDecryption = "SblBridgeCookieTicketDecryption";
 
         /// <summary>
-        /// When enabled, disables the SBL Bridge enterprise-user authentication call
-        /// (<c>POST authentication/api/enterpriseuser</c>) and returns HTTP 410 Gone with a
+        /// When enabled, disables the enterprise-user authentication path (SBL Bridge
+        /// <c>POST authentication/api/enterpriseuser</c>) and returns HTTP 410 Gone with a
         /// problem-details body pointing callers to Systembruker or ID-porten. Tracked in
         /// issue #2008 (SBL Bridge decommission, deadline 2026-06-19).
         /// </summary>
-        public const string SblBridgeEnterpriseUserAuthentication = "SblBridgeEnterpriseUserAuthentication";
+        public const string EnterpriseUserAuthenticationDisabled = "EnterpriseUserAuthenticationDisabled";
     }
 }

--- a/src/Authentication/Configuration/FeatureFlags.cs
+++ b/src/Authentication/Configuration/FeatureFlags.cs
@@ -38,5 +38,14 @@
         /// issue #2008 (SBL Bridge decommission, deadline 2026-06-19).
         /// </summary>
         public const string EnterpriseUserAuthenticationDisabled = "EnterpriseUserAuthenticationDisabled";
+
+        /// <summary>
+        /// When enabled, every logout path that would otherwise 302 to the Altinn 2 logout
+        /// endpoint (<c>GeneralSettings.SBLLogoutEndpoint</c>) redirects to
+        /// <c>GeneralSettings.BaseUrl</c> instead. Allows the flag to be flipped per
+        /// environment as Altinn 2 servers are switched off, ahead of the longer-term
+        /// frontchannel logout rewrite in #1582. Tracked in issue #2012.
+        /// </summary>
+        public const string Altinn2LogoutRedirectDisabled = "Altinn2LogoutRedirectDisabled";
     }
 }

--- a/src/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/Controllers/AuthenticationController.cs
@@ -743,6 +743,18 @@ namespace Altinn.Platform.Authentication.Controllers
 
         private async Task<(UserAuthenticationResult? AuthenticatedEnterpriseUser, ActionResult? Error)> HandleEnterpriseUserLogin(string enterpriseUserHeader, string orgNumber)
         {
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.SblBridgeEnterpriseUserAuthentication))
+            {
+                ProblemDetails problem = new ProblemDetails
+                {
+                    Status = StatusCodes.Status410Gone,
+                    Title = "Virksomhetsbruker is no longer available",
+                    Detail = "Virksomhetsbruker (enterprise user) is no longer available. It has been replaced by Systembruker (system user) or ID-porten, depending on the use case. See https://docs.altinn.studio for migration guidance.",
+                    Type = "https://docs.altinn.studio"
+                };
+                return (null, new ObjectResult(problem) { StatusCode = StatusCodes.Status410Gone });
+            }
+
             EnterpriseUserCredentials credentials;
 
             try

--- a/src/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/Controllers/AuthenticationController.cs
@@ -436,16 +436,21 @@ namespace Altinn.Platform.Authentication.Controllers
                         return StatusCode(StatusCodes.Status503ServiceUnavailable);
                     }
 
+                    if (userAuthentication == null)
+                    {
+                        return Redirect(sblRedirectUrl);
+                    }
+
                     if (userAuthentication.UserID.HasValue && userAuthentication.UserID.Value != 0 && userAuthentication.PartyUuid == null)
                     {
                         UserProfile profile = await _profileService.GetUserProfile(new UserProfileLookup { UserId = userAuthentication.UserID.Value });
                         userAuthentication.PartyUuid = profile.UserUuid;
                     }
 
-                    if (userAuthentication != null && userAuthentication.IsAuthenticated)
+                    if (userAuthentication.IsAuthenticated)
                     {
                         await CreateTokenCookie(userAuthentication);
-                        
+
                         return Redirect(validatedGoToUri.AbsoluteUri);
                     }
                 }

--- a/src/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/Controllers/AuthenticationController.cs
@@ -743,7 +743,7 @@ namespace Altinn.Platform.Authentication.Controllers
 
         private async Task<(UserAuthenticationResult? AuthenticatedEnterpriseUser, ActionResult? Error)> HandleEnterpriseUserLogin(string enterpriseUserHeader, string orgNumber)
         {
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.SblBridgeEnterpriseUserAuthentication))
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.EnterpriseUserAuthenticationDisabled))
             {
                 ProblemDetails problem = new ProblemDetails
                 {

--- a/src/Authentication/Controllers/LogoutController.cs
+++ b/src/Authentication/Controllers/LogoutController.cs
@@ -107,6 +107,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 OidcProvider provider = GetOidcProvider(orgIss);
                 if (provider == null)
                 {
+                    DeleteLegacySblCookies();
                     _eventLog.CreateAuthenticationEventAsync(_featureManager, tokenCookie, AuthenticationEventType.Logout, HttpContext.Connection.RemoteIpAddress);
                     return Redirect(await ResolveLogoutFallbackAsync());
                 }
@@ -162,6 +163,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 return Redirect(redirectUrl.Value);
             }
 
+            DeleteLegacySblCookies();
             return Redirect(await ResolveLogoutFallbackAsync());
         }
 
@@ -173,6 +175,16 @@ namespace Altinn.Platform.Authentication.Controllers
             }
 
             return _generalSettings.SBLLogoutEndpoint;
+        }
+
+        private void DeleteLegacySblCookies()
+        {
+            CookieOptions opt = new CookieOptions() { Domain = _generalSettings.HostName, Secure = true, HttpOnly = true };
+            Response.Cookies.Delete(_generalSettings.SblAuthCookieName, opt);
+            if (!string.Equals(_generalSettings.SblAuthCookieEnvSpecificName, _generalSettings.SblAuthCookieName, StringComparison.Ordinal))
+            {
+                Response.Cookies.Delete(_generalSettings.SblAuthCookieEnvSpecificName, opt);
+            }
         }
 
         /// <summary>

--- a/src/Authentication/Controllers/LogoutController.cs
+++ b/src/Authentication/Controllers/LogoutController.cs
@@ -108,7 +108,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 if (provider == null)
                 {
                     _eventLog.CreateAuthenticationEventAsync(_featureManager, tokenCookie, AuthenticationEventType.Logout, HttpContext.Connection.RemoteIpAddress);
-                    return Redirect(_generalSettings.SBLLogoutEndpoint);
+                    return Redirect(await ResolveLogoutFallbackAsync());
                 }
 
                 CookieOptions opt = new CookieOptions() { Domain = _generalSettings.HostName, Secure = true, HttpOnly = true };
@@ -162,7 +162,17 @@ namespace Altinn.Platform.Authentication.Controllers
                 return Redirect(redirectUrl.Value);
             }
 
-            return Redirect(_generalSettings.SBLLogoutEndpoint);
+            return Redirect(await ResolveLogoutFallbackAsync());
+        }
+
+        private async Task<string> ResolveLogoutFallbackAsync()
+        {
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.Altinn2LogoutRedirectDisabled))
+            {
+                return _generalSettings.BaseUrl;
+            }
+
+            return _generalSettings.SBLLogoutEndpoint;
         }
 
         /// <summary>

--- a/src/Authentication/Services/OidcServerService.cs
+++ b/src/Authentication/Services/OidcServerService.cs
@@ -505,7 +505,7 @@ namespace Altinn.Platform.Authentication.Services
                 _logger.LogDebug("EndSession: no sid from cookie or id_token_hint; returning cookie delete only.");
                 return new EndSessionResult
                 {
-                    RedirectUri = new Uri(_generalSettings.SBLLogoutEndpoint), // Redirect to SBL logout as a safe default
+                    RedirectUri = await ResolveLogoutFallbackAsync(),
                     State = input.State,
                     Cookies = new[]
                     {
@@ -566,7 +566,8 @@ namespace Altinn.Platform.Authentication.Services
                 if (issuer.Equals(AuthzConstants.ISSUER_ALTINN_PORTAL, StringComparison.OrdinalIgnoreCase))
                 {
                     // Session was created based on Altinn 2 ticket. Redirect back to Altinn 2 for logout
-                    redirect = new Uri(_generalSettings.SBLLogoutEndpoint);
+                    // unless the Altinn 2 servers are gone — in which case fall back to BaseUrl.
+                    redirect = await ResolveLogoutFallbackAsync();
                 }
                 else
                 {
@@ -634,6 +635,16 @@ namespace Altinn.Platform.Authentication.Services
                 State = input.State,
                 Cookies = [deleteRuntime, deleteSession]
             };
+        }
+
+        private async Task<Uri> ResolveLogoutFallbackAsync()
+        {
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.Altinn2LogoutRedirectDisabled))
+            {
+                return new Uri(_generalSettings.BaseUrl);
+            }
+
+            return new Uri(_generalSettings.SBLLogoutEndpoint);
         }
 
         /// <summary>

--- a/src/Authentication/Services/OidcServerService.cs
+++ b/src/Authentication/Services/OidcServerService.cs
@@ -503,35 +503,38 @@ namespace Altinn.Platform.Authentication.Services
             if (string.IsNullOrWhiteSpace(sid))
             {
                 _logger.LogDebug("EndSession: no sid from cookie or id_token_hint; returning cookie delete only.");
+                List<CookieInstruction> noSidCookies = new()
+                {
+                    new CookieInstruction
+                    {
+                        Name = _generalSettings.JwtCookieName,
+                        Value = string.Empty,
+                        HttpOnly = true,
+                        Secure = true,
+                        Path = "/",
+                        SameSite = SameSiteMode.Lax,
+                        Expires = DateTimeOffset.UnixEpoch,
+                        Domain = _generalSettings.HostName,
+                    },
+                    new CookieInstruction
+                    {
+                        Name = _generalSettings.AltinnSessionCookieName,
+                        Value = string.Empty,
+                        HttpOnly = true,
+                        Secure = true,
+                        Path = "/",
+                        SameSite = SameSiteMode.Lax,
+                        Expires = DateTimeOffset.UnixEpoch,
+                        Domain = _generalSettings.HostName,
+                    }
+                };
+                noSidCookies.AddRange(BuildLegacySblCookieDeletes());
+
                 return new EndSessionResult
                 {
                     RedirectUri = await ResolveLogoutFallbackAsync(),
                     State = input.State,
-                    Cookies = new[]
-                    {
-                        new CookieInstruction
-                        {
-                            Name = _generalSettings.JwtCookieName,
-                            Value = string.Empty,
-                            HttpOnly = true,
-                            Secure = true,
-                            Path = "/",
-                            SameSite = SameSiteMode.Lax,
-                            Expires = DateTimeOffset.UnixEpoch,
-                            Domain = _generalSettings.HostName,
-                        },
-                        new CookieInstruction
-                        {
-                            Name = _generalSettings.AltinnSessionCookieName,
-                            Value = string.Empty,
-                            HttpOnly = true,
-                            Secure = true,
-                            Path = "/",
-                            SameSite = SameSiteMode.Lax,
-                            Expires = DateTimeOffset.UnixEpoch,
-                            Domain = _generalSettings.HostName,
-                        }
-                    }
+                    Cookies = noSidCookies
                 };
             }
 
@@ -629,11 +632,14 @@ namespace Altinn.Platform.Authentication.Services
                 Domain = _generalSettings.HostName,
             };
             
+            List<CookieInstruction> finalCookies = new() { deleteRuntime, deleteSession };
+            finalCookies.AddRange(BuildLegacySblCookieDeletes());
+
             return new EndSessionResult
             {
                 RedirectUri = redirect,
                 State = input.State,
-                Cookies = [deleteRuntime, deleteSession]
+                Cookies = finalCookies
             };
         }
 
@@ -645,6 +651,36 @@ namespace Altinn.Platform.Authentication.Services
             }
 
             return new Uri(_generalSettings.SBLLogoutEndpoint);
+        }
+
+        private IEnumerable<CookieInstruction> BuildLegacySblCookieDeletes()
+        {
+            yield return new CookieInstruction
+            {
+                Name = _generalSettings.SblAuthCookieName,
+                Value = string.Empty,
+                HttpOnly = true,
+                Secure = true,
+                Path = "/",
+                SameSite = SameSiteMode.Lax,
+                Expires = DateTimeOffset.UnixEpoch,
+                Domain = _generalSettings.HostName,
+            };
+
+            if (!string.Equals(_generalSettings.SblAuthCookieEnvSpecificName, _generalSettings.SblAuthCookieName, StringComparison.Ordinal))
+            {
+                yield return new CookieInstruction
+                {
+                    Name = _generalSettings.SblAuthCookieEnvSpecificName,
+                    Value = string.Empty,
+                    HttpOnly = true,
+                    Secure = true,
+                    Path = "/",
+                    SameSite = SameSiteMode.Lax,
+                    Expires = DateTimeOffset.UnixEpoch,
+                    Domain = _generalSettings.HostName,
+                };
+            }
         }
 
         /// <summary>

--- a/src/Authentication/Services/SblCookieDecryptionService.cs
+++ b/src/Authentication/Services/SblCookieDecryptionService.cs
@@ -47,9 +47,9 @@ namespace Altinn.Platform.Authentication.Services
         /// <inheritdoc />
         public async Task<UserAuthenticationModel> DecryptTicket(string encryptedTicket)
         {
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.SblBridgeCookieTicketDecryption))
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.CookieTicketDecryptionDisabled))
             {
-                _logger.LogInformation("SBL Bridge cookie ticket decryption is disabled by feature flag {Flag}", FeatureFlags.SblBridgeCookieTicketDecryption);
+                _logger.LogInformation("Cookie ticket decryption is disabled by feature flag {Flag}", FeatureFlags.CookieTicketDecryptionDisabled);
                 return null;
             }
 

--- a/src/Authentication/Services/SblCookieDecryptionService.cs
+++ b/src/Authentication/Services/SblCookieDecryptionService.cs
@@ -13,6 +13,7 @@ using Altinn.Platform.Authentication.Services.Interfaces;
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement;
 
 namespace Altinn.Platform.Authentication.Services
 {
@@ -23,6 +24,7 @@ namespace Altinn.Platform.Authentication.Services
     {
         private readonly ILogger<SblCookieDecryptionService> _logger;
         private readonly GeneralSettings _generalSettings;
+        private readonly IFeatureManager _featureManager;
 
         private readonly HttpClient _client;
 
@@ -32,17 +34,25 @@ namespace Altinn.Platform.Authentication.Services
         /// <param name="httpClient">The <see cref="HttpClient"/> to use when performing requests against SblBridge.</param>
         /// <param name="generalSettings">General settings for the authentication application.</param>
         /// <param name="logger">A generic logger.</param>
+        /// <param name="featureManager">Feature manager used to gate the SBL Bridge call.</param>
         public SblCookieDecryptionService(
-            HttpClient httpClient, IOptions<GeneralSettings> generalSettings, ILogger<SblCookieDecryptionService> logger)
+            HttpClient httpClient, IOptions<GeneralSettings> generalSettings, ILogger<SblCookieDecryptionService> logger, IFeatureManager featureManager)
         {
             _client = httpClient;
             _logger = logger;
             _generalSettings = generalSettings.Value;
+            _featureManager = featureManager;
         }
 
         /// <inheritdoc />
         public async Task<UserAuthenticationModel> DecryptTicket(string encryptedTicket)
         {
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.SblBridgeCookieTicketDecryption))
+            {
+                _logger.LogInformation("SBL Bridge cookie ticket decryption is disabled by feature flag {Flag}", FeatureFlags.SblBridgeCookieTicketDecryption);
+                return null;
+            }
+
             DataContractJsonSerializer serializer = new(typeof(UserAuthenticationModel));
             Uri endpointUrl = new Uri($"{_generalSettings.BridgeAuthnApiEndpoint}tickets");
 

--- a/src/Authentication/appsettings.json
+++ b/src/Authentication/appsettings.json
@@ -65,7 +65,7 @@
     "AuditLog": false,
     "SystemUser": true,
     "RegisterSelfIdentifiedUserProvisioning": false,
-    "SblBridgeCookieTicketDecryption": false,
+    "CookieTicketDecryptionDisabled": false,
     "EnterpriseUserAuthenticationDisabled": false
   },
   "PostgreSQLSettings": {

--- a/src/Authentication/appsettings.json
+++ b/src/Authentication/appsettings.json
@@ -66,7 +66,8 @@
     "SystemUser": true,
     "RegisterSelfIdentifiedUserProvisioning": false,
     "CookieTicketDecryptionDisabled": false,
-    "EnterpriseUserAuthenticationDisabled": false
+    "EnterpriseUserAuthenticationDisabled": false,
+    "Altinn2LogoutRedirectDisabled": false
   },
   "PostgreSQLSettings": {
     "EnableDBConnection": true,

--- a/src/Authentication/appsettings.json
+++ b/src/Authentication/appsettings.json
@@ -64,7 +64,9 @@
   "FeatureManagement": {
     "AuditLog": false,
     "SystemUser": true,
-    "RegisterSelfIdentifiedUserProvisioning": false
+    "RegisterSelfIdentifiedUserProvisioning": false,
+    "SblBridgeCookieTicketDecryption": false,
+    "SblBridgeEnterpriseUserAuthentication": false
   },
   "PostgreSQLSettings": {
     "EnableDBConnection": true,

--- a/src/Authentication/appsettings.json
+++ b/src/Authentication/appsettings.json
@@ -66,7 +66,7 @@
     "SystemUser": true,
     "RegisterSelfIdentifiedUserProvisioning": false,
     "SblBridgeCookieTicketDecryption": false,
-    "SblBridgeEnterpriseUserAuthentication": false
+    "EnterpriseUserAuthenticationDisabled": false
   },
   "PostgreSQLSettings": {
     "EnableDBConnection": true,

--- a/test/Altinn.Platform.Authentication.Tests/Services/SblCookieDecryptionServiceTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Services/SblCookieDecryptionServiceTests.cs
@@ -11,6 +11,7 @@ using Altinn.Platform.Authentication.Services;
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement;
 
 using Moq;
 using Moq.Protected;
@@ -27,6 +28,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
         private readonly Mock<HttpMessageHandler> _handlerMock;
         private readonly Mock<IOptions<GeneralSettings>> _generalSettingsOptions;
         private readonly Mock<ILogger<SblCookieDecryptionService>> _logger;
+        private readonly Mock<IFeatureManager> _featureManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SblCookieDecryptionServiceTests"/> class.
@@ -36,6 +38,8 @@ namespace Altinn.Platform.Authentication.Tests.Services
             _generalSettingsOptions = new Mock<IOptions<GeneralSettings>>();
             _handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
             _logger = new Mock<ILogger<SblCookieDecryptionService>>();
+            _featureManager = new Mock<IFeatureManager>();
+            _featureManager.Setup(f => f.IsEnabledAsync(It.IsAny<string>())).ReturnsAsync(false);
         }
 
         /// <summary>
@@ -55,7 +59,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
             InitializeMocks(httpResponseMessage);
 
             HttpClient httpClient = new HttpClient(_handlerMock.Object);
-            SblCookieDecryptionService target = new SblCookieDecryptionService(httpClient, _generalSettingsOptions.Object, _logger.Object);
+            SblCookieDecryptionService target = new SblCookieDecryptionService(httpClient, _generalSettingsOptions.Object, _logger.Object, _featureManager.Object);
 
             // Act
             UserAuthenticationModel actual = await target.DecryptTicket("random and irrelevant bytes");
@@ -82,7 +86,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
             InitializeMocks(httpResponseMessage);
 
             HttpClient httpClient = new HttpClient(_handlerMock.Object);
-            SblCookieDecryptionService target = new SblCookieDecryptionService(httpClient, _generalSettingsOptions.Object, _logger.Object);
+            SblCookieDecryptionService target = new SblCookieDecryptionService(httpClient, _generalSettingsOptions.Object, _logger.Object, _featureManager.Object);
 
             SblBridgeResponseException actual = null;
 
@@ -119,7 +123,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
             InitializeMocks(httpResponseMessage);
 
             HttpClient httpClient = new HttpClient(_handlerMock.Object);
-            SblCookieDecryptionService target = new SblCookieDecryptionService(httpClient, _generalSettingsOptions.Object, _logger.Object);
+            SblCookieDecryptionService target = new SblCookieDecryptionService(httpClient, _generalSettingsOptions.Object, _logger.Object, _featureManager.Object);
 
             // Act
             UserAuthenticationModel actual = await target.DecryptTicket("random and irrelevant bytes");
@@ -128,6 +132,32 @@ namespace Altinn.Platform.Authentication.Tests.Services
             _handlerMock.VerifyAll();
 
             Assert.Null(actual);
+        }
+
+        /// <summary>
+        /// Testing the <see cref="SblCookieDecryptionService.DecryptTicket"/> method.
+        /// </summary>
+        [Fact]
+        public async Task DecryptTicket_FeatureFlagEnabled_ReturnsNullWithoutCallingBridge()
+        {
+            // Arrange
+            GeneralSettings generalSettings = new GeneralSettings { BridgeAuthnApiEndpoint = "http://localhost", OidcRefreshTokenPepper = "YWRzZmFzZmRhc2ZzYWVmZWY=" };
+            _generalSettingsOptions.Setup(s => s.Value).Returns(generalSettings);
+            _featureManager.Setup(f => f.IsEnabledAsync(FeatureFlags.SblBridgeCookieTicketDecryption)).ReturnsAsync(true);
+
+            HttpClient httpClient = new HttpClient(_handlerMock.Object);
+            SblCookieDecryptionService target = new SblCookieDecryptionService(httpClient, _generalSettingsOptions.Object, _logger.Object, _featureManager.Object);
+
+            // Act
+            UserAuthenticationModel actual = await target.DecryptTicket("random and irrelevant bytes");
+
+            // Assert
+            Assert.Null(actual);
+            _handlerMock.Protected().Verify(
+                "SendAsync",
+                Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>());
         }
 
         private void InitializeMocks(HttpResponseMessage httpResponseMessage)

--- a/test/Altinn.Platform.Authentication.Tests/Services/SblCookieDecryptionServiceTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Services/SblCookieDecryptionServiceTests.cs
@@ -143,7 +143,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
             // Arrange
             GeneralSettings generalSettings = new GeneralSettings { BridgeAuthnApiEndpoint = "http://localhost", OidcRefreshTokenPepper = "YWRzZmFzZmRhc2ZzYWVmZWY=" };
             _generalSettingsOptions.Setup(s => s.Value).Returns(generalSettings);
-            _featureManager.Setup(f => f.IsEnabledAsync(FeatureFlags.SblBridgeCookieTicketDecryption)).ReturnsAsync(true);
+            _featureManager.Setup(f => f.IsEnabledAsync(FeatureFlags.CookieTicketDecryptionDisabled)).ReturnsAsync(true);
 
             HttpClient httpClient = new HttpClient(_handlerMock.Object);
             SblCookieDecryptionService target = new SblCookieDecryptionService(httpClient, _generalSettingsOptions.Object, _logger.Object, _featureManager.Object);


### PR DESCRIPTION
Closes #2008.

## Summary
- Adds `CookieTicketDecryptionDisabled` (A) and `EnterpriseUserAuthenticationDisabled` (B) feature flags in `FeatureFlags.cs`, defaulted to `false` in `appsettings.json`. Independently flippable per environment.
- A is gated at the service layer in `SblCookieDecryptionService.DecryptTicket` so the single change covers all three call sites (`AuthenticationController` legacy cookie endpoint and the two `OidcServerService` A2-ticket paths). When the flag is on, the method returns `null` without calling Bridge — existing callers already handle that as "no valid session." Per #2008, no replacement is planned; the flow will be removed after 2026-06-19.
- B is gated at the top of `AuthenticationController.HandleEnterpriseUserLogin`. When the flag is on, the endpoint returns **HTTP 410 Gone** with a `ProblemDetails` body explaining that virksomhetsbruker is no longer available and pointing callers to Systembruker or ID-porten via docs.altinn.studio.
- Unit test added: `DecryptTicket_FeatureFlagEnabled_ReturnsNullWithoutCallingBridge` (asserts no HTTP call is made when flag is on).

## Rollout
Flags default `false` → no behavioural change on merge. Each environment opts in by setting the flag in its `FeatureManagement` section. Suggested order — happy to confirm with @TheTechArch:
- B (enterprise user): AT22 → AT23/AT24 → TT02 → PROD. Low risk since the replacement (Systembruker / ID-porten) is already in use.
- A (cookie ticket): coordinate with OIDC frontchannel — flipping disables A2 ticket session-reuse in `OidcServerService`, which still has live traffic in some envs.

## Test plan
- [x] `dotnet build src/Authentication` — 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~SblCookieDecryptionServiceTests"` — 4/4 pass
- [ ] CI: existing `AuthenticateEnterpriseUser_*` integration tests should still pass with flag default `false` (couldn't run locally — Testcontainers needs Docker)
- [ ] Manual smoke in AT22 after flipping B: enterprise-user request returns 410 with the expected problem-details body
- [ ] Manual smoke in AT22 after flipping A: legacy cookie endpoint redirects to `sblRedirectUrl` (existing null-fallback), OIDC A2 ticket reuse no longer creates sessions

## Out of scope
- Per-environment rollout-order doc (issue task #5) — to be added after confirmation
- Code removal for the cookie-ticket path — scheduled for after 2026-06-19 per #2008

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added feature flags to toggle legacy SBL Bridge behaviors with graceful fallbacks.
  * Cookie ticket decryption can be disabled, causing decryption to short-circuit with a null result.
  * Enterprise-user authentication can be disabled, returning HTTP 410 with migration guidance.
  * Logout and session end flows now delete legacy SBL cookies and support alternate redirect routing when configured.

* **Tests**
  * Added tests verifying feature-flag-driven authentication and that disabled decryption skips the bridge call.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->