### PR TITLE
feat: ID-porten exchange user lookup via Register (toggle off SBL Bridge)

### DIFF
--- a/src/Authentication/Configuration/FeatureFlags.cs
+++ b/src/Authentication/Configuration/FeatureFlags.cs
@@ -40,6 +40,16 @@
         public const string EnterpriseUserAuthenticationDisabled = "EnterpriseUserAuthenticationDisabled";
 
         /// <summary>
+        /// Controls the source of the user fields (UserId/UserName/PartyId/PartyUuid) in the
+        /// ID-porten token exchange, replacing the (decommissioned) SBL Bridge
+        /// <c>profile/users/</c> lookup. When enabled, the fields are read from Register's
+        /// <c>POST /register/api/v2/internal/parties/query</c> endpoint; when disabled, from the
+        /// platform Profile API (<c>internal/user</c>). Tracked under the SBL Bridge
+        /// decommission (deadline 2026-06-19).
+        /// </summary>
+        public const string IdPortenUserLookupFromRegister = "IdPortenUserLookupFromRegister";
+
+        /// <summary>
         /// When enabled, every logout path that would otherwise 302 to the Altinn 2 logout
         /// endpoint (<c>GeneralSettings.SBLLogoutEndpoint</c>) redirects to
         /// <c>GeneralSettings.BaseUrl</c> instead. Allows the flag to be flipped per

--- a/src/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/Controllers/AuthenticationController.cs
@@ -41,6 +41,7 @@ using Microsoft.FeatureManagement;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Net.Http.Headers;
 using Newtonsoft.Json.Linq;
+using RegisterContracts = Altinn.Register.Contracts;
 using SameSiteMode = Microsoft.AspNetCore.Http.SameSiteMode;
 
 namespace Altinn.Platform.Authentication.Controllers
@@ -864,8 +865,48 @@ namespace Altinn.Platform.Authentication.Controllers
                     authMethod = AuthenticationMethod.NotDefined.ToString();
                 }
 
-                UserProfile userProfile = await _userProfileService.GetUser(pid);
-                UserProfile profile = await _profileService.GetUserProfile(new UserProfileLookup { Ssn = pid });
+                // SBL Bridge user lookup is being decommissioned (deadline 2026-06-19). The user fields
+                // (UserId/UserName/PartyId/PartyUuid) are now resolved from either Register or the platform
+                // Profile API, selected by the IdPortenUserLookupFromRegister feature flag.
+                // UserProfile userProfile = await _userProfileService.GetUser(pid);
+
+                int userId;
+                string userName;
+                int partyId;
+                Guid? partyUuid;
+
+                if (await _featureManager.IsEnabledAsync(FeatureFlags.IdPortenUserLookupFromRegister))
+                {
+                    // Register: POST /register/api/v2/internal/parties/query (fields=uuid,id,user).
+                    RegisterContracts.Party? party = await _partiesClient.GetPartyByPersonId(pid);
+
+                    if (party is null || !party.User.HasValue || !party.User.Value.UserId.HasValue)
+                    {
+                        _logger.LogInformation("ID-porten exchange: person not found in Register, or has no associated Altinn user.");
+                        return Unauthorized();
+                    }
+
+                    userId = (int)party.User.Value.UserId.Value;
+                    userName = party.User.Value.Username.HasValue ? party.User.Value.Username.Value : string.Empty;
+                    partyId = (int)party.PartyId.Value;
+                    partyUuid = party.Uuid;
+                }
+                else
+                {
+                    // Platform Profile API: POST {ApiProfileEndpoint}internal/user (lookup by SSN).
+                    UserProfile profile = await _profileService.GetUserProfile(new UserProfileLookup { Ssn = pid });
+
+                    if (profile is null)
+                    {
+                        _logger.LogInformation("ID-porten exchange: user profile not found.");
+                        return Unauthorized();
+                    }
+
+                    userId = profile.UserId;
+                    userName = profile.UserName;
+                    partyId = profile.PartyId;
+                    partyUuid = profile.UserUuid;
+                }
 
                 string issuer = _generalSettings.AltinnOidcIssuerUrl;
 
@@ -889,11 +930,11 @@ namespace Altinn.Platform.Authentication.Controllers
                 }
 
                 List<Claim> claims = new List<Claim>();
