### PR TITLE
refactor: build SI account-link URL from GeneralSettings.HostName

### DIFF
--- a/src/Authentication/Configuration/SelfIdentifiedLinkSettings.cs
+++ b/src/Authentication/Configuration/SelfIdentifiedLinkSettings.cs
@@ -1,20 +1,14 @@
 #nullable enable
-using System;
 
 namespace Altinn.Platform.Authentication.Configuration
 {
     /// <summary>
-    /// Settings for the self-identified account-link request flow (issue #2035): where the emailed
-    /// link points and the email subject.
+    /// Settings for the self-identified account-link request flow (issue #2035). The access-management
+    /// landing URL is derived from <see cref="GeneralSettings.HostName"/> (see
+    /// <c>SelfIdentifiedLinkService</c>), so only the email subject is configured here.
     /// </summary>
     public class SelfIdentifiedLinkSettings
     {
-        /// <summary>
-        /// Gets or sets the access-management frontend URL that consumes the link token. The token is
-        /// appended as a <c>token</c> query parameter. Required for the email flow; no default.
-        /// </summary>
-        public Uri? AccessManagementLinkUrl { get; set; }
-
         /// <summary>
         /// Gets or sets the subject of the account-link email. (Localization of subject/body is a
         /// tracked follow-up in #2035.)

--- a/src/Authentication/Services/SelfIdentifiedLinkService.cs
+++ b/src/Authentication/Services/SelfIdentifiedLinkService.cs
@@ -20,10 +20,18 @@ namespace Altinn.Platform.Authentication.Services
     /// </summary>
     public class SelfIdentifiedLinkService : ISelfIdentifiedLinkService
     {
+        // Access-management frontend landing route that consumes the link token. Built from
+        // GeneralSettings.HostName the same way the system-user confirm URLs are
+        // (see RequestSystemUserController/ChangeRequestSystemUserController), so the AM frontend
+        // host is configured in exactly one place (HostName) per environment.
+        private const string LandingUrlPrefix = "https://am.ui.";
+        private const string LandingUrlPath = "/accessmanagement/ui/altinn2account";
+
         private readonly IUserProfileService _userProfileService;
         private readonly ISelfIdentifiedLinkTokenService _linkTokenService;
         private readonly IAltinnNotificationClient _notificationClient;
         private readonly SelfIdentifiedLinkSettings _settings;
+        private readonly GeneralSettings _generalSettings;
         private readonly TimeProvider _timeProvider;
         private readonly ILogger<SelfIdentifiedLinkService> _logger;
 
@@ -35,6 +43,7 @@ namespace Altinn.Platform.Authentication.Services
             ISelfIdentifiedLinkTokenService linkTokenService,
             IAltinnNotificationClient notificationClient,
             IOptions<SelfIdentifiedLinkSettings> settings,
+            IOptions<GeneralSettings> generalSettings,
             TimeProvider timeProvider,
             ILogger<SelfIdentifiedLinkService> logger)
         {
@@ -42,6 +51,7 @@ namespace Altinn.Platform.Authentication.Services
             _linkTokenService = linkTokenService;
             _notificationClient = notificationClient;
             _settings = settings.Value;
+            _generalSettings = generalSettings.Value;
             _timeProvider = timeProvider;
             _logger = logger;
         }
@@ -60,13 +70,14 @@ namespace Altinn.Platform.Authentication.Services
                 return null;
             }
 
-            if (_settings.AccessManagementLinkUrl is null)
+            if (string.IsNullOrEmpty(_generalSettings.HostName))
             {
-                throw new InvalidOperationException("SelfIdentifiedLinkSettings.AccessManagementLinkUrl is not configured.");
+                throw new InvalidOperationException("GeneralSettings.HostName is not configured; cannot build the access-management link URL.");
             }
 
             string token = await _linkTokenService.MintAsync(target.PartyUuid, toPartyUuid, cancellationToken);
-            string linkUrl = QueryHelpers.AddQueryString(_settings.AccessManagementLinkUrl.AbsoluteUri, "token", token);
+            string baseUrl = $"{LandingUrlPrefix}{_generalSettings.HostName}{LandingUrlPath}";
+            string linkUrl = QueryHelpers.AddQueryString(baseUrl, "token", token);
             string body = BuildEmailBody(linkUrl);
 
             // Idempotency id is bucketed to the minute so accidental double-submits (the same from/to

--- a/src/Authentication/Services/SelfIdentifiedLinkService.cs
+++ b/src/Authentication/Services/SelfIdentifiedLinkService.cs
@@ -70,13 +70,13 @@ namespace Altinn.Platform.Authentication.Services
                 return null;
             }
 
