### PR TITLE
Log reasons for delegation check failure

### DIFF
--- a/src/Authentication/Helpers/DelegationHelper.cs
+++ b/src/Authentication/Helpers/DelegationHelper.cs
@@ -87,18 +87,27 @@ public class DelegationHelper(
             if (!canDelegate)
             {
                 // The delegation check completed (HTTP 200) but the resource right is not delegable.
-                // Log the resource and the reason codes/descriptions returned by Access Management
-                // so the failure is debuggable in App Insights (issue #2027).
-                string errorDetails = errors is not null && errors.Count > 0
-                    ? string.Join("; ", errors.Select(e => $"{e.Code}: {e.Description}"))
-                    : "no reason provided";
+                // Access Management returns the actual reason in each right's ReasonCodes (e.g.
+                // MissingPackageAccess, MissingRoleAccess, MissingDelegationAccess) - not in Permissions -
+                // so read ReasonCodes directly to make the failure debuggable in App Insights (issue #2027).
+                string reasonDetails = string.Join(
+                    " | ",
+                    resourceCheckDto.Rights
+                        .Where(r => !r.Result)
+                        .Select(r =>
+                        {
+                            string reasonCodes = r.ReasonCodes is not null && r.ReasonCodes.Any()
+                                ? string.Join(", ", r.ReasonCodes)
+                                : "no reason provided";
+                            return $"{r.Right?.Key}: {reasonCodes}";
+                        }));
 
                 logger.LogError(
                     "Authentication // DelegationHelper // UserDelegationCheckForReportee // Resource right not delegable // Party: {PartyUuid}, System: {SystemId}, Resource: {Resource}, Reasons: {Reasons}",
                     partyUuid,
                     systemId,
                     resourceId,
-                    errorDetails);
+                    reasonDetails);
 
                 return new DelegationCheckResult(false, rightResponsesList, errors);
             }
@@ -195,32 +204,23 @@ public class DelegationHelper(
     /// <returns></returns>
     public static ProblemInstance MapDetailExternalErrorListToProblemInstance(List<DetailExternal>? errors)
     {
-        if (errors is null || errors.Count == 0 || errors[0].Code == DetailCodeExternal.Unknown)
+        if (errors is null || errors.Count == 0)
         {
             return Problem.UnableToDoDelegationCheck;
         }
-
-        if (errors[0].Code == DetailCodeExternal.MissingRoleAccess)
+  
+        return errors[0].Code switch
         {
-            return Problem.DelegationRightMissingRoleAccess;
-        }
-
-        if (errors[0].Code == DetailCodeExternal.MissingDelegationAccess)
-        {
-            return Problem.DelegationRightMissingDelegationAccess;
-        }
-
-        if (errors[0].Code == DetailCodeExternal.MissingSrrRightAccess)
-        {
-            return Problem.DelegationRightMissingSrrRightAccess;
-        }
-
-        if (errors[0].Code == DetailCodeExternal.InsufficientAuthenticationLevel)
-        {
-            return Problem.DelegationRightInsufficientAuthenticationLevel;
-        }
-
-        return Problem.UnableToDoDelegationCheck;
+            DetailCodeExternal.MissingPackageAccess => Problem.DelegationRightMissingPackageAccess,
+            DetailCodeExternal.MissingRoleAccess => Problem.DelegationRightMissingRoleAccess,
+            DetailCodeExternal.MissingDelegationAccess => Problem.DelegationRightMissingDelegationAccess,
+            DetailCodeExternal.MissingSrrRightAccess => Problem.DelegationRightMissingSrrRightAccess,
+            DetailCodeExternal.InsufficientAuthenticationLevel => Problem.DelegationRightInsufficientAuthenticationLevel,
+            DetailCodeExternal.AccessListValidationFail => Problem.DelegationRightAccessListValidationFail,
+            DetailCodeExternal.ResourceNotDelegable => Problem.DelegationRightResourceNotDelegable,
+            DetailCodeExternal.ResourceIsMaskinPortenSchema => Problem.DelegationRightResourceIsMaskinPortenSchema,
+            _ => Problem.UnableToDoDelegationCheck
+        };
     }
 
     /// <summary>
