### PR TITLE
feat: local SI-user credential validation + email for forgot-password (#2025)

### DIFF
--- a/scripts/si-credential-migration/01-generate-postgres-inserts.sql
+++ b/scripts/si-credential-migration/01-generate-postgres-inserts.sql
@@ -41,19 +41,22 @@
      AUTHN_UserProfile.password     -> password_hash   (Base64 SHA1, verbatim)
      AUTHN_UserProfile.salt         -> salt            (Base64, verbatim)
      AUTHN_UserProfile.passwordExpiry -> password_expiry (UTC -> ...Z)
+     AUTHN_UserProfile.email        -> email           (VARCHAR 400; NULL preserved as NULL;
+                                                         used by the forgot-password flow)
    ============================================================================ */
 
 SET NOCOUNT ON;
 
 SELECT
     'INSERT INTO oidcserver.selfidentified_user_credential '
-  + '(party_uuid, user_id, user_name, password_hash, salt, password_expiry, is_active, altinn2_user_id) VALUES ('
+  + '(party_uuid, user_id, user_name, password_hash, salt, password_expiry, email, is_active, altinn2_user_id) VALUES ('
   + '''' + LOWER(CONVERT(varchar(36), up.UserUUID_AK)) + ''', '
   + CONVERT(varchar(20), up.uid) + ', '
   + '''' + REPLACE(up.username, '''', '''''') + ''', '
   + '''' + REPLACE(up.password, '''', '''''') + ''', '
   + '''' + REPLACE(up.salt,     '''', '''''') + ''', '
   + '''' + CONVERT(varchar(23), up.passwordExpiry, 126) + 'Z'', '
+  + CASE WHEN up.email IS NULL THEN 'NULL' ELSE '''' + REPLACE(up.email, '''', '''''') + '''' END + ', '
   + 'TRUE, '
   + CONVERT(varchar(20), up.uid)
   + ') ON CONFLICT (user_id) DO NOTHING;'  AS pg_insert

--- a/scripts/si-credential-migration/01-generate-postgres-inserts.sql
+++ b/scripts/si-credential-migration/01-generate-postgres-inserts.sql
@@ -1,0 +1,69 @@
+/* ============================================================================
+   Manual SI-user credential migration  —  Altinn 2 (SQL Server)  ->  Altinn 3 (Postgres)
+   Issue: #2025
+
+   WHAT THIS DOES
+   --------------
+   Run this query against the Altinn 2 SQL Server [AuthenticationDB]. Each output
+   row is a complete Postgres INSERT statement for
+   oidcserver.selfidentified_user_credential. Save the result set as text and run
+   it against the Altinn 3 Postgres database.
+
+   This is a *generator*: it does not modify any data. It only SELECTs and emits text.
+
+   HOW TO RUN (SSMS)
+   -----------------
+   1. Query > Results To > Results to Text            (Ctrl+T)
+   2. Tools > Options > Query Results > SQL Server > Results to Text:
+        - Maximum number of characters displayed in each column = 8192
+   3. Query > Query Options > Results > Text:
+        - Uncheck "Include column headers in the result set"
+   4. Execute, then copy the output into a .sql file (e.g. inserts.generated.sql).
+   5. Run that file against Postgres (psql -f inserts.generated.sql).
+
+   IDEMPOTENCY
+   -----------
+   Generated statements use ON CONFLICT (user_id) DO NOTHING, so re-running the
+   import will not error on rows that already exist.
+
+   FILTER (matches issue #2025 / #2007 task C):
+     - UserTypeID = 2   -> self-identified only (NOT 1=SSN, NOT 3=enterprise)
+     - statusId   = 1   -> active users only
+     - username/password/salt present
+   Remove the passwordExpiry filter intentionally: expired rows are imported and
+   the expiry policy is enforced in Altinn 3 (see issue "Open decisions").
+
+   COLUMN MAPPING
+   --------------
+     AUTHN_UserProfile.UserUUID_AK  -> party_uuid
+     AUTHN_UserProfile.uid          -> user_id  AND  altinn2_user_id
+     AUTHN_UserProfile.username     -> user_name
+     AUTHN_UserProfile.password     -> password_hash   (Base64 SHA1, verbatim)
+     AUTHN_UserProfile.salt         -> salt            (Base64, verbatim)
+     AUTHN_UserProfile.passwordExpiry -> password_expiry (UTC -> ...Z)
+   ============================================================================ */
+
+SET NOCOUNT ON;
+
+SELECT
+    'INSERT INTO oidcserver.selfidentified_user_credential '
+  + '(party_uuid, user_id, user_name, password_hash, salt, password_expiry, is_active, altinn2_user_id) VALUES ('
+  + '''' + LOWER(CONVERT(varchar(36), up.UserUUID_AK)) + ''', '
+  + CONVERT(varchar(20), up.uid) + ', '
+  + '''' + REPLACE(up.username, '''', '''''') + ''', '
+  + '''' + REPLACE(up.password, '''', '''''') + ''', '
+  + '''' + REPLACE(up.salt,     '''', '''''') + ''', '
+  + '''' + CONVERT(varchar(23), up.passwordExpiry, 126) + 'Z'', '
+  + 'TRUE, '
+  + CONVERT(varchar(20), up.uid)
+  + ') ON CONFLICT (user_id) DO NOTHING;'  AS pg_insert
+FROM
+    [AuthenticationDB].[dbo].[AUTHN_UserProfile] AS up
+WHERE
+    up.UserTypeID = 2
+    AND up.statusId = 1
+    AND up.username IS NOT NULL
+    AND up.password IS NOT NULL
+    AND up.salt IS NOT NULL
+ORDER BY
+    up.uid;

--- a/scripts/si-credential-migration/02-verify-after-import.sql
+++ b/scripts/si-credential-migration/02-verify-after-import.sql
@@ -1,0 +1,21 @@
+-- Run against Altinn 3 Postgres after importing the generated INSERTs (issue #2025).
+
+-- Row count imported
+SELECT count(*) AS imported_rows
+FROM oidcserver.selfidentified_user_credential;
+
+-- Duplicate usernames (must be 0 — uq_si_user_credential_username also guards this)
+SELECT user_name, count(*)
+FROM oidcserver.selfidentified_user_credential
+GROUP BY user_name
+HAVING count(*) > 1;
+
+-- Already-expired passwords at import time (input for the expiry-policy decision)
+SELECT count(*) AS expired_rows
+FROM oidcserver.selfidentified_user_credential
+WHERE password_expiry < now();
+
+-- Sanity: rows with empty credential fields (must be 0)
+SELECT count(*) AS bad_rows
+FROM oidcserver.selfidentified_user_credential
+WHERE coalesce(password_hash, '') = '' OR coalesce(salt, '') = '';

--- a/scripts/si-credential-migration/02-verify-after-import.sql
+++ b/scripts/si-credential-migration/02-verify-after-import.sql
@@ -19,3 +19,8 @@ WHERE password_expiry < now();
 SELECT count(*) AS bad_rows
 FROM oidcserver.selfidentified_user_credential
 WHERE coalesce(password_hash, '') = '' OR coalesce(salt, '') = '';
+
+-- Forgot-password readiness: how many users lack an email (cannot receive reset info)
+SELECT count(*) AS rows_without_email
+FROM oidcserver.selfidentified_user_credential
+WHERE coalesce(email, '') = '';

--- a/scripts/si-credential-migration/README.md
+++ b/scripts/si-credential-migration/README.md
@@ -25,3 +25,4 @@ One-off manual data migration of self-identified (SI) user credentials. Tracked 
 - Only `UserTypeID = 2` (self-identified), `statusId = 1` (active) rows are exported — SSN (`1`) and enterprise (`3`) users are excluded.
 - `password_hash` and `salt` are copied **verbatim** (Base64). Altinn 3 re-runs the same SHA1+salt verification — no password reset required.
 - `passwordExpiry` is emitted as UTC ISO-8601 with a trailing `Z`. Confirm the source column is stored in UTC before importing.
+- `email` (source `AUTHN_UserProfile.email`, VARCHAR 400) is exported for the **forgot-password** flow — Altinn 3 emails reset info to this address; it does **not** generate a new password. `NULL` emails are preserved as `NULL`; the verify script counts how many users lack an email. The actual reset-ticket/flow (Altinn 2 `AUTHN_PasswordResetTicket`) is a separate runtime feature, not part of this data migration.

--- a/scripts/si-credential-migration/README.md
+++ b/scripts/si-credential-migration/README.md
@@ -1,0 +1,27 @@
+# SI-user credential migration (Altinn 2 → Altinn 3)
+
+One-off manual data migration of self-identified (SI) user credentials. Tracked in issue #2025.
+
+- **Source:** Altinn 2 SQL Server, `[AuthenticationDB].[dbo].[AUTHN_UserProfile]`
+- **Target:** Altinn 3 Postgres, `oidcserver.selfidentified_user_credential`
+  (created by migration `src/Persistance/Migration/v0.27/`)
+
+## Procedure
+
+1. **Create the target table** — apply migration `v0.27` to the Altinn 3 Postgres database (runs automatically with the normal migration flow).
+
+2. **Generate the inserts** — run [`01-generate-postgres-inserts.sql`](01-generate-postgres-inserts.sql) against the Altinn 2 SQL Server. Follow the SSMS output settings in the file header (Results to Text, 8192 char column width, no column headers). Save the output as `inserts.generated.sql`.
+
+3. **Import** — run the generated file against Postgres:
+   ```
+   psql -h <host> -d <db> -U <user> -f inserts.generated.sql
+   ```
+   Statements use `ON CONFLICT (user_id) DO NOTHING`, so the import is re-runnable.
+
+4. **Verify** — run [`02-verify-after-import.sql`](02-verify-after-import.sql) against Postgres and check: row count matches the source, no duplicate usernames, no empty credential fields. The expired-password count feeds the expiry-policy decision in #2025.
+
+## Notes
+
+- Only `UserTypeID = 2` (self-identified), `statusId = 1` (active) rows are exported — SSN (`1`) and enterprise (`3`) users are excluded.
+- `password_hash` and `salt` are copied **verbatim** (Base64). Altinn 3 re-runs the same SHA1+salt verification — no password reset required.
+- `passwordExpiry` is emitted as UTC ISO-8601 with a trailing `Z`. Confirm the source column is stored in UTC before importing.

--- a/src/Authentication/Configuration/FeatureFlags.cs
+++ b/src/Authentication/Configuration/FeatureFlags.cs
@@ -24,6 +24,15 @@
         public const string RegisterSelfIdentifiedUserProvisioning = "RegisterSelfIdentifiedUserProvisioning";
 
         /// <summary>
+        /// When enabled, self-identified (SI) user credential validation is performed locally
+        /// against <c>oidcserver.selfidentified_user_credential</c> (SHA1 + salt) instead of
+        /// calling SBL Bridge (<c>POST authentication/api/siuser</c>). Lets the flag be flipped
+        /// per environment once the migrated credentials are imported. Tracked in issue #2025
+        /// (SBL Bridge decommission, deadline 2026-06-19).
+        /// </summary>
+        public const string LocalSelfIdentifiedCredentialValidation = "LocalSelfIdentifiedCredentialValidation";
+
+        /// <summary>
         /// When enabled, disables the cookie ticket decryption path (SBL Bridge
         /// <c>POST authentication/api/tickets</c>). No replacement exists; the A2 cookie→token
         /// flow will be removed entirely after the SBL Bridge decommission (deadline 2026-06-19).

--- a/src/Authentication/Services/Interfaces/IUserProfileService.cs
+++ b/src/Authentication/Services/Interfaces/IUserProfileService.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Platform.Authentication.Core.Models.Profile;
 
@@ -26,5 +27,13 @@ namespace Altinn.Platform.Authentication.Services.Interfaces
         /// Endpoints that lookup a user based on username and password. This is used for validating credentials when using basic authentication.
         /// </summary>
         Task<UserCredentialVerificationResult> ValidateCredentialsAsync(string username, string password);
+
+        /// <summary>
+        /// Gets the stored email for a self-identified user, used by the forgot-password flow to send
+        /// reset information. Returns <c>null</c> when the user is unknown or has no email on file.
+        /// </summary>
+        /// <param name="username">The self-identified user's username (login key).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task<string> GetSelfIdentifiedUserEmailAsync(string username, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Authentication/Services/UserProfileService.cs
+++ b/src/Authentication/Services/UserProfileService.cs
@@ -1,14 +1,19 @@
 using System;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Altinn.Platform.Authentication.Configuration;
 using Altinn.Platform.Authentication.Core.Models.Profile;
+using Altinn.Platform.Authentication.Core.Models.Profile.Enums;
+using Altinn.Platform.Authentication.Core.RepositoryInterfaces;
 using Altinn.Platform.Authentication.Services.Interfaces;
+using Altinn.Register.Contracts.V1;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement;
 
 namespace Altinn.Platform.Authentication.Services
 {
@@ -20,6 +25,8 @@ namespace Altinn.Platform.Authentication.Services
         private readonly GeneralSettings _settings;
         private readonly HttpClient _client;
         private readonly ILogger _logger;
+        private readonly IFeatureManager _featureManager;
+        private readonly ISelfIdentifiedUserCredentialRepository _selfIdentifiedUserCredentialRepository;
 
         /// <summary>
         /// Initialize a new instance of <see cref="UserProfileService"/> with settings for SBL Bridge endpoints.
@@ -27,11 +34,20 @@ namespace Altinn.Platform.Authentication.Services
         /// <param name="httpClient">Httpclient from httpclientfactory</param>
         /// <param name="settings">General settings for the authentication application</param>
         /// <param name="logger">A generic logger</param>
-        public UserProfileService(HttpClient httpClient, IOptions<GeneralSettings> settings, ILogger<IUserProfileService> logger)
+        /// <param name="featureManager">Feature manager used to switch SI credential validation to the local database</param>
+        /// <param name="selfIdentifiedUserCredentialRepository">Repository for locally stored SI credentials</param>
+        public UserProfileService(
+            HttpClient httpClient,
+            IOptions<GeneralSettings> settings,
+            ILogger<IUserProfileService> logger,
+            IFeatureManager featureManager,
+            ISelfIdentifiedUserCredentialRepository selfIdentifiedUserCredentialRepository)
         {
             _client = httpClient;
             _settings = settings.Value;
             _logger = logger;
+            _featureManager = featureManager;
+            _selfIdentifiedUserCredentialRepository = selfIdentifiedUserCredentialRepository;
         }
 
         /// <inheritdoc/>
@@ -81,11 +97,19 @@ namespace Altinn.Platform.Authentication.Services
         }
 
         /// <summary>
-        /// Validates a self identified user's credentials against the SBL Bridge authentication API
-        /// (<c>authentication/api/siuser</c>), and returns the user profile when the credentials are valid.
+        /// Validates a self identified user's credentials. When the
+        /// <see cref="FeatureFlags.LocalSelfIdentifiedCredentialValidation"/> flag is enabled the
+        /// check is performed locally against <c>oidcserver.selfidentified_user_credential</c>
+        /// (SHA1 + salt); otherwise it is delegated to the SBL Bridge authentication API
+        /// (<c>authentication/api/siuser</c>). On success the user profile is returned.
         /// </summary>
         public async Task<UserCredentialVerificationResult> ValidateCredentialsAsync(string username, string password)
         {
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.LocalSelfIdentifiedCredentialValidation))
+            {
+                return await ValidateCredentialsLocallyAsync(username, password);
+            }
+
             UserProfile identifedProfile = null;
 
             SiUserCredentials credentials = new SiUserCredentials()
@@ -131,9 +155,81 @@ namespace Altinn.Platform.Authentication.Services
             }
 
             UserCredentialVerificationResult result = new UserCredentialVerificationResult();
-            result.UserProfile = identifedProfile; 
+            result.UserProfile = identifedProfile;
 
             return result;
+        }
+
+        /// <summary>
+        /// Validates SI credentials against the locally migrated credentials in
+        /// <c>oidcserver.selfidentified_user_credential</c>. Mirrors the contract of the SBL Bridge
+        /// path: returns an empty result for unknown/invalid credentials (so the controller answers
+        /// 401) and a populated <see cref="UserProfile"/> on success.
+        /// </summary>
+        /// <remarks>
+        /// Lockout/throttling and the expired-password policy are not yet enforced here - both are
+        /// tracked as open items in issue #2025. The username must never be logged.
+        /// </remarks>
+        private async Task<UserCredentialVerificationResult> ValidateCredentialsLocallyAsync(string username, string password)
+        {
+            if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
+            {
+                return new UserCredentialVerificationResult();
+            }
+
+            SelfIdentifiedUserCredential credential = await _selfIdentifiedUserCredentialRepository.GetByUsernameAsync(username);
+
+            if (credential is null || !credential.IsActive || !VerifyAltinn2Password(password, credential.PasswordHash, credential.Salt))
+            {
+                return new UserCredentialVerificationResult();
+            }
+
+            return new UserCredentialVerificationResult
+            {
+                UserProfile = new UserProfile
+                {
+                    UserId = credential.UserId,
+                    UserUuid = credential.PartyUuid,
+                    UserName = credential.UserName,
+                    UserType = UserType.SelfIdentified,
+                    Party = new Party { PartyUuid = credential.PartyUuid }
+                }
+            };
+        }
+
+        /// <summary>
+        /// Verifies a plaintext password against an Altinn 2 SHA1 hash and salt, using the same
+        /// algorithm as Altinn 2: <c>Base64( SHA1( UTF8(password) || Base64Decode(salt) ) )</c>.
+        /// Uses a fixed-time comparison to avoid timing attacks.
+        /// </summary>
+        private static bool VerifyAltinn2Password(string plaintext, string storedHash, string storedSalt)
+        {
+            if (string.IsNullOrEmpty(storedHash) || string.IsNullOrEmpty(storedSalt))
+            {
+                return false;
+            }
+
+            byte[] saltBytes;
+            try
+            {
+                saltBytes = Convert.FromBase64String(storedSalt);
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+
+            byte[] plaintextBytes = Encoding.UTF8.GetBytes(plaintext);
+            byte[] combined = new byte[plaintextBytes.Length + saltBytes.Length];
+            Buffer.BlockCopy(plaintextBytes, 0, combined, 0, plaintextBytes.Length);
+            Buffer.BlockCopy(saltBytes, 0, combined, plaintextBytes.Length, saltBytes.Length);
+
+            byte[] hashBytes = SHA1.HashData(combined);
+            string computed = Convert.ToBase64String(hashBytes);
+
+            return CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(computed),
+                Encoding.UTF8.GetBytes(storedHash));
         }
     }
 }

--- a/src/Authentication/Services/UserProfileService.cs
+++ b/src/Authentication/Services/UserProfileService.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Platform.Authentication.Configuration;
 using Altinn.Platform.Authentication.Core.Models.Profile;
@@ -195,6 +196,20 @@ namespace Altinn.Platform.Authentication.Services
                     Party = new Party { PartyUuid = credential.PartyUuid }
                 }
             };
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> GetSelfIdentifiedUserEmailAsync(string username, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(username))
+            {
+                return null;
+            }
+
+            SelfIdentifiedUserCredential credential =
+                await _selfIdentifiedUserCredentialRepository.GetByUsernameAsync(username, cancellationToken);
+
+            return credential?.Email;
         }
 
         /// <summary>

--- a/src/Authentication/appsettings.json
+++ b/src/Authentication/appsettings.json
@@ -65,6 +65,7 @@
     "AuditLog": false,
     "SystemUser": true,
     "RegisterSelfIdentifiedUserProvisioning": false,
+    "LocalSelfIdentifiedCredentialValidation": false,
     "CookieTicketDecryptionDisabled": false,
     "EnterpriseUserAuthenticationDisabled": false,
     "Altinn2LogoutRedirectDisabled": false

--- a/src/Core/Models/Profile/SelfIdentifiedUserCredential.cs
+++ b/src/Core/Models/Profile/SelfIdentifiedUserCredential.cs
@@ -1,0 +1,55 @@
+namespace Altinn.Platform.Authentication.Core.Models.Profile
+{
+    /// <summary>
+    /// A self-identified (SI) user credential migrated from Altinn 2, stored in
+    /// <c>oidcserver.selfidentified_user_credential</c>. Used to validate SI logins locally
+    /// (SHA1 + salt) instead of calling SBL Bridge (<c>authentication/api/siuser</c>). See issue #2025.
+    /// </summary>
+    public class SelfIdentifiedUserCredential
+    {
+        /// <summary>
+        /// Gets or sets the Altinn 3 party UUID of the user. Returned on successful validation.
+        /// </summary>
+        public Guid PartyUuid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the legacy user id (matches <c>oidc_session.subject_user_id</c>).
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the username (login key, matches <c>oidc_session.subject_user_name</c>).
+        /// </summary>
+        public string UserName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Base64-encoded SHA1 password hash, copied verbatim from Altinn 2.
+        /// </summary>
+        public string PasswordHash { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Base64-encoded salt, copied verbatim from Altinn 2.
+        /// </summary>
+        public string Salt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password expiry timestamp.
+        /// </summary>
+        public DateTimeOffset PasswordExpiry { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the credential is active.
+        /// </summary>
+        public bool IsActive { get; set; }
+
+        /// <summary>
+        /// Gets or sets the source Altinn 2 user id (<c>AUTHN_UserProfile.uid</c>), for traceability.
+        /// </summary>
+        public int? Altinn2UserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timestamp the row was imported into Altinn 3.
+        /// </summary>
+        public DateTimeOffset ImportedAt { get; set; }
+    }
+}

--- a/src/Core/Models/Profile/SelfIdentifiedUserCredential.cs
+++ b/src/Core/Models/Profile/SelfIdentifiedUserCredential.cs
@@ -38,6 +38,12 @@ namespace Altinn.Platform.Authentication.Core.Models.Profile
         public DateTimeOffset PasswordExpiry { get; set; }
 
         /// <summary>
+        /// Gets or sets the user's email address (source: <c>AUTHN_UserProfile.email</c>). Used by the
+        /// forgot-password flow to send reset information; no new password is generated. May be null.
+        /// </summary>
+        public string? Email { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the credential is active.
         /// </summary>
         public bool IsActive { get; set; }

--- a/src/Core/RepositoryInterfaces/ISelfIdentifiedUserCredentialRepository.cs
+++ b/src/Core/RepositoryInterfaces/ISelfIdentifiedUserCredentialRepository.cs
@@ -1,0 +1,19 @@
+using Altinn.Platform.Authentication.Core.Models.Profile;
+
+namespace Altinn.Platform.Authentication.Core.RepositoryInterfaces
+{
+    /// <summary>
+    /// Reads self-identified (SI) user credentials migrated from Altinn 2, used to validate SI
+    /// logins locally instead of via SBL Bridge. See issue #2025.
+    /// </summary>
+    public interface ISelfIdentifiedUserCredentialRepository
+    {
+        /// <summary>
+        /// Gets the stored credential for the given username, or <c>null</c> if no such user exists.
+        /// The match is case-insensitive to mirror Altinn 2 login behaviour. Returns the row
+        /// regardless of <see cref="SelfIdentifiedUserCredential.IsActive"/> / expiry so the caller
+        /// can apply policy and distinguish "no user" from "locked / expired".
+        /// </summary>
+        Task<SelfIdentifiedUserCredential?> GetByUsernameAsync(string userName, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Persistance/Extensions/PersistanceDependencyInjection.cs
+++ b/src/Persistance/Extensions/PersistanceDependencyInjection.cs
@@ -46,6 +46,7 @@ public static class PersistanceDependencyInjection
         AddAuthorizationCodeRepository(services);
         AddRefreshTokenRepository(services);
         AddUnregisteredClientRequestRepository(services);
+        AddSelfIdentifiedUserCredentialRepository(services);
         return builder;
     }
 
@@ -132,6 +133,11 @@ public static class PersistanceDependencyInjection
     private static void AddOidcSessionRepository(this IServiceCollection services)
     {
         services.TryAddTransient<IOidcSessionRepository, OidcSessionRepository>();
+    }
+
+    private static void AddSelfIdentifiedUserCredentialRepository(this IServiceCollection services)
+    {
+        services.TryAddTransient<ISelfIdentifiedUserCredentialRepository, SelfIdentifiedUserCredentialRepository>();
     }
 
     /// <summary>

--- a/src/Persistance/Migration/v0.27/01-setup-selfidentified_user_credential-table.sql
+++ b/src/Persistance/Migration/v0.27/01-setup-selfidentified_user_credential-table.sql
@@ -1,0 +1,27 @@
+-- Table: oidcserver.selfidentified_user_credential
+-- Holds Altinn 2 self-identified (SI) user credentials migrated into Altinn 3, so SI
+-- logins can be validated locally (SHA1 + salt) instead of via SBL Bridge (authentication/api/siuser).
+-- See issue #2025.
+
+CREATE TABLE IF NOT EXISTS oidcserver.selfidentified_user_credential (
+    -- Altinn 3 identity (returned by ValidateCredentials, used to mint the token)
+    party_uuid       UUID         NOT NULL,
+    user_id          INTEGER      NOT NULL,   -- legacy, == oidc_session.subject_user_id
+    user_name        TEXT         NOT NULL,   -- == oidc_session.subject_user_name; login key
+
+    -- Credentials, copied verbatim from Altinn 2 (no reset required)
+    password_hash    TEXT         NOT NULL,   -- Base64 SHA1
+    salt             TEXT         NOT NULL,   -- Base64
+    password_expiry  TIMESTAMPTZ  NOT NULL,
+
+    -- Status / bookkeeping
+    is_active        BOOLEAN      NOT NULL DEFAULT TRUE,
+    altinn2_user_id  INTEGER      NULL,       -- source ref for traceability (AUTHN_UserProfile.uid)
+    imported_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT pk_si_user_credential PRIMARY KEY (user_id),
+    CONSTRAINT uq_si_user_credential_username UNIQUE (user_name)
+);
+
+CREATE INDEX IF NOT EXISTS ix_si_user_credential_party_uuid
+    ON oidcserver.selfidentified_user_credential (party_uuid);

--- a/src/Persistance/Migration/v0.27/01-setup-selfidentified_user_credential-table.sql
+++ b/src/Persistance/Migration/v0.27/01-setup-selfidentified_user_credential-table.sql
@@ -14,6 +14,10 @@ CREATE TABLE IF NOT EXISTS oidcserver.selfidentified_user_credential (
     salt             TEXT         NOT NULL,   -- Base64
     password_expiry  TIMESTAMPTZ  NOT NULL,
 
+    -- Contact, for the "forgot password" flow (send reset info by email; no auto-generated password).
+    -- Source: AUTHN_UserProfile.email (VARCHAR 400). Nullable - not every SI user has an email.
+    email            TEXT         NULL,
+
     -- Status / bookkeeping
     is_active        BOOLEAN      NOT NULL DEFAULT TRUE,
     altinn2_user_id  INTEGER      NULL,       -- source ref for traceability (AUTHN_UserProfile.uid)

--- a/src/Persistance/Migration/v0.27/02-re-grants.sql
+++ b/src/Persistance/Migration/v0.27/02-re-grants.sql
@@ -1,0 +1,3 @@
+GRANT USAGE ON SCHEMA oidcserver TO auth_authentication;
+GRANT SELECT,INSERT,UPDATE,REFERENCES,DELETE ON ALL TABLES IN SCHEMA oidcserver TO auth_authentication;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA oidcserver TO auth_authentication;

--- a/src/Persistance/RepositoryImplementations/OidcServer/SelfIdentifiedUserCredentialRepository.cs
+++ b/src/Persistance/RepositoryImplementations/OidcServer/SelfIdentifiedUserCredentialRepository.cs
@@ -1,0 +1,62 @@
+using System.Data;
+using Altinn.Authorization.ServiceDefaults.Npgsql;
+using Altinn.Platform.Authentication.Core.Models.Profile;
+using Altinn.Platform.Authentication.Core.RepositoryInterfaces;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+
+namespace Altinn.Platform.Authentication.Persistance.RepositoryImplementations.OidcServer;
+
+/// <summary>
+/// Repository for reading migrated self-identified (SI) user credentials. See issue #2025.
+/// </summary>
+public sealed class SelfIdentifiedUserCredentialRepository(NpgsqlDataSource ds, ILogger<SelfIdentifiedUserCredentialRepository> logger) : ISelfIdentifiedUserCredentialRepository
+{
+    private readonly NpgsqlDataSource _ds = ds;
+    private readonly ILogger<SelfIdentifiedUserCredentialRepository> _logger = logger;
+
+    /// <inheritdoc/>
+    public async Task<SelfIdentifiedUserCredential?> GetByUsernameAsync(string userName, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(userName))
+        {
+            return null;
+        }
+
+        // Case-insensitive match mirrors Altinn 2 login behaviour. A lower(user_name) functional
+        // index can be added if lookup volume warrants it.
+        const string SQL = /*strpsql*/ @"
+            SELECT party_uuid, user_id, user_name, password_hash, salt, password_expiry,
+                   is_active, altinn2_user_id, imported_at
+              FROM oidcserver.selfidentified_user_credential
+             WHERE lower(user_name) = lower(@user_name)
+             LIMIT 1;";
+
+        await using var cmd = _ds.CreateCommand(SQL);
+        cmd.Parameters.AddWithValue("user_name", userName);
+
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        return Map(reader);
+    }
+
+    private static SelfIdentifiedUserCredential Map(NpgsqlDataReader r)
+    {
+        return new SelfIdentifiedUserCredential
+        {
+            PartyUuid = r.GetFieldValue<Guid>("party_uuid"),
+            UserId = r.GetFieldValue<int>("user_id"),
+            UserName = r.GetFieldValue<string>("user_name"),
+            PasswordHash = r.GetFieldValue<string>("password_hash"),
+            Salt = r.GetFieldValue<string>("salt"),
+            PasswordExpiry = r.GetFieldValue<DateTimeOffset>("password_expiry"),
+            IsActive = r.GetFieldValue<bool>("is_active"),
+            Altinn2UserId = r.IsDBNull("altinn2_user_id") ? null : r.GetFieldValue<int?>("altinn2_user_id"),
+            ImportedAt = r.GetFieldValue<DateTimeOffset>("imported_at")
+        };
+    }
+}

--- a/src/Persistance/RepositoryImplementations/OidcServer/SelfIdentifiedUserCredentialRepository.cs
+++ b/src/Persistance/RepositoryImplementations/OidcServer/SelfIdentifiedUserCredentialRepository.cs
@@ -27,7 +27,7 @@ public sealed class SelfIdentifiedUserCredentialRepository(NpgsqlDataSource ds, 
         // index can be added if lookup volume warrants it.
         const string SQL = /*strpsql*/ @"
             SELECT party_uuid, user_id, user_name, password_hash, salt, password_expiry,
-                   is_active, altinn2_user_id, imported_at
+                   email, is_active, altinn2_user_id, imported_at
               FROM oidcserver.selfidentified_user_credential
              WHERE lower(user_name) = lower(@user_name)
              LIMIT 1;";
@@ -54,6 +54,7 @@ public sealed class SelfIdentifiedUserCredentialRepository(NpgsqlDataSource ds, 
             PasswordHash = r.GetFieldValue<string>("password_hash"),
             Salt = r.GetFieldValue<string>("salt"),
             PasswordExpiry = r.GetFieldValue<DateTimeOffset>("password_expiry"),
+            Email = r.IsDBNull("email") ? null : r.GetFieldValue<string>("email"),
             IsActive = r.GetFieldValue<bool>("is_active"),
             Altinn2UserId = r.IsDBNull("altinn2_user_id") ? null : r.GetFieldValue<int?>("altinn2_user_id"),
             ImportedAt = r.GetFieldValue<DateTimeOffset>("imported_at")

--- a/test/Altinn.Platform.Authentication.Tests/Services/UserProfileServiceLocalSiTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Services/UserProfileServiceLocalSiTests.cs
@@ -105,6 +105,39 @@ public class UserProfileServiceLocalSiTests
         _repo.Verify(r => r.GetByUsernameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Fact]
+    public async Task GetSelfIdentifiedUserEmail_ReturnsStoredEmail()
+    {
+        SelfIdentifiedUserCredential credential = Credential();
+        credential.Email = "user@example.com";
+        _repo.Setup(r => r.GetByUsernameAsync("user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(credential);
+
+        string email = await CreateService().GetSelfIdentifiedUserEmailAsync("user");
+
+        Assert.Equal("user@example.com", email);
+    }
+
+    [Fact]
+    public async Task GetSelfIdentifiedUserEmail_UnknownUser_ReturnsNull()
+    {
+        _repo.Setup(r => r.GetByUsernameAsync("nobody", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SelfIdentifiedUserCredential?)null);
+
+        string email = await CreateService().GetSelfIdentifiedUserEmailAsync("nobody");
+
+        Assert.Null(email);
+    }
+
+    [Fact]
+    public async Task GetSelfIdentifiedUserEmail_EmptyInput_ReturnsNullWithoutRepoLookup()
+    {
+        string email = await CreateService().GetSelfIdentifiedUserEmailAsync(string.Empty);
+
+        Assert.Null(email);
+        _repo.Verify(r => r.GetByUsernameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     private static SelfIdentifiedUserCredential Credential() => new()
     {
         PartyUuid = PartyUuid,

--- a/test/Altinn.Platform.Authentication.Tests/Services/UserProfileServiceLocalSiTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Services/UserProfileServiceLocalSiTests.cs
@@ -1,0 +1,138 @@
+#nullable enable
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Altinn.Platform.Authentication.Configuration;
+using Altinn.Platform.Authentication.Core.Models.Profile;
+using Altinn.Platform.Authentication.Core.Models.Profile.Enums;
+using Altinn.Platform.Authentication.Core.RepositoryInterfaces;
+using Altinn.Platform.Authentication.Services;
+using Altinn.Platform.Authentication.Services.Interfaces;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement;
+using Moq;
+using Xunit;
+
+namespace Altinn.Platform.Authentication.Tests.Services;
+
+/// <summary>
+/// Unit tests for the local self-identified credential validation path in
+/// <see cref="UserProfileService"/> (feature flag
+/// <see cref="FeatureFlags.LocalSelfIdentifiedCredentialValidation"/> enabled). These tests do not
+/// require Docker - they exercise the service directly with mocks and a throwing HTTP handler that
+/// guarantees the SBL Bridge is never contacted on the local path.
+/// </summary>
+public class UserProfileServiceLocalSiTests
+{
+    // Independently computed vector: Base64( SHA1( UTF8("P@ssw0rd!") || Base64Decode(salt) ) ).
+    private const string Password = "P@ssw0rd!";
+    private const string Salt = "AQIDBAUGBwgJCgsM";
+    private const string PasswordHash = "YwOo/PvLMkNE37TEnEo3xxQs/qk=";
+
+    private static readonly Guid PartyUuid = Guid.Parse("2c3bb12a-5e41-4cc9-9a36-7b5ac6f9f102");
+
+    private readonly Mock<ISelfIdentifiedUserCredentialRepository> _repo = new();
+    private readonly Mock<IFeatureManager> _featureManager = new();
+
+    public UserProfileServiceLocalSiTests()
+    {
+        _featureManager
+            .Setup(f => f.IsEnabledAsync(FeatureFlags.LocalSelfIdentifiedCredentialValidation))
+            .ReturnsAsync(true);
+    }
+
+    [Fact]
+    public async Task ValidateCredentials_Local_ValidCredentials_ReturnsProfileWithPartyUuid()
+    {
+        _repo.Setup(r => r.GetByUsernameAsync("user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Credential());
+
+        UserCredentialVerificationResult result = await CreateService().ValidateCredentialsAsync("user", Password);
+
+        Assert.False(result.IsLocked);
+        Assert.False(result.WrongUserType);
+        Assert.NotNull(result.UserProfile);
+        Assert.Equal(PartyUuid, result.UserProfile!.Party.PartyUuid);
+        Assert.Equal(PartyUuid, result.UserProfile.UserUuid);
+        Assert.Equal(UserType.SelfIdentified, result.UserProfile.UserType);
+        Assert.Equal(1337, result.UserProfile.UserId);
+    }
+
+    [Fact]
+    public async Task ValidateCredentials_Local_WrongPassword_ReturnsEmptyResult()
+    {
+        _repo.Setup(r => r.GetByUsernameAsync("user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Credential());
+
+        UserCredentialVerificationResult result = await CreateService().ValidateCredentialsAsync("user", "wrong-password");
+
+        Assert.Null(result.UserProfile);
+        Assert.False(result.IsLocked);
+    }
+
+    [Fact]
+    public async Task ValidateCredentials_Local_InactiveUser_ReturnsEmptyResult()
+    {
+        SelfIdentifiedUserCredential credential = Credential();
+        credential.IsActive = false;
+        _repo.Setup(r => r.GetByUsernameAsync("user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(credential);
+
+        UserCredentialVerificationResult result = await CreateService().ValidateCredentialsAsync("user", Password);
+
+        Assert.Null(result.UserProfile);
+    }
+
+    [Fact]
+    public async Task ValidateCredentials_Local_UnknownUser_ReturnsEmptyResult()
+    {
+        _repo.Setup(r => r.GetByUsernameAsync("nobody", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SelfIdentifiedUserCredential?)null);
+
+        UserCredentialVerificationResult result = await CreateService().ValidateCredentialsAsync("nobody", Password);
+
+        Assert.Null(result.UserProfile);
+    }
+
+    [Fact]
+    public async Task ValidateCredentials_Local_EmptyInput_ReturnsEmptyResult()
+    {
+        UserCredentialVerificationResult result = await CreateService().ValidateCredentialsAsync(string.Empty, string.Empty);
+
+        Assert.Null(result.UserProfile);
+        _repo.Verify(r => r.GetByUsernameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static SelfIdentifiedUserCredential Credential() => new()
+    {
+        PartyUuid = PartyUuid,
+        UserId = 1337,
+        UserName = "user",
+        PasswordHash = PasswordHash,
+        Salt = Salt,
+        PasswordExpiry = DateTimeOffset.MaxValue,
+        IsActive = true
+    };
+
+    private UserProfileService CreateService()
+    {
+        // A handler that throws if invoked - the local path must never call SBL Bridge.
+        HttpClient client = new(new ThrowingHandler());
+        IOptions<GeneralSettings> settings = Options.Create(new GeneralSettings { OidcRefreshTokenPepper = "unit-test-pepper" });
+
+        return new UserProfileService(
+            client,
+            settings,
+            NullLogger<IUserProfileService>.Instance,
+            _featureManager.Object,
+            _repo.Object);
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("HTTP call should not happen on the local validation path.");
+    }
+}


### PR DESCRIPTION
## Summary

Persist Altinn 2 **self-identified (SI) user** credentials in Altinn 3 and validate SI logins **locally** (SHA1 + salt) instead of calling SBL Bridge (`authentication/api/siuser`), ahead of the SBL Bridge decommission (deadline **2026-06-19**). This is the local replacement for SI-user credential validation flagged as task C in #2007.

Also exports and stores the user's **email** so the **forgot-password** flow can send reset information (no auto-generated password).

Switching login validation to the local table is gated by a feature flag (`LocalSelfIdentifiedCredentialValidation`, default **off**) so it can be flipped per environment once the migrated credentials are imported.

Closes #2025.

## Changes

**Schema**
- Migration `v0.27`: `oidcserver.selfidentified_user_credential` table + grants (auto-discovered by Yuniql). Columns: identity mapping (`party_uuid`, legacy `user_id`/`user_name`), credentials (`password_hash`, `salt`, `password_expiry`), `email`, and bookkeeping.

**Data layer**
- `SelfIdentifiedUserCredential` model + `ISelfIdentifiedUserCredentialRepository` (Core) and Npgsql implementation (Persistance), registered in the persistence DI layer.

**Login validation / toggle**
- `UserProfileService.ValidateCredentialsAsync` branches to a local path when the flag is enabled; verifies with `Base64(SHA1(UTF8(pwd) || Base64Decode(salt)))` using `CryptographicOperations.FixedTimeEquals`. The SBL Bridge path is unchanged when the flag is off. Controller and its response contract are untouched.
- Flag added to `FeatureFlags` + `appsettings.json` (`FeatureManagement`).

**Forgot-password (email)**
- `email` exported from `AUTHN_UserProfile.email` and stored (nullable; NULL preserved).
- Exposed via `IUserProfileService.GetSelfIdentifiedUserEmailAsync(username)` for the reset flow to look up the address. The runtime reset-ticket/flow (token issuance + email send + reset endpoint) is **out of scope** here — tracked in #1884 / #1885.

**Data migration (manual, one-off)**
- `scripts/si-credential-migration/` — a SQL Server query that emits ready-to-run Postgres `INSERT`s (source SQL Server, target Postgres), a post-import verification script (incl. email-readiness count), and a README.

**Tests**
- Unit tests for the local validation path, SHA1 verification (independently-computed vector), and the email lookup — 8/8 passing locally without Docker.

## Known follow-ups (tracked in #2025)
- **No local lockout/throttle** yet — `IsLocked` (429) only comes from SBL Bridge today. Needs its own `login_attempts` table/repo.
- **Expired-password policy not enforced** on the local path (reject vs. auto-extend is an open decision).

## Test notes
The existing SI integration tests use Testcontainers (Postgres via Docker) and were not runnable locally; CI runs them. The new unit tests pass locally (8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