-                claims.Add(new Claim(ClaimTypes.NameIdentifier, userProfile.UserId.ToString(), ClaimValueTypes.String, issuer));
-                claims.Add(new Claim(AltinnCoreClaimTypes.UserId, userProfile.UserId.ToString(), ClaimValueTypes.String, issuer));
-                claims.Add(new Claim(AltinnCoreClaimTypes.UserName, userProfile.UserName, ClaimValueTypes.String, issuer));
-                claims.Add(new Claim(AltinnCoreClaimTypes.PartyID, userProfile.PartyId.ToString(), ClaimValueTypes.Integer32, issuer));
-                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUUID, profile.UserUuid.ToString(), ClaimValueTypes.String, issuer));
+                claims.Add(new Claim(ClaimTypes.NameIdentifier, userId.ToString(), ClaimValueTypes.String, issuer));
+                claims.Add(new Claim(AltinnCoreClaimTypes.UserId, userId.ToString(), ClaimValueTypes.String, issuer));
+                claims.Add(new Claim(AltinnCoreClaimTypes.UserName, userName, ClaimValueTypes.String, issuer));
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyID, partyId.ToString(), ClaimValueTypes.Integer32, issuer));
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUUID, partyUuid.ToString(), ClaimValueTypes.String, issuer));
                 claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticateMethod, authMethod, ClaimValueTypes.String, issuer));
                 claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticationLevel, authLevelValue, ClaimValueTypes.Integer32, issuer));
                 claims.AddRange(token.Claims);

--- a/src/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/Controllers/AuthenticationController.cs
@@ -908,6 +908,12 @@ namespace Altinn.Platform.Authentication.Controllers
                     partyUuid = profile.UserUuid;
                 }
 
+                if (!partyUuid.HasValue)
+                {
+                    _logger.LogInformation("ID-porten exchange: party UUID missing for user.");
+                    return Unauthorized();
+                }
+
                 string issuer = _generalSettings.AltinnOidcIssuerUrl;
 
                 string authLevelValue = "0";
@@ -934,7 +940,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 claims.Add(new Claim(AltinnCoreClaimTypes.UserId, userId.ToString(), ClaimValueTypes.String, issuer));
                 claims.Add(new Claim(AltinnCoreClaimTypes.UserName, userName, ClaimValueTypes.String, issuer));
                 claims.Add(new Claim(AltinnCoreClaimTypes.PartyID, partyId.ToString(), ClaimValueTypes.Integer32, issuer));
-                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUUID, partyUuid.ToString(), ClaimValueTypes.String, issuer));
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUUID, partyUuid.Value.ToString(), ClaimValueTypes.String, issuer));
                 claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticateMethod, authMethod, ClaimValueTypes.String, issuer));
                 claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticationLevel, authLevelValue, ClaimValueTypes.Integer32, issuer));
                 claims.AddRange(token.Claims);