@@ -387,6 +387,13 @@ public class DelegationHelper(
                         Code = p.PermisionKey,
                         Description = p.Description,
                         Parameters = []
+                    }));
+                }
+                else if (rightCheckDto.ReasonCodes is not null && rightCheckDto.ReasonCodes.Any())
+                {                   
+                    errors.AddRange(rightCheckDto.ReasonCodes.Select(code => new DetailExternal
+                    {
+                        Code = code
                     }));
                 }
             }

--- a/src/Authentication/Helpers/DelegationHelper.cs
+++ b/src/Authentication/Helpers/DelegationHelper.cs
@@ -11,6 +11,7 @@ using Altinn.Platform.Authentication.Core.Models.Rights;
 using Altinn.Platform.Authentication.Core.Telemetry;
 using Altinn.Platform.Authentication.Integration.AccessManagement;
 using Altinn.Platform.Authentication.Services.Interfaces;
+using Microsoft.Extensions.Logging;
 
 namespace Altinn.Platform.Authentication.Helpers;
 #nullable enable
@@ -20,7 +21,8 @@ namespace Altinn.Platform.Authentication.Helpers;
 /// </summary>
 public class DelegationHelper(
     ISystemRegisterService systemRegisterService,
-    IAccessManagementClient accessManagementClient)
+    IAccessManagementClient accessManagementClient,
+    ILogger<DelegationHelper> logger)
 {
     /// <summary>
     /// Checks Delegation for a user
@@ -75,6 +77,8 @@ public class DelegationHelper(
             
             if (resourceCheckDto is null)
             {
+                // HTTP failure during the delegation check is already logged with the response body,
+                // status code, party and resource in AccessManagementClient.CheckDelegationAccess.
                 return new DelegationCheckResult(false, null, null);
             }
 
@@ -82,6 +86,20 @@ public class DelegationHelper(
 
             if (!canDelegate)
             {
+                // The delegation check completed (HTTP 200) but the resource right is not delegable.
+                // Log the resource and the reason codes/descriptions returned by Access Management
+                // so the failure is debuggable in App Insights (issue #2027).
+                string errorDetails = errors is not null && errors.Count > 0
+                    ? string.Join("; ", errors.Select(e => $"{e.Code}: {e.Description}"))
+                    : "no reason provided";
+
+                logger.LogError(
+                    "Authentication // DelegationHelper // UserDelegationCheckForReportee // Resource right not delegable // Party: {PartyUuid}, System: {SystemId}, Resource: {Resource}, Reasons: {Reasons}",
+                    partyUuid,
+                    systemId,
+                    resourceId,
+                    errorDetails);
+
                 return new DelegationCheckResult(false, rightResponsesList, errors);
             }
 
@@ -254,6 +272,8 @@ public class DelegationHelper(
         {
             if (result.IsProblem)
             {
+                // HTTP failure during the delegation check is already logged with the response body,
+                // status code, party and packages in AccessManagementClient.CheckDelegationAccessForAccessPackage.
                 var problemExtensionData = ProblemExtensionData.Create(new[]
                 {
                     new KeyValuePair<string, string>("Problem Detail : ", result.Problem.Detail)
@@ -278,6 +298,28 @@ public class DelegationHelper(
         }
         else
         {
+            // The delegation check completed (HTTP 200) but one or more access packages are not delegable.
+            // Log which packages failed and the reasons returned by Access Management to make this debuggable
+            // in App Insights (issue #2027).
+            List<AccessPackageDto.Check> notDelegable = delegationCheckResults.Where(r => !r.Result).ToList();
+
+            string notDelegableDetails = string.Join(
+                " | ",
+                notDelegable.Select(r =>
+                {
+                    string urn = r.Package?.Urn ?? "unknown";
+                    string reasons = r.Reasons is not null && r.Reasons.Any()
+                        ? string.Join("; ", r.Reasons.Select(reason => reason.Description))
+                        : "no reason provided";
+                    return $"{urn}: {reasons}";
+                }));
+
+            logger.LogError(
+                "Authentication // DelegationHelper // ValidateDelegationRightsForAccessPackages // Access package(s) not delegable // Party: {PartyId}, System: {SystemId}, NotDelegable: {NotDelegable}",
+                partyId,
+                systemId,
+                notDelegableDetails);
+
             return new Result<AccessPackageDelegationCheckResult>(Problem.AccessPackage_Delegation_MissingRequiredAccess);
         }
     }

--- a/src/Core/Problems/Problem.cs
+++ b/src/Core/Problems/Problem.cs
@@ -412,5 +412,29 @@ public static class Problem
     /// Gets a <see cref="ProblemDescriptor"/>.
     /// </summary>
     public static ProblemDescriptor SystemUser_FailedToAddAsAgent { get; }
-        = _factory.Create(67, HttpStatusCode.BadRequest, "Unable to add system user as agent for the organisation");    
+        = _factory.Create(67, HttpStatusCode.BadRequest, "Unable to add system user as agent for the organisation");
+
+    /// <summary>
+    /// Gets a <see cref="ProblemDescriptor"/>.
+    /// </summary>
+    public static ProblemDescriptor DelegationRightMissingPackageAccess { get; }
+        = _factory.Create(68, HttpStatusCode.Forbidden, "DelegationCheck failed with error: Has not access by a delegation of package in Altinn.");
+
+    /// <summary>
+    /// Gets a <see cref="ProblemDescriptor"/>.
+    /// </summary>
+    public static ProblemDescriptor DelegationRightAccessListValidationFail { get; }
+        = _factory.Create(69, HttpStatusCode.Forbidden, "DelegationCheck failed with error: The receiver does not have the right based on Access List delegation.");
+
+    /// <summary>
+    /// Gets a <see cref="ProblemDescriptor"/>.
+    /// </summary>
+    public static ProblemDescriptor DelegationRightResourceNotDelegable { get; }
+        = _factory.Create(70, HttpStatusCode.Forbidden, "DelegationCheck failed with error: The resource cannot be delegated to another user or entity.");
+
+    /// <summary>
+    /// Gets a <see cref="ProblemDescriptor"/>.
+    /// </summary>
+    public static ProblemDescriptor DelegationRightResourceIsMaskinPortenSchema { get; }
+        = _factory.Create(71, HttpStatusCode.Forbidden, "DelegationCheck failed with error: The resource is not delegable because it is a Maskinporten schema resource.");
 }

--- a/src/Integration/AccessManagement/AccessManagementClient.cs
+++ b/src/Integration/AccessManagement/AccessManagementClient.cs
@@ -132,9 +132,13 @@ public class AccessManagementClient : IAccessManagementClient
             HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, cancellationToken: cancellationToken);
             if (!response.IsSuccessStatusCode)
             {
-                string responseContent = await response.Content.ReadAsStringAsync();
-                ProblemDetails problemDetails = JsonSerializer.Deserialize<ProblemDetails>(responseContent, _serializerOptions)!;
-                _logger.LogError($"Authentication. // AccessManagementClient // CheckDelegationAccess // Title: {problemDetails.Title}, HttpStatusCode : {response.StatusCode},Problem: {problemDetails.Detail}");
+                string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                _logger.LogError(
+                    "Authentication // AccessManagementClient // CheckDelegationAccess // Delegation check failed // HttpStatusCode: {StatusCode}, Party: {PartyUuid}, Resource: {Resource}, ResponseBody: {ResponseBody}",
+                    response.StatusCode,
+                    partyUuid,
+                    resource,
+                    responseContent);
                 return null;
             }
             return await response.Content.ReadFromJsonAsync<ResourceCheckDto>(_serializerOptions, cancellationToken);
@@ -172,10 +176,14 @@ public class AccessManagementClient : IAccessManagementClient
                 }
                 else
                 {
-                    string responseContent = await response.Content.ReadAsStringAsync();
-                    ProblemDetails problemDetails = JsonSerializer.Deserialize<ProblemDetails>(responseContent, _serializerOptions)!;
-                    _logger.LogError($"Authentication. // AccessManagementClient // CheckDelegationAccessForAccessPackage // Title: {problemDetails.Title}, HttpStatusCode : {response.StatusCode},Problem: {problemDetails.Detail}");
-                    problemInstance = ProblemInstance.Create(Problem.AccessPackage_DelegationCheckFailed);                    
+                    string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                    _logger.LogError(
+                        "Authentication // AccessManagementClient // CheckDelegationAccessForAccessPackage // Delegation check failed // HttpStatusCode: {StatusCode}, Party: {PartyId}, Packages: {Packages}, ResponseBody: {ResponseBody}",
+                        response.StatusCode,
+                        partyId,
+                        string.Join(", ", requestedPackages ?? []),
+                        responseContent);
+                    problemInstance = ProblemInstance.Create(Problem.AccessPackage_DelegationCheckFailed);
                 }
                 
             }

--- a/test/Altinn.Platform.Authentication.Tests/Clients/AccessManagementClientTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Clients/AccessManagementClientTests.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Altinn.Authentication.Core.Problems;
+using Altinn.Authentication.Integration.Configuration;
+using Altinn.Authorization.ProblemDetails;
+using Altinn.Common.AccessTokenClient.Services;
+using Altinn.Platform.Authentication.Core.Models.AccessPackages;
+using Altinn.Platform.Authentication.Core.Models.Rights;
+using Altinn.Platform.Authentication.Core.Models.Rights.ConnectionsDtos;
+using Altinn.Platform.Authentication.Integration.AccessManagement;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Altinn.Platform.Authentication.Tests.Clients
+{
+    /// <summary>
+    /// Tests for <see cref="AccessManagementClient"/>, covering that the response body from
+    /// Access Management is logged when a delegation check fails (issue #2027).
+    /// </summary>
+    public class AccessManagementClientTests
+    {
+        private readonly Mock<ILogger<AccessManagementClient>> _loggerMock = new();
+
+        [Fact]
+        public async Task CheckDelegationAccess_Non200_LogsStatusCodePartyResourceAndResponseBody_ReturnsNull()
+        {
+            // Arrange
+            Guid partyUuid = Guid.NewGuid();
+            const string resource = "ttd-am-k6";
+            const string responseBody = "{\"title\":\"Forbidden\",\"detail\":\"Party does not have permission to perform delegation check\"}";
+            var client = CreateClient(CreateHttpClient(HttpStatusCode.Forbidden, responseBody));
+
+            // Act
+            ResourceCheckDto? result = await client.CheckDelegationAccess(partyUuid, resource, CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+            VerifyErrorLogged("Forbidden", partyUuid.ToString(), resource, responseBody);
+        }
+
+        [Fact]
+        public async Task CheckDelegationAccess_Non200_NonJsonBody_DoesNotThrow_LogsRawBody()
+        {
+            // Arrange: a gateway/proxy error returning plain text instead of ProblemDetails JSON.
+            // Before the fix this threw a JsonException and the body was never logged.
+            Guid partyUuid = Guid.NewGuid();
+            const string responseBody = "502 Bad Gateway - upstream timed out";
+            var client = CreateClient(CreateHttpClient(HttpStatusCode.BadGateway, responseBody, "text/plain"));
+
+            // Act
+            ResourceCheckDto? result = await client.CheckDelegationAccess(partyUuid, "some-resource", CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+            VerifyErrorLogged("BadGateway", partyUuid.ToString(), responseBody);
+        }
+
+        [Fact]
+        public async Task CheckDelegationAccess_200_ReturnsDto_NoErrorLogged()
+        {
+            // Arrange
+            const string responseBody = "{\"resource\":{\"refId\":\"ttd-am-k6\"},\"rights\":[{\"right\":{\"key\":\"read\"},\"result\":true}]}";
+            var client = CreateClient(CreateHttpClient(HttpStatusCode.OK, responseBody));
+
+            // Act
+            ResourceCheckDto? result = await client.CheckDelegationAccess(Guid.NewGuid(), "ttd-am-k6", CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Single(result.Rights);
+            VerifyNoErrorLogged();
+        }
+
+        [Fact]
+        public async Task CheckDelegationAccessForAccessPackage_Non200_LogsStatusCodePartyPackagesAndResponseBody_ReturnsProblem()
+        {
+            // Arrange
+            Guid partyId = Guid.NewGuid();
+            const string packageUrn = "urn:altinn:accesspackage:skattnaering";
+            const string responseBody = "{\"title\":\"Internal Server Error\",\"detail\":\"Delegation check failed unexpectedly\"}";
+            var client = CreateClient(CreateHttpClient(HttpStatusCode.InternalServerError, responseBody));
+
+            // Act
+            List<Result<AccessPackageDto.Check>> results = [];
+            await foreach (Result<AccessPackageDto.Check> result in client.CheckDelegationAccessForAccessPackage(partyId, [packageUrn], CancellationToken.None))
+            {
+                results.Add(result);
+            }
+
+            // Assert
+            Result<AccessPackageDto.Check> single = Assert.Single(results);
+            Assert.True(single.IsProblem);
+            Assert.Equal(Problem.AccessPackage_DelegationCheckFailed.Detail, single.Problem!.Detail);
+            VerifyErrorLogged("InternalServerError", partyId.ToString(), packageUrn, responseBody);
+        }
+
+        [Fact]
+        public async Task CheckDelegationAccessForAccessPackage_Non200_NonJsonBody_DoesNotThrow_LogsRawBody()
+        {
+            // Arrange
+            Guid partyId = Guid.NewGuid();
+            const string responseBody = "Service Unavailable";
+            var client = CreateClient(CreateHttpClient(HttpStatusCode.ServiceUnavailable, responseBody, "text/plain"));
+
+            // Act
+            List<Result<AccessPackageDto.Check>> results = [];
+            await foreach (Result<AccessPackageDto.Check> result in client.CheckDelegationAccessForAccessPackage(partyId, ["urn:altinn:accesspackage:skattnaering"], CancellationToken.None))
+            {
+                results.Add(result);
+            }
+
+            // Assert
+            Result<AccessPackageDto.Check> single = Assert.Single(results);
+            Assert.True(single.IsProblem);
+            VerifyErrorLogged("ServiceUnavailable", responseBody);
+        }
+
+        private static HttpClient CreateHttpClient(HttpStatusCode statusCode, string responseBody, string mediaType = "application/json")
+        {
+            Mock<HttpMessageHandler> handlerMock = new();
+            handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage(statusCode)
+                {
+                    Content = new StringContent(responseBody, Encoding.UTF8, mediaType)
+                });
+
+            return new HttpClient(handlerMock.Object);
+        }
+
+        private AccessManagementClient CreateClient(HttpClient httpClient)
+        {
+            DefaultHttpContext httpContext = new();
+            httpContext.Request.Headers.Authorization = "Bearer unittest-token";
+
+            Mock<IHttpContextAccessor> httpContextAccessorMock = new();
+            httpContextAccessorMock.Setup(a => a.HttpContext).Returns(httpContext);
+
+            IOptions<AccessManagementSettings> accessManagementSettings = Options.Create(new AccessManagementSettings
+            {
+                ApiAccessManagementEndpoint = "http://localhost:5117/accessmanagement/api/v1/"
+            });
+
+            IOptions<PlatformSettings> platformSettings = Options.Create(new PlatformSettings
+            {
+                JwtCookieName = "AltinnStudioRuntime"
+            });
+
+            return new AccessManagementClient(
+                httpClient,
+                _loggerMock.Object,
+                httpContextAccessorMock.Object,
+                accessManagementSettings,
+                platformSettings,
+                new Mock<IWebHostEnvironment>().Object,
+                new Mock<IAccessTokenGenerator>().Object);
+        }
+
+        private void VerifyErrorLogged(params string[] expectedFragments)
+        {
+            _loggerMock.Verify(
+                l => l.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((state, _) => expectedFragments.All(fragment => state.ToString()!.Contains(fragment))),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+
+        private void VerifyNoErrorLogged()
+        {
+            _loggerMock.Verify(
+                l => l.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Never);
+        }
+    }
+}

--- a/test/Altinn.Platform.Authentication.Tests/Helpers/DelegationHelperTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Helpers/DelegationHelperTests.cs
@@ -10,6 +10,8 @@ using Altinn.Platform.Authentication.Core.Models.AccessPackages;
 using Altinn.Platform.Authentication.Core.Models.Rights;
 using Altinn.Platform.Authentication.Integration.AccessManagement;
 using Altinn.Platform.Authentication.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -180,7 +182,7 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
                     .Select(c => new Result<AccessPackageDto.Check>(c)) // Use constructor
                     .ToAsyncEnumerable());
 
-            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object);
+            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object, NullLogger<DelegationHelper>.Instance);
 
             // Act
             var result = await helper.ValidateDelegationRightsForAccessPackages(Guid.NewGuid(), "sys", requested, false, CancellationToken.None);
@@ -204,7 +206,7 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
                 .Setup(s => s.GetAccessPackagesForRegisteredSystem(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(systemPackages);
 
-            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object);
+            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object, NullLogger<DelegationHelper>.Instance);
 
             // Act
             var result = await helper.ValidateDelegationRightsForAccessPackages(Guid.NewGuid(), "sys", requested, false, CancellationToken.None);
@@ -230,7 +232,12 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
 
             var checkResult = new List<AccessPackageDto.Check>
             {
-                new() { Package = new(), Result = false, Reasons = new List<AccessPackageDto.Check.Reason> { new() { Description = "Not allowed" } } }
+                new()
+                {
+                    Package = new() { Urn = "urn:valid" },
+                    Result = false,
+                    Reasons = new List<AccessPackageDto.Check.Reason> { new() { Description = "Not allowed" } }
+                }
             };
 
             accessManagementClient
@@ -239,7 +246,8 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
                 .Select(c => new Result<AccessPackageDto.Check>(c)) // Use constructor
                 .ToAsyncEnumerable());
 
-            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object);
+            var loggerMock = new Mock<ILogger<DelegationHelper>>();
+            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object, loggerMock.Object);
 
             // Act
             var result = await helper.ValidateDelegationRightsForAccessPackages(Guid.NewGuid(), "sys", requested, false, CancellationToken.None);
@@ -247,6 +255,16 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
             // Assert
             Assert.True(result.IsProblem);
             Assert.Equal(Problem.AccessPackage_Delegation_MissingRequiredAccess.Detail, result.Problem.Detail);
+
+            // Issue #2027: the failed package urn and its reason must be logged so the failure is debuggable in App Insights.
+            loggerMock.Verify(
+                l => l.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("urn:valid") && state.ToString()!.Contains("Not allowed")),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
         }
 
         [Fact]