-            if (string.IsNullOrEmpty(_generalSettings.HostName))
+            if (string.IsNullOrWhiteSpace(_generalSettings.HostName))
             {
                 throw new InvalidOperationException("GeneralSettings.HostName is not configured; cannot build the access-management link URL.");
             }
 
             string token = await _linkTokenService.MintAsync(target.PartyUuid, toPartyUuid, cancellationToken);
-            string baseUrl = $"{LandingUrlPrefix}{_generalSettings.HostName}{LandingUrlPath}";
+            string baseUrl = $"{LandingUrlPrefix}{_generalSettings.HostName.Trim()}{LandingUrlPath}";
             string linkUrl = QueryHelpers.AddQueryString(baseUrl, "token", token);
             string body = BuildEmailBody(linkUrl);
 

--- a/src/Authentication/appsettings.json
+++ b/src/Authentication/appsettings.json
@@ -50,9 +50,6 @@
     "SubscriptionKeyHeaderName": "Ocp-Apim-Subscription-Key",
     "JwtCookieName": "AltinnStudioRuntime"
   },
-  "SelfIdentifiedLinkSettings": {
-    "AccessManagementLinkUrl": "https://am.ui.at22.altinn.cloud/accessmanagement/ui/profile/selfidentified-link"
-  },
   "CertificateSettings": {
     "CertificateName": "JWTCertificate",
     "CertificatePwd": "qwer1234",

--- a/test/Altinn.Platform.Authentication.Tests/Services/SelfIdentifiedLinkServiceTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Services/SelfIdentifiedLinkServiceTests.cs
@@ -31,10 +31,17 @@ public class SelfIdentifiedLinkServiceTests
     private readonly Mock<ISelfIdentifiedLinkTokenService> _tokenService = new();
     private readonly Mock<IAltinnNotificationClient> _notification = new();
 
+    private const string HostName = "at22.altinn.cloud";
+
     private readonly SelfIdentifiedLinkSettings _settings = new()
     {
-        AccessManagementLinkUrl = new Uri("https://am.example/accessmanagement/ui/selfidentified-link"),
         EmailSubject = "Test subject",
+    };
+
+    private readonly GeneralSettings _generalSettings = new()
+    {
+        HostName = HostName,
+        OidcRefreshTokenPepper = "unit-test-pepper",
     };
 
     [Fact]
@@ -64,7 +71,7 @@ public class SelfIdentifiedLinkServiceTests
         Assert.Equal(Email, sentTo);
         Assert.Equal("Test subject", sentSubject);
         Assert.NotNull(sentBody);
-        Assert.Contains($"{_settings.AccessManagementLinkUrl}?token={Token}", sentBody!);
+        Assert.Contains($"https://am.ui.{HostName}/accessmanagement/ui/altinn2account?token={Token}", sentBody!);
 
         // Caller gets the masked address, never the full one.
         Assert.Equal("s*****@e****.com", masked);
@@ -118,6 +125,7 @@ public class SelfIdentifiedLinkServiceTests
             _tokenService.Object,
             _notification.Object,
             Options.Create(_settings),
+            Options.Create(_generalSettings),
             TimeProvider.System,
             NullLogger<SelfIdentifiedLinkService>.Instance);
 }


### PR DESCRIPTION
@
Follow-up to #2036 (self-identified account-link flow).

The emailed forgot-password link is built as `{base}?token={jwt}`. Originally the base came from a bespoke `SelfIdentifiedLinkSettings.AccessManagementLinkUrl` setting (a full URL configured per environment). This reuses the existing AM-frontend URL convention instead — the same one `RequestSystemUserController`, `ChangeRequestSystemUserController` and `LogoutController` already use:

```
https://am.ui.{GeneralSettings.HostName}/accessmanagement/ui/<path>
```

## Changes
- `SelfIdentifiedLinkService` now builds `https://am.ui.{HostName}/accessmanagement/ui/altinn2account?token={jwt}` from the already-configured `GeneralSettings.HostName` (AT22 → `https://am.ui.at22.altinn.cloud/accessmanagement/ui/altinn2account?token=…`, the route AM listens on).
- Removed `SelfIdentifiedLinkSettings.AccessManagementLinkUrl` and its `appsettings.json` entry; the setting now only carries the email subject.
- Injected `IOptions<GeneralSettings>`; throws a clear error if `HostName` is unset.
- Tests updated to assert the HostName-derived URL.

## Why
The AM frontend host is now configured in **one place** (`HostName`, already set per environment) instead of a duplicated full URL — so AT22/TT02/prod work with no extra config, consistent with the rest of the codebase.

Refs #2035

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated email link URL configuration by removing redundant settings.
  * Updated how the system derives and constructs access-management email links using hostname configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->