### PR TITLE
feat: support authentication step-up (level 3 → 4) for unregistered clients

### DIFF
--- a/src/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/Controllers/AuthenticationController.cs
@@ -148,6 +148,7 @@ namespace Altinn.Platform.Authentication.Controllers
         /// </summary>
         /// <param name="goTo">The url to redirect to if everything validates ok</param>
         /// <param name="dontChooseReportee">Parameter to indicate disabling of reportee selection in Altinn Portal.</param>
+        /// <param name="acrValues">Optional requested authentication level (space-separated acr_values). When the current session does not meet the requested level, the user is re-authenticated upstream (step-up).</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>redirect to correct url based on the validation of the form authentication sbl cookie</returns>
         [AllowAnonymous]
@@ -155,9 +156,16 @@ namespace Altinn.Platform.Authentication.Controllers
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(void), StatusCodes.Status503ServiceUnavailable)]
         [HttpGet("authentication")]
-        public async Task<ActionResult> AuthenticateUser([FromQuery] string? goTo, [FromQuery] bool dontChooseReportee, CancellationToken cancellationToken = default)
+        public async Task<ActionResult> AuthenticateUser([FromQuery] string? goTo, [FromQuery] bool dontChooseReportee, [FromQuery(Name = "acr_values")] string? acrValues = null, CancellationToken cancellationToken = default)
         {
             System.Net.IPAddress? ip = HttpContext.Connection.RemoteIpAddress;
+
+            // Optional requested authentication level (acr_values). Lets unregistered clients (e.g. Altinn Apps)
+            // ask for a higher level than the user's current session — i.e. trigger a step-up (level 3 -> 4).
+            if (!AuthenticationHelper.TryParseAcrValues(acrValues, out string[] requestedAcrValues))
+            {
+                return BadRequest("Invalid acr_values.");
+            }
 
             if (string.IsNullOrEmpty(goTo) && HttpContext.Request.Cookies[_generalSettings.AuthnGoToCookieName] != null)
             {
@@ -243,8 +251,14 @@ namespace Altinn.Platform.Authentication.Controllers
                     {
                         try
                         {
-                            await _oidcServerService.HandleSessionRefresh(User, cancellationToken);
-                            return Redirect(validatedGoToUri.AbsoluteUri);
+                            OidcSession? refreshedSession = await _oidcServerService.HandleSessionRefresh(User, cancellationToken);
+
+                            // Only reuse the existing session if it already satisfies the requested level.
+                            // Otherwise fall through and re-authenticate upstream at the higher level (step-up).
+                            if (!AuthenticationHelper.NeedAcrUpgrade(refreshedSession?.Acr, requestedAcrValues))
+                            {
+                                return Redirect(validatedGoToUri.AbsoluteUri);
+                            }
                         }
                         catch
                         {
@@ -266,7 +280,10 @@ namespace Altinn.Platform.Authentication.Controllers
                     {
                         AuthenticateFromSessionInput sessionCookieInput = new() { SessionHandle = sessionCookieValue };
                         AuthenticateFromSessionResult authenticateFromSessionResult = await _oidcServerService.HandleAuthenticateFromSessionResult(sessionCookieInput, cancellationToken);
-                        if (authenticateFromSessionResult.Kind.Equals(AuthenticateFromSessionResultKind.Success))
+
+                        // Reuse the session only when it already meets the requested level; otherwise step up.
+                        if (authenticateFromSessionResult.Kind.Equals(AuthenticateFromSessionResultKind.Success)
+                            && !AuthenticationHelper.NeedAcrUpgrade(authenticateFromSessionResult.Acr, requestedAcrValues))
                         {
                             foreach (var c in authenticateFromSessionResult.Cookies)
                             {
@@ -305,7 +322,10 @@ namespace Altinn.Platform.Authentication.Controllers
                         };
                         
                         AuthenticateFromAltinn2TicketResult ticketResult = await _oidcServerService.HandleAuthenticateFromTicket(ticketInput, cancellationToken);
-                        if (ticketResult.Kind.Equals(AuthenticateFromAltinn2TicketResultKind.Success))
+
+                        // Reuse the Altinn 2 session only when it already meets the requested level; otherwise step up.
+                        if (ticketResult.Kind.Equals(AuthenticateFromAltinn2TicketResultKind.Success)
+                            && !AuthenticationHelper.NeedAcrUpgrade(ticketResult.Acr, requestedAcrValues))
                         {
                             foreach (var c in ticketResult.Cookies)
                             {
@@ -333,7 +353,7 @@ namespace Altinn.Platform.Authentication.Controllers
                         ClientIp = ip,
                         UserAgentHash = userAgentHash,
                         CorrelationId = corr,
-                        AcrValues = []
+                        AcrValues = requestedAcrValues
                     };
 
                     AuthorizeResult result = await _oidcServerService.AuthorizeUnregisteredClient(authorizeUnregisteredClientRequest, cancellationToken);

--- a/src/Authentication/Helpers/AuthenticationHelper.cs
+++ b/src/Authentication/Helpers/AuthenticationHelper.cs
@@ -29,6 +29,14 @@ namespace Altinn.Platform.Authentication.Helpers
         private const string IdPortenAcrHigh = "idporten-loa-high";
 
         /// <summary>
+        /// The acr_values accepted on the public authentication entry point. Mirrors the allow-list
+        /// enforced for registered clients in <c>AuthorizeRequestValidator</c>.
+        /// </summary>
+        private static readonly HashSet<string> AllowedAcrValues = new(
+            new[] { "selfregistered-email", "idporten-loa-substantial", "idporten-loa-high", "level0", "level1", "level2" },
+            StringComparer.Ordinal);
+
+        /// <summary>
         /// Get user information from the token
         /// </summary>
         /// <param name="jwtSecurityToken">jwt token</param>
@@ -740,6 +748,34 @@ namespace Altinn.Platform.Authentication.Helpers
            }
 
            return false;
+        }
+
+        /// <summary>
+        /// Parses and validates a space-separated <c>acr_values</c> string from the public authentication
+        /// entry point against the allowed set.
+        /// </summary>
+        /// <param name="raw">The raw, space-separated acr_values query value. Null/empty is valid (no level requested).</param>
+        /// <param name="values">The parsed acr values, or an empty array when none were requested or validation failed.</param>
+        /// <returns><c>true</c> when the input is absent or contains only allowed values; otherwise <c>false</c>.</returns>
+        public static bool TryParseAcrValues(string? raw, out string[] values)
+        {
+            values = Array.Empty<string>();
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return true;
+            }
+
+            string[] parsed = raw.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            foreach (string v in parsed)
+            {
+                if (!AllowedAcrValues.Contains(v))
+                {
+                    return false;
+                }
+            }
+
+            values = parsed;
+            return true;
         }
     }
 }

--- a/src/Authentication/Services/OidcServerService.cs
+++ b/src/Authentication/Services/OidcServerService.cs
@@ -785,7 +785,8 @@ namespace Altinn.Platform.Authentication.Services
                 return new AuthenticateFromSessionResult
                 {
                     Kind = AuthenticateFromSessionResultKind.Success,
-                    Cookies = [cookieInstruction]
+                    Cookies = [cookieInstruction],
+                    Acr = oidcSession.Acr
                 };
             }
 
@@ -843,7 +844,8 @@ namespace Altinn.Platform.Authentication.Services
                 return new AuthenticateFromAltinn2TicketResult
                 {
                     Kind = AuthenticateFromAltinn2TicketResultKind.Success,
-                    Cookies = [cookieInstruction, altinnSessionCookie]
+                    Cookies = [cookieInstruction, altinnSessionCookie],
+                    Acr = session.Acr
                 };
             }
 