@@ -266,7 +284,7 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
                 .Setup(a => a.CheckDelegationAccessForAccessPackage(It.IsAny<Guid>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
                 .Returns(AsyncEnumerable.Empty<Result<AccessPackageDto.Check>>());
 
-            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object);
+            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object, NullLogger<DelegationHelper>.Instance);
 
             // Act
             var result = await helper.ValidateDelegationRightsForAccessPackages(Guid.NewGuid(), "sys", requested, false, CancellationToken.None);
@@ -293,7 +311,7 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
                 .Setup(a => a.CheckDelegationAccessForAccessPackage(It.IsAny<Guid>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
                 .Returns(AsyncEnumerable.Empty<Result<AccessPackageDto.Check>>());
 
-            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object);
+            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object, NullLogger<DelegationHelper>.Instance);
 
             // Act
             var result = await helper.ValidateDelegationRightsForAccessPackages(Guid.NewGuid(), "sys", requested, false, CancellationToken.None);
@@ -357,7 +375,7 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
                 .Setup(a => a.CheckDelegationAccess(It.IsAny<Guid>(), It.IsAny<string>()))
                 .ReturnsAsync(dto);
 
-            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object);
+            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object, NullLogger<DelegationHelper>.Instance);
 
             // Act
             var result = await helper.UserDelegationCheckForReportee(Guid.NewGuid(), "sys", requestedRights, false);