--- a/src/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/Controllers/AuthenticationController.cs
@@ -878,7 +878,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 if (await _featureManager.IsEnabledAsync(FeatureFlags.IdPortenUserLookupFromRegister))
                 {
                     // Register: POST /register/api/v2/internal/parties/query (fields=uuid,id,user).
-                    RegisterContracts.Party? party = await _partiesClient.GetPartyByPersonId(pid);
+                    RegisterContracts.Party? party = await _partiesClient.GetPartyIdentifiersAndUsernameByPersonIdentifier(pid);
 
                     if (party is null || !party.User.HasValue || !party.User.Value.UserId.HasValue)
                     {

--- a/src/Authentication/appsettings.json
+++ b/src/Authentication/appsettings.json
@@ -68,7 +68,7 @@
     "CookieTicketDecryptionDisabled": false,
     "EnterpriseUserAuthenticationDisabled": false,
     "Altinn2LogoutRedirectDisabled": false,
-    "IdPortenUserLookupFromRegister": false
+    "IdPortenUserLookupFromRegister": true
   },
   "PostgreSQLSettings": {
     "EnableDBConnection": true,

--- a/src/Authentication/appsettings.json
+++ b/src/Authentication/appsettings.json
@@ -67,7 +67,8 @@
     "RegisterSelfIdentifiedUserProvisioning": false,
     "CookieTicketDecryptionDisabled": false,
     "EnterpriseUserAuthenticationDisabled": false,
-    "Altinn2LogoutRedirectDisabled": false
+    "Altinn2LogoutRedirectDisabled": false,
+    "IdPortenUserLookupFromRegister": false
   },
   "PostgreSQLSettings": {
     "EnableDBConnection": true,

--- a/src/Core/Clients/Interfaces/IPartiesClient.cs
+++ b/src/Core/Clients/Interfaces/IPartiesClient.cs
@@ -1,6 +1,7 @@
 ﻿using Altinn.Authorization.ProblemDetails;
 using Altinn.Platform.Authentication.Core.Models.SystemUsers;
 using Altinn.Register.Contracts.V1;
+using RegisterContracts = Altinn.Register.Contracts;
 
 namespace Altinn.Authentication.Core.Clients.Interfaces;
 
@@ -40,6 +41,22 @@ public interface IPartiesClient
     /// <param name="cancellationToken">The cancellation token<see cref="CancellationToken"/></param>
     /// <returns>party information</returns>
     Task<Party> GetPartyByUuId(Guid partyUuId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Looks up a person party in Register by national identity number (SSN), returning the
+    /// party together with its associated Altinn user (<c>UserId</c>/<c>UserName</c>), <c>PartyId</c>
+    /// and <c>PartyUuid</c>.
+    /// </summary>
+    /// <remarks>
+    /// Backed by <c>POST register/api/v2/internal/parties/query</c> with <c>fields=uuid,id,user</c>.
+    /// Intended as the Register-based replacement for the SBL Bridge user lookup
+    /// (<c>profile/users/</c>) in the ID-porten token exchange. Note the returned party may have an
+    /// unset <see cref="RegisterContracts.PartyUser"/> when the person has no associated Altinn user.
+    /// </remarks>
+    /// <param name="ssn">The person's national identity number (fødselsnummer).</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The matched party, or <see langword="null"/> if the person was not found.</returns>
+    Task<RegisterContracts.Party?> GetPartyByPersonId(string ssn, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Return all customers of a specific type for party

--- a/src/Core/Clients/Interfaces/IPartiesClient.cs
+++ b/src/Core/Clients/Interfaces/IPartiesClient.cs
@@ -43,9 +43,9 @@ public interface IPartiesClient
     Task<Party> GetPartyByUuId(Guid partyUuId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Looks up a person party in Register by national identity number (SSN), returning the
-    /// party together with its associated Altinn user (<c>UserId</c>/<c>UserName</c>), <c>PartyId</c>
-    /// and <c>PartyUuid</c>.
+    /// Looks up a person party in Register by national identity number (SSN), returning a minimal
+    /// party populated with only its identifiers (<c>PartyId</c>/<c>PartyUuid</c>) and the associated
+    /// Altinn user (<c>UserId</c>/<c>UserName</c>).
     /// </summary>
     /// <remarks>
     /// Backed by <c>POST register/api/v2/internal/parties/query</c> with <c>fields=uuid,id,user</c>.
@@ -56,7 +56,7 @@ public interface IPartiesClient
     /// <param name="ssn">The person's national identity number (fødselsnummer).</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The matched party, or <see langword="null"/> if the person was not found.</returns>
-    Task<RegisterContracts.Party?> GetPartyByPersonId(string ssn, CancellationToken cancellationToken = default);
+    Task<RegisterContracts.Party?> GetPartyIdentifiersAndUsernameByPersonIdentifier(string ssn, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Return all customers of a specific type for party

--- a/src/Integration/Clients/PartiesClient.cs
+++ b/src/Integration/Clients/PartiesClient.cs
@@ -220,8 +220,10 @@ public class PartiesClient : IPartiesClient
         }
         catch (Exception ex) when (ex is FormatException or ArgumentException)
         {
-            // PersonIdentifier.Parse rejects a malformed national identity number. The SSN must not be logged.
-            _logger.LogError("Authentication // PartiesClient // GetPartyByPersonId // Invalid person identifier");
+            // PersonIdentifier.Parse rejects a malformed national identity number. Returning null is the
+            // expected outcome for invalid input, so this is logged as a warning, not an error. The SSN
+            // must not be logged.
+            _logger.LogWarning("Authentication // PartiesClient // GetPartyByPersonId // Invalid person identifier");
             return null;
         }
         catch (Exception ex)

--- a/src/Integration/Clients/PartiesClient.cs
+++ b/src/Integration/Clients/PartiesClient.cs
@@ -15,6 +15,8 @@ using Altinn.Platform.Authentication.Core.Models.SystemUsers;
 using Altinn.Platform.Authentication.Core.Enums;
 using Altinn.Authorization.ProblemDetails;
 using Altinn.Register.Contracts.V1;
+using System.Text.Json.Serialization;
+using RegisterContracts = Altinn.Register.Contracts;
 
 namespace Altinn.Authentication.Integration.Clients;
 
@@ -30,6 +32,10 @@ public class PartiesClient : IPartiesClient
     private readonly PlatformSettings _platformSettings;
     private readonly IAccessTokenGenerator _accessTokenGenerator;
     private readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+    // Plain web defaults for the Register v2 polymorphic party contracts (Party/PartyUser/PartyUrn).
+    // These carry their own attribute-based converters, mirroring RegisterUserProvisioningClient.
+    private static readonly JsonSerializerOptions _registerQueryOptions = new(JsonSerializerDefaults.Web);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PartiesClient"/> class
@@ -169,6 +175,62 @@ public class PartiesClient : IPartiesClient
         }
     }
 
+    /// <inheritdoc/>
+    public async Task<RegisterContracts.Party?> GetPartyByPersonId(string ssn, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(_platformSettings.ApiRegisterInternalEndpoint))
+            {
+                _logger.LogError("Authentication // PartiesClient // GetPartyByPersonId // ApiRegisterInternalEndpoint is not configured");
+                return null;
+            }
+
+            // The query endpoint lives under the v2 internal base, while this client's BaseAddress
+            // points at the v1 register base, so build an absolute URI. 'fields' must explicitly
+            // include 'user' - querying by person-id only auto-includes the person identifier, not
+            // the associated user object (UserId/UserName).
+            string baseInternal = _platformSettings.ApiRegisterInternalEndpoint.TrimEnd('/');
+            string endpointUrl = $"{baseInternal}/parties/query?fields=uuid,id,user";
+
+            string personUrn = RegisterContracts.PartyUrn.PersonId.Create(RegisterContracts.PersonIdentifier.Parse(ssn)).ToString();
+            PartyQueryRequest queryRequest = new([personUrn]);
+
+            StringContent requestBody = new(JsonSerializer.Serialize(queryRequest, _registerQueryOptions), Encoding.UTF8, "application/json");
+            var accessToken = _accessTokenGenerator.GenerateAccessToken("platform", "authentication");
+
+            HttpResponseMessage response = await _client.PostAsync(null, endpointUrl, requestBody, accessToken);
+            string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            // 200 = all urns matched. 206 = at least one urn did not resolve; for a single lookup that means "not found".
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                PartyQueryResponse? result = JsonSerializer.Deserialize<PartyQueryResponse>(responseContent, _registerQueryOptions);
+                return result?.Data?.FirstOrDefault();
+            }
+
+            if (response.StatusCode == HttpStatusCode.PartialContent)
+            {
+                _logger.LogInformation("Authentication // PartiesClient // GetPartyByPersonId // Person not found in Register");
+                return null;
+            }
+
+            _logger.LogError("Authentication // PartiesClient // GetPartyByPersonId // Unexpected HttpStatusCode: {StatusCode}", response.StatusCode);
+            return null;
+        }
+        catch (Exception ex) when (ex is FormatException or ArgumentException)
+        {
+            // PersonIdentifier.Parse rejects a malformed national identity number. The SSN must not be logged.
+            _logger.LogError("Authentication // PartiesClient // GetPartyByPersonId // Invalid person identifier");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Authentication // PartiesClient // GetPartyByPersonId // Exception");
+            throw;
+        }
+    }
+
     /// <inheritdoc />
     public async Task<Result<CustomerList>> GetPartyCustomers(Guid partyUuid, string accessPackage, CancellationToken cancellationToken)
     {
@@ -273,4 +335,17 @@ public class PartiesClient : IPartiesClient
             throw;
         }
     }