--- a/src/Core/Models/Oidc/AuthenticateFromAltinn2TicketResult.cs
+++ b/src/Core/Models/Oidc/AuthenticateFromAltinn2TicketResult.cs
@@ -8,5 +8,11 @@
         public AuthenticateFromAltinn2TicketResultKind Kind { get; init; }
 
         public IEnumerable<CookieInstruction> Cookies { get; init; } = [];
+
+        /// <summary>
+        /// The authentication context class reference (acr) of the session created from the Altinn 2 ticket.
+        /// Used to decide whether the session satisfies a requested authentication level (step-up).
+        /// </summary>
+        public string? Acr { get; init; }
     }
 }

--- a/src/Core/Models/Oidc/AuthenticateFromSessionResult.cs
+++ b/src/Core/Models/Oidc/AuthenticateFromSessionResult.cs
@@ -8,5 +8,11 @@
         public AuthenticateFromSessionResultKind Kind { get; init; }
 
         public IEnumerable<CookieInstruction> Cookies { get; init; } = [];
+
+        /// <summary>
+        /// The authentication context class reference (acr) of the resolved session, when one was found.
+        /// Used to decide whether the session satisfies a requested authentication level (step-up).
+        /// </summary>
+        public string? Acr { get; init; }
     }
 }

--- a/test/Altinn.Platform.Authentication.Tests/AuthenticationHelperTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/AuthenticationHelperTests.cs
@@ -364,5 +364,43 @@ namespace Altinn.Platform.Authentication.Tests
             var result = AuthenticationHelper.HasSpaceInId(input);
             Assert.Equal(expected, result);
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void TryParseAcrValues_NoValueRequested_IsValidAndEmpty(string input)
+        {
+            bool ok = AuthenticationHelper.TryParseAcrValues(input, out string[] values);
+
+            Assert.True(ok);
+            Assert.Empty(values);
+        }
+
+        [Theory]
+        [InlineData("idporten-loa-high", new[] { "idporten-loa-high" })]
+        [InlineData("idporten-loa-substantial", new[] { "idporten-loa-substantial" })]
+        [InlineData("selfregistered-email idporten-loa-substantial", new[] { "selfregistered-email", "idporten-loa-substantial" })]
+        [InlineData("  idporten-loa-high   ", new[] { "idporten-loa-high" })]
+        public void TryParseAcrValues_AllowedValues_ParsesAndValidates(string input, string[] expected)
+        {
+            bool ok = AuthenticationHelper.TryParseAcrValues(input, out string[] values);
+
+            Assert.True(ok);
+            Assert.Equal(expected, values);
+        }
+
+        [Theory]
+        [InlineData("idporten-loa-extreme")]
+        [InlineData("level4")]
+        [InlineData("idporten-loa-high something-bogus")]
+        [InlineData("'; drop table sessions;--")]
+        public void TryParseAcrValues_DisallowedValue_ReturnsFalseAndEmpty(string input)
+        {
+            bool ok = AuthenticationHelper.TryParseAcrValues(input, out string[] values);
+
+            Assert.False(ok);
+            Assert.Empty(values);
+        }
     }
 }

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
@@ -1678,6 +1678,101 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             Assert.Equal("OK", frontChannelContent);
         }
 