@@ -383,7 +401,7 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
                 .Setup(s => s.GetRightsForRegisteredSystem(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<Right>());
 
-            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object);
+            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object, NullLogger<DelegationHelper>.Instance);
 
             // Act
             var result = await helper.UserDelegationCheckForReportee(Guid.NewGuid(), "sys", new List<Right> { requestedRight }, false);
@@ -438,7 +456,7 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
                 .Setup(a => a.CheckDelegationAccess(It.IsAny<Guid>(), It.IsAny<string>()))
                 .ReturnsAsync(dto);
 
-            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object);
+            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object, NullLogger<DelegationHelper>.Instance);
 
             // Act
             var result = await helper.UserDelegationCheckForReportee(Guid.NewGuid(), "sys", new List<Right> { right }, false);
@@ -492,7 +510,8 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
                 .Setup(a => a.CheckDelegationAccess(It.IsAny<Guid>(), It.IsAny<string>()))
                 .ReturnsAsync(dto);
 
-            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object);
+            var loggerMock = new Mock<ILogger<DelegationHelper>>();
+            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object, loggerMock.Object);
 
             // Act
             var result = await helper.UserDelegationCheckForReportee(Guid.NewGuid(), "sys", new List<Right> { right }, false);
@@ -502,6 +521,16 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
             Assert.NotNull(result.RightResponses);
             Assert.NotEmpty(result.errors);
             Assert.Contains(result.errors, e => e.Description == "Delegation denied");