+
+    /// <summary>
+    /// Request payload for <c>POST register/api/v2/internal/parties/query</c>. The party URNs are
+    /// sent as their canonical string form (e.g. <c>urn:altinn:person:identifier-no:{ssn}</c>).
+    /// </summary>
+    private sealed record PartyQueryRequest(
+        [property: JsonPropertyName("data")] IReadOnlyList<string> Data);
+
+    /// <summary>
+    /// Response wrapper for <c>POST register/api/v2/internal/parties/query</c>.
+    /// </summary>
+    private sealed record PartyQueryResponse(
+        [property: JsonPropertyName("data")] IReadOnlyList<RegisterContracts.Party>? Data);
 }

--- a/src/Integration/Clients/PartiesClient.cs
+++ b/src/Integration/Clients/PartiesClient.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text;
@@ -15,7 +16,6 @@ using Altinn.Platform.Authentication.Core.Models.SystemUsers;
 using Altinn.Platform.Authentication.Core.Enums;
 using Altinn.Authorization.ProblemDetails;
 using Altinn.Register.Contracts.V1;
-using System.Text.Json.Serialization;
 using RegisterContracts = Altinn.Register.Contracts;
 
 namespace Altinn.Authentication.Integration.Clients;
@@ -176,13 +176,26 @@ public class PartiesClient : IPartiesClient
     }
 
     /// <inheritdoc/>