+        /// <summary>
+        /// Step-up (level 3 → 4) for the unregistered-client "goto" flow used by Altinn Apps.
+        ///
+        /// 1) A user authenticates at level 3 (substantial) through the standard goto endpoint.
+        /// 2) Calling the goto endpoint again WITHOUT acr_values reuses the level-3 session (regression guard).
+        /// 3) Calling it WITH acr_values=idporten-loa-high must NOT reuse the level-3 session: the user is
+        ///    re-driven upstream at LoA-high, with acr_values sent as-is (no selfregistered-email widening
+        ///    because the user is already known).
+        /// 4) After the upstream callback the previous session is removed and a fresh level-4 session is
+        ///    created, and the browser is redirected back to the App.
+        ///
+        /// Refs #2016.
+        /// </summary>
+        [Fact]
+        public async Task TC13_Auth_App_Level3_StepUp_Level4_Via_Goto_End_To_End_OK()
+        {
+            using HttpClient client = CreateClientWithHeaders();
+            OidcTestScenario testScenario = OidcScenarioHelper.GetScenario("Arbeidsflate_Level34");
+
+            const string gotoUrl =
+                "/authentication/api/v1/authentication?goto=https%3A%2F%2Ftad.apps.localhost%2Ftad%2Fpagaendesak%3FDONTCHOOSEREPORTEE%3Dtrue%23%2Finstance%2F51441547%2F26cbe3f0-355d-4459-b085-7edaa899b6ba";
+            const string appRedirectPrefix =
+                "https://tad.apps.localhost/tad/pagaendesak?DONTCHOOSEREPORTEE=true#/instance/51441547/26cbe3f0-355d-4459-b085-7edaa899b6ba";
+
+            // === Phase 1: unauthenticated user hits the goto endpoint, no level requested ===
+            HttpResponseMessage initialRedirect = await client.GetAsync(gotoUrl);
+            Assert.Equal(HttpStatusCode.Redirect, initialRedirect.StatusCode);
+            Assert.StartsWith("https://login.idporten.no/authorize", initialRedirect.Headers.Location!.ToString());
+
+            // Anonymous user: upstream acr_values widened with selfregistered-email at substantial.
+            string initialUpstreamAcr = HttpUtility.ParseQueryString(initialRedirect.Headers.Location!.Query)["acr_values"] ?? string.Empty;
+            Assert.Equal("selfregistered-email idporten-loa-substantial", initialUpstreamAcr);
+
+            (string? upstreamState, UpstreamLoginTransaction? upstreamTx) = await AssertAutorizeRequestResult(testScenario, initialRedirect, _fakeTime.GetUtcNow());
+            Debug.Assert(upstreamTx != null);
+
+            _fakeTime.Advance(TimeSpan.FromMinutes(1));
+            ConfigureMockProviderTokenResponse(testScenario, upstreamTx, _fakeTime.GetUtcNow());
+
+            // === Phase 2: upstream callback -> level-3 session created, redirect back to the App ===
+            string callbackUrl = $"/authentication/api/v1/upstream/callback?code={Uri.EscapeDataString(testScenario.GetUpstreamProviderCode())}&state={Uri.EscapeDataString(upstreamState!)}";
+            HttpResponseMessage callbackResp = await client.GetAsync(callbackUrl);
+            Assert.Equal(HttpStatusCode.Redirect, callbackResp.StatusCode);
+            Assert.StartsWith(appRedirectPrefix, callbackResp.Headers.Location!.ToString());
+
+            // Confirm the active session is level 3 (substantial).
+            _fakeTime.Advance(TimeSpan.FromMinutes(1));
+            string level3CookieToken = await (await client.GetAsync("/authentication/api/v1/refresh")).Content.ReadAsStringAsync();
+            string level3Sid = TokenAssertsHelper.AssertCookieAccessToken(level3CookieToken, testScenario, _fakeTime.GetUtcNow());
+            OidcSession? level3Session = await OidcServerDatabaseUtil.GetOidcSessionAsync(level3Sid, DataSource);
+            Assert.Equal("idporten-loa-substantial", level3Session!.Acr);
+
+            // === Phase 3 (regression guard): goto again WITHOUT acr_values -> reuse, straight back to the App ===
+            HttpResponseMessage reuseResp = await client.GetAsync(gotoUrl);
+            Assert.Equal(HttpStatusCode.Redirect, reuseResp.StatusCode);
+            Assert.StartsWith(appRedirectPrefix, reuseResp.Headers.Location!.ToString());
+
+            // === Phase 4: goto again WITH acr_values=idporten-loa-high -> step-up, NOT reuse ===
+            testScenario.Acr = ["idporten-loa-high"];
+            testScenario.Amr = ["BankID Mobil"];
+            testScenario.SetLoginAttempt(2);
+
+            HttpResponseMessage stepUpRedirect = await client.GetAsync(gotoUrl + "&acr_values=idporten-loa-high");
+            Assert.Equal(HttpStatusCode.Redirect, stepUpRedirect.StatusCode);
+            Assert.StartsWith("https://login.idporten.no/authorize", stepUpRedirect.Headers.Location!.ToString());
+
+            // Known user being stepped up: acr_values sent as-is, no selfregistered-email widening.
+            string stepUpUpstreamAcr = HttpUtility.ParseQueryString(stepUpRedirect.Headers.Location!.Query)["acr_values"] ?? string.Empty;
+            Assert.Equal("idporten-loa-high", stepUpUpstreamAcr);
+
+            (string? stepUpState, UpstreamLoginTransaction? stepUpTx) = await AssertAutorizeRequestResult(testScenario, stepUpRedirect, _fakeTime.GetUtcNow());
+            Debug.Assert(stepUpTx != null);
+
+            _fakeTime.Advance(TimeSpan.FromMinutes(1));
+            ConfigureMockProviderTokenResponse(testScenario, stepUpTx, _fakeTime.GetUtcNow());
+
+            // === Phase 5: upstream callback for the step-up -> old session removed, fresh level-4 session, back to App ===
+            string stepUpCallbackUrl = $"/authentication/api/v1/upstream/callback?code={Uri.EscapeDataString(testScenario.GetUpstreamProviderCode())}&state={Uri.EscapeDataString(stepUpState!)}";
+            HttpResponseMessage stepUpCallbackResp = await client.GetAsync(stepUpCallbackUrl);
+            Assert.Equal(HttpStatusCode.Redirect, stepUpCallbackResp.StatusCode);
+            Assert.StartsWith(appRedirectPrefix, stepUpCallbackResp.Headers.Location!.ToString());
+
+            // The previous level-3 session must be gone.
+            OidcSession? oldSession = await OidcServerDatabaseUtil.GetOidcSessionAsync(level3Sid, DataSource);
+            Assert.Null(oldSession);
+
+            // The new session must be level 4 (high).
+            _fakeTime.Advance(TimeSpan.FromMinutes(1));
+            string level4CookieToken = await (await client.GetAsync("/authentication/api/v1/refresh")).Content.ReadAsStringAsync();
+            string level4Sid = TokenAssertsHelper.AssertCookieAccessToken(level4CookieToken, testScenario, _fakeTime.GetUtcNow());
+            OidcSession? level4Session = await OidcServerDatabaseUtil.GetOidcSessionAsync(level4Sid, DataSource);
+            Assert.Equal("idporten-loa-high", level4Session!.Acr);
+            Assert.NotEqual(level3Sid, level4Sid);
+        }
+
         [Fact]
         public async Task TC9_Auth_App_Logout_End_To_End_OK()
         {


### PR DESCRIPTION
## Description

Adds authentication **step-up (level 3 → 4)** support to the goto-based authentication entry point used by **unregistered clients** (Altinn Apps and other platform components). Registered OIDC clients already had step-up via `/authorize`; the goto flow did not — a user with a level-3 session was silently reused even when level 4 was required, because the session-reuse paths never compared ACR.

This implements **Option A** from #2016 (no new endpoint).

Refs #2016.

## Changes

- **`AuthenticateUser`** ([authentication endpoint](https://github.com/Altinn/altinn-authentication/blob/feat/stepup-unregistered-clients-2016/src/Authentication/Controllers/AuthenticationController.cs)) now accepts an optional `acr_values` query param, validated against the allowed set via `AuthenticationHelper.TryParseAcrValues`, and maps it into `AuthorizeUnregisteredClientRequest.AcrValues` (previously hardcoded empty).
- All three **session-reuse branches** (authenticated principal, Altinn session cookie, Altinn 2 ticket) now compare the existing session's ACR against the requested level via `NeedAcrUpgrade`. When an upgrade is needed they fall through to re-authenticate upstream at the higher level; otherwise behaviour is unchanged.
- Exposed `Acr` on `AuthenticateFromSessionResult` / `AuthenticateFromAltinn2TicketResult` so the controller can make the reuse-vs-upgrade decision.

The **upstream callback is unchanged**: it already deletes the prior session and creates a fresh one storing the new (higher) ACR, then redirects back to the goto URL.

## Behaviour

| Request | Existing session | Result |
|---|---|---|
| goto, no `acr_values` | any / none | unchanged (defaults to substantial when anonymous) |
| goto `acr_values=idporten-loa-high` | none | login at LoA-high |
| goto `acr_values=idporten-loa-high` | level 3 | **step-up** — re-auth upstream at LoA-high |
| goto `acr_values=idporten-loa-high` | level 4 | reuse, no upstream round-trip |
| invalid `acr_values` | — | `400 Bad Request` |

## Example usage for applications

An application triggers authentication (and optionally step-up) by redirecting the browser to the authentication endpoint with a URL-encoded `goTo` and the desired `acr_values`.

**Endpoint:** `GET {platform-host}/authentication/api/v1/authentication`

Host per environment, e.g. `https://platform.tt02.altinn.no` (TT02) or `https://platform.altinn.no` (production).

**Substantial — `idporten-loa-substantial` (level 3):**

```
https://platform.tt02.altinn.no/authentication/api/v1/authentication?goTo=https%3A%2F%2Fdigdir.apps.tt02.altinn.no%2Fdigdir%2Fmy-app&acr_values=idporten-loa-substantial
```

**High — `idporten-loa-high` (level 4):**

```
https://platform.tt02.altinn.no/authentication/api/v1/authentication?goTo=https%3A%2F%2Fdigdir.apps.tt02.altinn.no%2Fdigdir%2Fmy-app&acr_values=idporten-loa-high
```

Notes:
- `goTo` must be a URL-encoded absolute URL on an allowed host (validated as today).
- `acr_values` is space-separated and validated against the allowed set (`selfregistered-email`, `idporten-loa-substantial`, `idporten-loa-high`, `level0`, `level1`, `level2`); anything else → `400 Bad Request`. Encode the space as `%20` if requesting multiple values.
- **Only `idporten-loa-high` currently triggers a step-up from an existing lower-level session** (`NeedAcrUpgrade` compares against LoA-high). Requesting `idporten-loa-substantial` will authenticate an anonymous user at substantial, but will *not* upgrade an existing lower-level session — it is reused as-is.

## Tests

- **Unit**: `TryParseAcrValues` (valid / empty / rejected inputs) in `AuthenticationHelperTests`.
- **End-to-end**: `TC13_Auth_App_Level3_StepUp_Level4_Via_Goto_End_To_End_OK` in the ForceOidc front-channel suite — level-3 goto login → reuse without `acr_values` (regression guard) → step-up with `acr_values=idporten-loa-high` (asserts upstream redirect, acr sent as-is, no email widening) → upstream callback removes the old session and creates a fresh level-4 session.

## Verification status

- ✅ `Altinn.Platform.Authentication` and the test project build with **0 errors**.
- ✅ The `TryParseAcrValues` unit tests pass locally (11 cases).
- ⚠️ The end-to-end test could **not** be run locally — that suite uses the Postgres Testcontainers `DbFixture` which requires Docker, unavailable in the dev sandbox (fails at fixture construction with `DockerUnavailableException`). **CI must validate it.**

## Notes / open points

- Public contract uses OIDC-native `acr_values` (matches the registered flow and the existing `AuthorizeRequestValidator` allow-list). A friendly `securityLevel=4` alias could be added if preferred.
- On an A2-ticket step-up, `HandleAuthenticateFromTicket` creates a session as a side effect that is then discarded; it expires naturally. Confirmed acceptable (mirrors the registered OIDC flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for requesting specific authentication levels during authentication flows
  * Implemented step-up authentication to enforce higher security levels when required
  * Sessions now track and respect authentication context levels

* **Tests**
  * Added comprehensive test coverage for authentication level validation
  * Added end-to-end tests for step-up authentication scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->