+
+            // Issue #2027: the reason the right is not delegable must be logged for App Insights.
+            loggerMock.Verify(
+                l => l.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("not delegable") && state.ToString()!.Contains("Delegation denied")),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
         }
     }
 }

--- a/test/Altinn.Platform.Authentication.Tests/Helpers/DelegationHelperTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Helpers/DelegationHelperTests.cs
@@ -49,6 +49,70 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
         }
 
         [Fact]
+        public void MapDetailExternalErrorListToProblemInstance_MissingPackageAccess_ReturnsDelegationRightMissingPackageAccess()
+        {
+            // Arrange
+            var errors = new List<DetailExternal>
+            {
+                new DetailExternal { Code = DetailCodeExternal.MissingPackageAccess, Description = "Missing package access" }
+            };
+
+            // Act
+            var result = DelegationHelper.MapDetailExternalErrorListToProblemInstance(errors);
+
+            // Assert
+            Assert.Equal(Problem.DelegationRightMissingPackageAccess, result);
+        }
+
+        [Fact]
+        public void MapDetailExternalErrorListToProblemInstance_AccessListValidationFail_ReturnsDelegationRightAccessListValidationFail()
+        {
+            // Arrange
+            var errors = new List<DetailExternal>
+            {
+                new DetailExternal { Code = DetailCodeExternal.AccessListValidationFail, Description = "Access list validation failed" }
+            };
+
+            // Act
+            var result = DelegationHelper.MapDetailExternalErrorListToProblemInstance(errors);
+
+            // Assert
+            Assert.Equal(Problem.DelegationRightAccessListValidationFail, result);
+        }
+
+        [Fact]
+        public void MapDetailExternalErrorListToProblemInstance_ResourceNotDelegable_ReturnsDelegationRightResourceNotDelegable()
+        {
+            // Arrange
+            var errors = new List<DetailExternal>
+            {
+                new DetailExternal { Code = DetailCodeExternal.ResourceNotDelegable, Description = "Resource not delegable" }
+            };
+
+            // Act
+            var result = DelegationHelper.MapDetailExternalErrorListToProblemInstance(errors);
+
+            // Assert
+            Assert.Equal(Problem.DelegationRightResourceNotDelegable, result);
+        }
+
+        [Fact]
+        public void MapDetailExternalErrorListToProblemInstance_ResourceIsMaskinPortenSchema_ReturnsDelegationRightResourceIsMaskinPortenSchema()
+        {
+            // Arrange
+            var errors = new List<DetailExternal>
+            {
+                new DetailExternal { Code = DetailCodeExternal.ResourceIsMaskinPortenSchema, Description = "Maskinporten schema resource" }
+            };
+
+            // Act
+            var result = DelegationHelper.MapDetailExternalErrorListToProblemInstance(errors);
+
+            // Assert
+            Assert.Equal(Problem.DelegationRightResourceIsMaskinPortenSchema, result);
+        }
+
+        [Fact]
         public void MapDetailExternalErrorListToProblemInstance_MissingRoleAccess_ReturnsDelegationRightMissingRoleAccess()
         {
             // Arrange
@@ -494,13 +558,21 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
                         Key = "right1"
                     },
                     Result = false,