-    public async Task<RegisterContracts.Party?> GetPartyByPersonId(string ssn, CancellationToken cancellationToken = default)
+    public async Task<RegisterContracts.Party?> GetPartyIdentifiersAndUsernameByPersonIdentifier(string ssn, CancellationToken cancellationToken = default)
     {
+        RegisterContracts.PartyUrn personUrn;
+        try
+        {
+            personUrn = RegisterContracts.PartyUrn.PersonId.Create(RegisterContracts.PersonIdentifier.Parse(ssn));
+        }
+        catch (Exception ex) when (ex is FormatException or ArgumentException)
+        {
+            // Parse rejects a malformed national identity number. Returning null is the expected outcome
+            // for invalid input, so this is logged as a warning, not an error. The SSN must not be logged.
+            _logger.LogWarning("Authentication // PartiesClient // GetPartyIdentifiersAndUsernameByPersonIdentifier // Invalid person identifier");
+            return null;
+        }
+
         try
         {
             if (string.IsNullOrEmpty(_platformSettings.ApiRegisterInternalEndpoint))
             {
-                _logger.LogError("Authentication // PartiesClient // GetPartyByPersonId // ApiRegisterInternalEndpoint is not configured");
+                _logger.LogError("Authentication // PartiesClient // GetPartyIdentifiersAndUsernameByPersonIdentifier // ApiRegisterInternalEndpoint is not configured");
                 return null;
             }
 
@@ -193,42 +206,31 @@ public class PartiesClient : IPartiesClient
             string baseInternal = _platformSettings.ApiRegisterInternalEndpoint.TrimEnd('/');
             string endpointUrl = $"{baseInternal}/parties/query?fields=uuid,id,user";
 
-            string personUrn = RegisterContracts.PartyUrn.PersonId.Create(RegisterContracts.PersonIdentifier.Parse(ssn)).ToString();
             PartyQueryRequest queryRequest = new([personUrn]);
-
-            StringContent requestBody = new(JsonSerializer.Serialize(queryRequest, _registerQueryOptions), Encoding.UTF8, "application/json");
+            JsonContent requestBody = JsonContent.Create(queryRequest, options: _registerQueryOptions);
             var accessToken = _accessTokenGenerator.GenerateAccessToken("platform", "authentication");
 
             HttpResponseMessage response = await _client.PostAsync(null, endpointUrl, requestBody, accessToken);
-            string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
             // 200 = all urns matched. 206 = at least one urn did not resolve; for a single lookup that means "not found".
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                PartyQueryResponse? result = JsonSerializer.Deserialize<PartyQueryResponse>(responseContent, _registerQueryOptions);
-                return result?.Data?.FirstOrDefault();
+                PartyQueryResponse? result = await response.Content.ReadFromJsonAsync<PartyQueryResponse>(_registerQueryOptions, cancellationToken);
+                return result?.Data is { Count: > 0 } parties ? parties[0] : null;
             }
 
             if (response.StatusCode == HttpStatusCode.PartialContent)
             {
-                _logger.LogInformation("Authentication // PartiesClient // GetPartyByPersonId // Person not found in Register");
+                _logger.LogInformation("Authentication // PartiesClient // GetPartyIdentifiersAndUsernameByPersonIdentifier // Person not found in Register");
                 return null;
             }
 
-            _logger.LogError("Authentication // PartiesClient // GetPartyByPersonId // Unexpected HttpStatusCode: {StatusCode}", response.StatusCode);
-            return null;
-        }
-        catch (Exception ex) when (ex is FormatException or ArgumentException)
-        {
-            // PersonIdentifier.Parse rejects a malformed national identity number. Returning null is the
-            // expected outcome for invalid input, so this is logged as a warning, not an error. The SSN
-            // must not be logged.
-            _logger.LogWarning("Authentication // PartiesClient // GetPartyByPersonId // Invalid person identifier");
+            _logger.LogError("Authentication // PartiesClient // GetPartyIdentifiersAndUsernameByPersonIdentifier // Unexpected HttpStatusCode: {StatusCode}", response.StatusCode);
             return null;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Authentication // PartiesClient // GetPartyByPersonId // Exception");
+            _logger.LogError(ex, "Authentication // PartiesClient // GetPartyIdentifiersAndUsernameByPersonIdentifier // Exception");
             throw;
         }
     }
