### PR TITLE
feat: Altinn2LogoutRedirectDisabled toggle (#2012)

### DIFF
--- a/src/Authentication/Configuration/FeatureFlags.cs
+++ b/src/Authentication/Configuration/FeatureFlags.cs
@@ -38,5 +38,14 @@
         /// issue #2008 (SBL Bridge decommission, deadline 2026-06-19).
         /// </summary>
         public const string EnterpriseUserAuthenticationDisabled = "EnterpriseUserAuthenticationDisabled";
+
+        /// <summary>
+        /// When enabled, every logout path that would otherwise 302 to the Altinn 2 logout
+        /// endpoint (<c>GeneralSettings.SBLLogoutEndpoint</c>) redirects to
+        /// <c>GeneralSettings.BaseUrl</c> instead. Allows the flag to be flipped per
+        /// environment as Altinn 2 servers are switched off, ahead of the longer-term
+        /// frontchannel logout rewrite in #1582. Tracked in issue #2012.
+        /// </summary>
+        public const string Altinn2LogoutRedirectDisabled = "Altinn2LogoutRedirectDisabled";
     }
 }

--- a/src/Authentication/Controllers/LogoutController.cs
+++ b/src/Authentication/Controllers/LogoutController.cs
@@ -108,7 +108,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 if (provider == null)
                 {
                     _eventLog.CreateAuthenticationEventAsync(_featureManager, tokenCookie, AuthenticationEventType.Logout, HttpContext.Connection.RemoteIpAddress);
-                    return Redirect(_generalSettings.SBLLogoutEndpoint);
+                    return Redirect(await ResolveLogoutFallbackAsync());
                 }
 
                 CookieOptions opt = new CookieOptions() { Domain = _generalSettings.HostName, Secure = true, HttpOnly = true };
@@ -162,7 +162,17 @@ namespace Altinn.Platform.Authentication.Controllers
                 return Redirect(redirectUrl.Value);
             }
 
-            return Redirect(_generalSettings.SBLLogoutEndpoint);
+            return Redirect(await ResolveLogoutFallbackAsync());
+        }
+
+        private async Task<string> ResolveLogoutFallbackAsync()
+        {
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.Altinn2LogoutRedirectDisabled))
+            {
+                return _generalSettings.BaseUrl;
+            }
+
+            return _generalSettings.SBLLogoutEndpoint;
         }
 
         /// <summary>

--- a/src/Authentication/Services/OidcServerService.cs
+++ b/src/Authentication/Services/OidcServerService.cs
@@ -505,7 +505,7 @@ namespace Altinn.Platform.Authentication.Services
                 _logger.LogDebug("EndSession: no sid from cookie or id_token_hint; returning cookie delete only.");
                 return new EndSessionResult
                 {
-                    RedirectUri = new Uri(_generalSettings.SBLLogoutEndpoint), // Redirect to SBL logout as a safe default
+                    RedirectUri = await ResolveLogoutFallbackAsync(),
                     State = input.State,
                     Cookies = new[]
                     {
@@ -566,7 +566,8 @@ namespace Altinn.Platform.Authentication.Services
                 if (issuer.Equals(AuthzConstants.ISSUER_ALTINN_PORTAL, StringComparison.OrdinalIgnoreCase))
                 {
                     // Session was created based on Altinn 2 ticket. Redirect back to Altinn 2 for logout
-                    redirect = new Uri(_generalSettings.SBLLogoutEndpoint);
+                    // unless the Altinn 2 servers are gone — in which case fall back to BaseUrl.
+                    redirect = await ResolveLogoutFallbackAsync();
                 }
                 else
                 {
@@ -634,6 +635,16 @@ namespace Altinn.Platform.Authentication.Services
                 State = input.State,
                 Cookies = [deleteRuntime, deleteSession]
             };
+        }
+
+        private async Task<Uri> ResolveLogoutFallbackAsync()
+        {
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.Altinn2LogoutRedirectDisabled))
+            {
+                return new Uri(_generalSettings.BaseUrl);
+            }
+
+            return new Uri(_generalSettings.SBLLogoutEndpoint);
         }
 
         /// <summary>

--- a/src/Authentication/appsettings.json
+++ b/src/Authentication/appsettings.json
@@ -66,7 +66,8 @@
     "SystemUser": true,
     "RegisterSelfIdentifiedUserProvisioning": false,
     "CookieTicketDecryptionDisabled": false,
-    "EnterpriseUserAuthenticationDisabled": false
+    "EnterpriseUserAuthenticationDisabled": false,
+    "Altinn2LogoutRedirectDisabled": false
   },
   "PostgreSQLSettings": {
     "EnableDBConnection": true,


### PR DESCRIPTION
Closes #2012. **Stacked on #2011** — base is `feat/sbl-bridge-decom-toggles-2008` so this diff shows only the new changes. Will need to be re-targeted to `main` after #2011 merges.

## Summary
- Adds `Altinn2LogoutRedirectDisabled` to `FeatureFlags.cs`, default `false` in `appsettings.json`. Same `*Disabled` naming convention as PR #2011.
- Gates all four logout paths that currently 302 to `GeneralSettings.SBLLogoutEndpoint`:
  - `OidcServerService.EndSessionAsync` no-sid fallback (line 508)
  - `OidcServerService.EndSessionAsync` session-from-A2-ticket branch (line 569)
  - `LogoutController.Logout` legacy-mode no-OIDC-provider path (line 111)
  - `LogoutController.HandleLoggedOut` final fallthrough (line 165)
- When the flag is enabled, all four sites redirect to `GeneralSettings.BaseUrl` instead, via a small private `ResolveLogoutFallbackAsync` helper in each class.

## ⚠️ Decision flagged for review: replacement target
The issue listed three options for where to redirect when the A2 endpoint is disabled. I went with **Option A (`BaseUrl`)** because it's already used as a fallback in `LogoutController.Logout` line 94 and keeps the change mechanical. If the right target is actually a dedicated post-logout page (Option B) or an inline view (Option C), the change is localised to the two `ResolveLogoutFallbackAsync` helpers — easy to swap. Worth a sanity-check from @TheTechArch before merging.

## Rollout
Flag defaults to `false` → no behavioural change on merge. Flip per environment as that environment's A2 servers go offline.

## Test plan
- [x] `dotnet build src/Authentication` — 0 errors
- [x] `dotnet test --filter SblCookieDecryptionServiceTests` — 4/4 pass (sanity-check that the non-integration suite still builds)
- [ ] CI: existing logout integration tests should still pass with flag default `false` (couldn't run locally — Testcontainers needs Docker)
- [ ] Manual smoke in an env once flipped: all four logout paths land on `BaseUrl` instead of `SBLLogoutEndpoint`

## Related
- #2008 — cookie ticket + enterprise-user toggles (same pattern, PR #2011)
- #1582 — long-term frontchannel logout protocol rewrite. This toggle is a **near-term cutover, not** a replacement.
- #2006 — SBL Bridge call inventory

🤖 Generated with [Claude Code](https://claude.com/claude-code)