-                    Permissions = 
+                    Permissions =
                     [
-                        new Permision() 
-                        { 
-                            Description = "Delegation denied",                            
+                        new Permision()
+                        {
+                            Description = "Delegation denied",
                             PermisionKey = DetailCodeExternal.MissingDelegationAccess
                         }
+                    ],
+
+                    // Access Management returns the actual reason in ReasonCodes (see issue #2027 sample response).
+                    ReasonCodes =
+                    [
+                        DetailCodeExternal.MissingPackageAccess,
+                        DetailCodeExternal.MissingRoleAccess,
+                        DetailCodeExternal.MissingDelegationAccess
                     ]
                 }
             ]
@@ -522,15 +594,72 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
             Assert.NotEmpty(result.errors);
             Assert.Contains(result.errors, e => e.Description == "Delegation denied");
 
-            // Issue #2027: the reason the right is not delegable must be logged for App Insights.
+            // Issue #2027: the reason codes returned by Access Management must be logged for App Insights.
             loggerMock.Verify(
                 l => l.Log(
                     LogLevel.Error,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("not delegable") && state.ToString()!.Contains("Delegation denied")),
+                    It.Is<It.IsAnyType>((state, _) =>
+                        state.ToString()!.Contains("not delegable")
+                        && state.ToString()!.Contains("MissingPackageAccess")
+                        && state.ToString()!.Contains("MissingRoleAccess")
+                        && state.ToString()!.Contains("MissingDelegationAccess")),
                     It.IsAny<Exception?>(),
                     It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
+        }
+
+        [Fact]
+        public async Task UserDelegationCheckForReportee_NotDelegable_ReasonCodesOnly_PopulatesErrorsFromReasonCodes()
+        {
+            // Arrange: mirrors the actual Access Management 200 response where the reason is carried
+            // in ReasonCodes and Permissions is empty (issue #2027 sample response).
+            var systemRegisterService = new Mock<ISystemRegisterService>();
+            var accessManagementClient = new Mock<IAccessManagementClient>();
+
+            var right = new Right { Action = "read", Resource = new List<AttributePair>() };
+            systemRegisterService
+                .Setup(s => s.GetRightsForRegisteredSystem(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Right> { right });
+
+            ResourceCheckDto dto = new()
+            {
+                Resource = new ResourceDto() { Id = Guid.NewGuid(), RefId = "change-request-jordbruk" },
+                Rights =
+                [
+                    new RightCheckDto()
+                    {
+                        Right = new() { Key = "right1" },
+                        Result = false,
+                        ReasonCodes =
+                        [
+                            DetailCodeExternal.MissingPackageAccess,
+                            DetailCodeExternal.MissingRoleAccess,
+                            DetailCodeExternal.MissingDelegationAccess
+                        ]
+                    }
+                ]
+            };
+
+            accessManagementClient
+                .Setup(a => a.CheckDelegationAccess(It.IsAny<Guid>(), It.IsAny<string>()))
+                .ReturnsAsync(dto);
+
+            var helper = new DelegationHelper(systemRegisterService.Object, accessManagementClient.Object, NullLogger<DelegationHelper>.Instance);
+
+            // Act
+            var result = await helper.UserDelegationCheckForReportee(Guid.NewGuid(), "sys", new List<Right> { right }, false);
+
+            // Assert: errors are now populated from ReasonCodes (previously empty because only Permissions was read).
+            Assert.False(result.CanDelegate);
+            Assert.NotNull(result.errors);
+            Assert.Contains(result.errors, e => e.Code == DetailCodeExternal.MissingPackageAccess);
+            Assert.Contains(result.errors, e => e.Code == DetailCodeExternal.MissingRoleAccess);
+            Assert.Contains(result.errors, e => e.Code == DetailCodeExternal.MissingDelegationAccess);
+
+            // The first reason code maps to a specific problem instead of the generic UnableToDoDelegationCheck.
+            var problem = DelegationHelper.MapDetailExternalErrorListToProblemInstance(result.errors);
+            Assert.Equal(Problem.DelegationRightMissingPackageAccess, problem);
         }
     }
 }


### PR DESCRIPTION
Fix the logging and test if the information is logged with required details for troubleshooting

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for delegation checks (captures HTTP status, identifiers, requested resources/packages, and raw response bodies) and logs non-delegable resource/access-package reasons when checks indicate missing delegation.
  * Added new problem descriptors for delegation-related access failures to improve user-facing error responses.

* **Tests**
  * Added and expanded unit tests covering delegation checks, non-200/error bodies, reason-code handling, and logging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->