@@ -343,7 +345,7 @@ public class PartiesClient : IPartiesClient
     /// sent as their canonical string form (e.g. <c>urn:altinn:person:identifier-no:{ssn}</c>).
     /// </summary>
     private sealed record PartyQueryRequest(
-        [property: JsonPropertyName("data")] IReadOnlyList<string> Data);
+        [property: JsonPropertyName("data")] IReadOnlyList<RegisterContracts.PartyUrn> Data);
 
     /// <summary>
     /// Response wrapper for <c>POST register/api/v2/internal/parties/query</c>.

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerIdPortenRegisterTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerIdPortenRegisterTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Altinn.Authentication.Core.Clients.Interfaces;
+using Altinn.Common.AccessToken.Services;
+using Altinn.Platform.Authentication.Clients.Interfaces;
+using Altinn.Platform.Authentication.Configuration;
+using Altinn.Platform.Authentication.Controllers;
+using Altinn.Platform.Authentication.Services.Interfaces;
+using Altinn.Platform.Authentication.Tests.Fakes;
+using Altinn.Platform.Authentication.Tests.Mocks;
+using Altinn.Platform.Authentication.Tests.RepositoryDataAccess;
+using Altinn.Platform.Authentication.Tests.Utils;
+using AltinnCore.Authentication.JwtCookie;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+using RegisterContracts = Altinn.Register.Contracts;
+
+namespace Altinn.Platform.Authentication.Tests.Controllers
+{
+    /// <summary>
+    /// Covers the Register branch of the ID-porten token exchange, i.e. when the
+    /// <see cref="FeatureFlags.IdPortenUserLookupFromRegister"/> flag is enabled and the user fields
+    /// are resolved from Register (<see cref="IPartiesClient.GetPartyByPersonId"/>) instead of the
+    /// platform Profile API. The flag-off (Profile) branch is covered by
+    /// <see cref="AuthenticationControllerTests"/>.
+    /// </summary>
+    public class AuthenticationControllerIdPortenRegisterTests(DbFixture dbFixture, WebApplicationFixture webApplicationFixture)
+        : WebApplicationTests(dbFixture, webApplicationFixture)
+    {
+        private readonly Mock<IUserProfileService> _userProfileService = new();
+        private readonly Mock<ISblCookieDecryptionService> _cookieDecryptionService = new();
+        private readonly Mock<IGuidService> _guidService = new();
+        private readonly Mock<IEventsQueueClient> _eventQueue = new();
+        private readonly Mock<IPartiesClient> _partiesClient = new();
+
+        protected override void ConfigureHost(IWebHostBuilder builder)
+        {
+            builder.UseSetting("feature_management:feature_flags:0:id", "AuditLog");
+            builder.UseSetting("feature_management:feature_flags:0:enabled", "true");
+
+            // Enable the Register-based ID-porten user lookup for this test class.
+            builder.UseSetting("feature_management:feature_flags:1:id", FeatureFlags.IdPortenUserLookupFromRegister);
+            builder.UseSetting("feature_management:feature_flags:1:enabled", "true");
+            base.ConfigureHost(builder);
+        }
+
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            base.ConfigureServices(services);
+
+            string configPath = GetConfigPath();
+
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddJsonFile(configPath)
+                .AddInMemoryCollection(
+                    new Dictionary<string, string>
+                    {
+                        { "GeneralSettings:EnableOidc", "false" },
+                        { "GeneralSettings:ForceOidc", "false" },
+                        { "GeneralSettings:DefaultOidcProvider", "altinn" }
+                    })
+                .Build();
+
+            IConfigurationSection generalSettingSection = configuration.GetSection("GeneralSettings");
+
+            _eventQueue.Setup(q => q.EnqueueAuthenticationEvent(It.IsAny<string>()));
+
+            services.Configure<GeneralSettings>(generalSettingSection);
+            services.AddSingleton(_cookieDecryptionService);
+            services.AddSingleton(_userProfileService);
+            services.AddSingleton(_partiesClient.Object);
+            services.AddSingleton<IOrganisationsService, OrganisationsServiceMock>();
+            services.AddSingleton<ISigningKeysRetriever, SigningKeysRetrieverStub>();
+            services.AddSingleton<IJwtSigningCertificateProvider, JwtSigningCertificateProviderStub>();
+            services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
+            services.AddSingleton<IPublicSigningKeyProvider, SigningKeyResolverStub>();
+            services.AddSingleton<IEnterpriseUserAuthenticationService, EnterpriseUserAuthenticationServiceMock>();
+            services.AddSingleton<IOidcProvider, OidcProviderServiceMock>();
+            services.AddSingleton(_eventQueue.Object);
+            services.AddSingleton(_guidService.Object);
+            services.AddSingleton<IUserProfileService>(_userProfileService.Object);
+            services.AddSingleton<ISblCookieDecryptionService>(_cookieDecryptionService.Object);
+            _guidService.Setup(q => q.NewGuid()).Returns("eaec330c-1e2d-4acb-8975-5f3eba12b2fb");
+        }
+
+        protected override ValueTask InitializeAsync()
+        {
+            // Token validation depends on current time.
+            TimeProvider.SetUtcNow(DateTimeOffset.UtcNow);
+            return base.InitializeAsync();
+        }
+
+        /// <summary>
+        /// When the Register lookup flag is enabled, the ID-porten exchange resolves the user fields from
+        /// Register and issues a token carrying UserId/UserName/PartyId from the returned party.
+        /// </summary>
+        [Fact]
+        public async Task AuthenticateEndUser_RegisterLookupEnabled_ReturnsTokenWithRegisterUserFields()
+        {
+            // Arrange
+            List<Claim> claims = new()
+            {
+                new Claim("pid", "19108000239"),
+                new Claim("amr", "Minid-PIN"),
+                new Claim("acr", "idporten-loa-high"),
+                new Claim("scope", "altinn:instances.read"),
+            };
+
+            ClaimsIdentity identity = new();
+            identity.AddClaims(claims);
+            ClaimsPrincipal externalPrincipal = new(identity);
+
+            // The mock returns a Register party (deserialized to exercise the real polymorphic contract)
+            // whose User object carries the Altinn user id and username.
+            RegisterContracts.Party party = JsonSerializer.Deserialize<RegisterContracts.Party>(
+                """
+                {
+                  "partyType": "person",
+                  "partyUuid": "5c0656db-cf51-43a9-bd68-d8a55e7b6f3b",
+                  "versionId": 1,
+                  "partyId": 50001,
+                  "personIdentifier": "19108000239",
+                  "displayName": "Test Testesen",
+                  "createdAt": "2020-01-01T00:00:00Z",
+                  "modifiedAt": "2020-01-01T00:00:00Z",
+                  "isDeleted": false,
+                  "user": { "userId": 20000, "username": "steph", "userIds": [ 20000 ] }
+                }
+                """,
+                new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+            _partiesClient
+                .Setup(p => p.GetPartyByPersonId(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(party);
+
+            HttpClient client = CreateClient();
+
+            string externalToken = JwtTokenMock.GenerateToken(externalPrincipal, TimeSpan.FromMinutes(2), now: TimeProvider.GetUtcNow());
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", externalToken);
+
+            // Act
+            HttpResponseMessage response = await client.GetAsync("/authentication/api/v1/exchange/id-porten");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            string token = await response.Content.ReadAsStringAsync();
+            ClaimsPrincipal principal = JwtTokenMock.ValidateToken(token, TimeProvider.GetUtcNow());
+
+            Assert.NotNull(principal);
+            Assert.Equal("20000", principal.FindFirstValue("urn:altinn:userid"));
+            Assert.Equal("steph", principal.FindFirstValue("urn:altinn:username"));
+            Assert.Equal("50001", principal.FindFirstValue("urn:altinn:partyid"));
+            Assert.Equal("4", principal.FindFirstValue("urn:altinn:authlevel"));
+
+            _partiesClient.Verify(p => p.GetPartyByPersonId(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        private static string GetConfigPath()
+        {
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(AuthenticationControllerIdPortenRegisterTests).Assembly.Location).LocalPath);
+            return Path.Combine(unitTestFolder, $"../../../appsettings.test.json");
+        }
+    }
+}

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerIdPortenRegisterTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerIdPortenRegisterTests.cs
@@ -163,6 +163,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             Assert.Equal("20000", principal.FindFirstValue("urn:altinn:userid"));
             Assert.Equal("steph", principal.FindFirstValue("urn:altinn:username"));
             Assert.Equal("50001", principal.FindFirstValue("urn:altinn:partyid"));
+            Assert.Equal("5c0656db-cf51-43a9-bd68-d8a55e7b6f3b", principal.FindFirstValue("urn:altinn:party:uuid"));
             Assert.Equal("4", principal.FindFirstValue("urn:altinn:authlevel"));
 
             _partiesClient.Verify(p => p.GetPartyByPersonId(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerIdPortenRegisterTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerIdPortenRegisterTests.cs
@@ -32,7 +32,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
     /// <summary>
     /// Covers the Register branch of the ID-porten token exchange, i.e. when the
     /// <see cref="FeatureFlags.IdPortenUserLookupFromRegister"/> flag is enabled and the user fields
-    /// are resolved from Register (<see cref="IPartiesClient.GetPartyByPersonId"/>) instead of the
+    /// are resolved from Register (<see cref="IPartiesClient.GetPartyIdentifiersAndUsernameByPersonIdentifier"/>) instead of the
     /// platform Profile API. The flag-off (Profile) branch is covered by
     /// <see cref="AuthenticationControllerTests"/>.
     /// </summary>
@@ -142,7 +142,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 new JsonSerializerOptions(JsonSerializerDefaults.Web));
 
             _partiesClient
-                .Setup(p => p.GetPartyByPersonId(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Setup(p => p.GetPartyIdentifiersAndUsernameByPersonIdentifier(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(party);
 
             HttpClient client = CreateClient();
@@ -166,7 +166,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             Assert.Equal("5c0656db-cf51-43a9-bd68-d8a55e7b6f3b", principal.FindFirstValue("urn:altinn:party:uuid"));
             Assert.Equal("4", principal.FindFirstValue("urn:altinn:authlevel"));
 
-            _partiesClient.Verify(p => p.GetPartyByPersonId(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            _partiesClient.Verify(p => p.GetPartyIdentifiersAndUsernameByPersonIdentifier(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         private static string GetConfigPath()

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerTests.cs
@@ -57,6 +57,11 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         {
             builder.UseSetting("feature_management:feature_flags:0:id", "AuditLog");
             builder.UseSetting("feature_management:feature_flags:0:enabled", "true");
+
+            // The ID-porten exchange tests in this class exercise the Profile-API branch, so the
+            // Register lookup flag must be off here regardless of its (now enabled-by-default) value.
+            builder.UseSetting("feature_management:feature_flags:1:id", FeatureFlags.IdPortenUserLookupFromRegister);
+            builder.UseSetting("feature_management:feature_flags:1:enabled", "false");
             base.ConfigureHost(builder);
         }
 

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/PartiesClientMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/PartiesClientMock.cs
@@ -8,6 +8,7 @@ using Altinn.Authentication.Core.Clients.Interfaces;
 using Altinn.Authorization.ProblemDetails;
 using Altinn.Platform.Authentication.Core.Models.SystemUsers;
 using Altinn.Register.Contracts.V1;
+using RegisterContracts = Altinn.Register.Contracts;
 
 namespace Altinn.Authentication.Tests.Mocks;
 
@@ -98,6 +99,12 @@ public class PartiesClientMock : IPartiesClient
     public Task<Result<CustomerList>> GetPartyCustomers(Guid partyUuid, string accessPackage, CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
+    }
+
+    /// <inheritdoc/>
+    public Task<RegisterContracts.Party?> GetPartyByPersonId(string ssn, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult<RegisterContracts.Party?>(null);
     }
 
     public Task<Party> GetPartyByUuId(Guid partyUuId, CancellationToken cancellationToken = default)

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/PartiesClientMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/PartiesClientMock.cs
@@ -102,7 +102,7 @@ public class PartiesClientMock : IPartiesClient
     }
 
     /// <inheritdoc/>
-    public Task<RegisterContracts.Party?> GetPartyByPersonId(string ssn, CancellationToken cancellationToken = default)
+    public Task<RegisterContracts.Party?> GetPartyIdentifiersAndUsernameByPersonIdentifier(string ssn, CancellationToken cancellationToken = default)
     {
         return Task.FromResult<RegisterContracts.Party?>(null);
     }

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/ProfileMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/ProfileMock.cs
@@ -11,6 +11,22 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
     {
         public Task<UserProfile> GetUserProfile(UserProfileLookup profileLookup)
         {
+            // Lookup by SSN is used by the ID-porten token exchange - the Profile/Register replacement
+            // for the decommissioned SBL Bridge user lookup. Return a fully populated profile (matching
+            // the canonical test user) so the default (Profile) path issues a complete token.
+            if (!string.IsNullOrEmpty(profileLookup.Ssn))
+            {
+                UserProfile bySsn = new UserProfile
+                {
+                    UserId = 20000,
+                    PartyId = 50001,
+                    UserName = "steph",
+                    UserUuid = Guid.NewGuid(),
+                    Party = new Party() { PartyId = 50001, SSN = profileLookup.Ssn, Person = new Person() { SSN = profileLookup.Ssn } }
+                };
+                return Task.FromResult(bySsn);
+            }
+
             UserProfile userProfile = new UserProfile
             {
                 UserId = profileLookup.UserId,


### PR DESCRIPTION
## Description

The ID-porten token exchange (`GET /authentication/api/v1/exchange/id-porten`) resolved the user fields (`UserId`/`UserName`/`PartyId`/`PartyUuid`) via the SBL Bridge profile lookup (`profile/users/`), which is being decommissioned (deadline **2026-06-19**).

This PR introduces a **Register-based** source for those fields and a **feature toggle** to select between Register and the platform Profile API. The SBL Bridge call in this path is commented out.

**Register is the default** (`IdPortenUserLookupFromRegister = true`). The Profile API is kept as a fallback behind the toggle for this iteration; once Register is confirmed working in the relevant environments, the Profile path will be removed in a later iteration.

## Changes

- **`IPartiesClient.GetPartyIdentifiersAndUsernameByPersonIdentifier(ssn)`** — new client method that looks up a person by national identity number (SSN) via Register `POST /register/api/v2/internal/parties/query` with `fields=uuid,id,user`. Returns a minimal party populated with `PartyId`/`PartyUuid` plus the associated Altinn `user` (`UserId`/`UserName`).
  - Built as an absolute URI against `ApiRegisterInternalEndpoint` (v2 internal), since the client's base address is the v1 register base.
  - `fields` explicitly includes `user` — querying by person-id does not auto-include the user object.
  - `200` → party returned; `206 Partial Content` → not found; malformed SSN → null (warning, never logged).
- **`AuthenticationController.AuthenticateIdPortenToken`** — SBL Bridge `GetUser` call is **commented out**. The four user fields are resolved into locals from either Register or the Profile API, selected by the flag. Guards for not-found / missing user / missing PartyUUID → `Unauthorized`.
- **Feature flag `IdPortenUserLookupFromRegister`** — **default on** (Register). Set to `false` to fall back to the Profile API.

## Toggle behaviour

| Flag | Source of user fields |
|------|----------------------|
| `true` (**default**) | Register (`parties/query` by person-id) |
| `false` | Platform Profile API (`internal/user` by SSN) |

Both replace the (now commented-out) SBL Bridge lookup.

## Tests

- **Register branch** (flag on, default): `AuthenticationControllerIdPortenRegisterTests` — sets up the parties mock with a Register `Party` and asserts the issued token carries the Register-sourced `UserId`/`UserName`/`PartyId`/`PartyUUID`.
- **Profile branch** (flag off): existing `AuthenticationControllerTests` ID-porten tests, which now disable the flag explicitly so they stay deterministic against the new default; `ProfileMock` returns a fully-populated profile on SSN lookups.
- Full `AuthenticationController` suite: **39 passed, 0 failed** (run against Postgres via Testcontainers).

## Notes / follow-ups

- `ApiRegisterInternalEndpoint` must be configured in the target environments (same setting used by `RegisterUserProvisioningClient`).
- **Behavioural caveat:** Register's `Party.User` can be unset for a person with no associated Altinn user; that path returns `Unauthorized`. Since Register is now the default, confirm the Register team that every authenticatable ID-porten person has a user populated.
- **Next iteration:** once Register is validated, remove the Profile-API branch and the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
