### PR TITLE
add support for nynorsk and english forgot password email template

### DIFF
--- a/src/Authentication/Configuration/SelfIdentifiedLinkSettings.cs
+++ b/src/Authentication/Configuration/SelfIdentifiedLinkSettings.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using System.Collections.Generic;
+
 namespace Altinn.Platform.Authentication.Configuration
 {
     /// <summary>
@@ -13,6 +15,11 @@ namespace Altinn.Platform.Authentication.Configuration
         /// Gets or sets the subject of the account-link email. (Localization of subject/body is a
         /// tracked follow-up in #2035.)
         /// </summary>
-        public string EmailSubject { get; set; } = "Altinn - kobling av selvidentifisert bruker";
+        public Dictionary<string, string> EmailSubject { get; set; } = new()
+        {
+            ["no_nb"] = "Altinn - kobling av selvidentifisert bruker",
+            ["no_nn"] = "Altinn - kopling av sjølvidentifisert brukar",
+            ["en"] = "Altinn - link of self-identified user",
+        };
     }
 }

--- a/src/Authentication/Controllers/SelfIdentifiedAuthenticationController.cs
+++ b/src/Authentication/Controllers/SelfIdentifiedAuthenticationController.cs
@@ -79,7 +79,7 @@ namespace Altinn.Platform.Authentication.Controllers
         /// </summary>
         [HttpPost("link-request")]
         [Authorize(Policy = AuthzConstants.POLICY_SCOPE_PORTAL)]
-        public async Task<ActionResult> RequestLink([FromQuery] string lang, [FromBody] SelfIdentifiedLinkRequest request, CancellationToken cancellationToken)
+        public async Task<ActionResult> RequestLink([FromQuery] string? lang, [FromBody] SelfIdentifiedLinkRequest request, CancellationToken cancellationToken)
         {
             Guid toPartyUuid = AuthenticationHelper.GetPartyUuId(HttpContext);
             if (toPartyUuid == Guid.Empty)
@@ -89,7 +89,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 return AuthProblem.SelfIdentifiedLink_MissingPartyUuid.ToActionResult();
             }
 
-            string? maskedEmail = await _linkService.RequestLinkAsync(request.UserName, toPartyUuid, lang, cancellationToken);
+            string? maskedEmail = await _linkService.RequestLinkAsync(request.UserName, toPartyUuid, lang ?? string.Empty, cancellationToken);
 
             return Ok(new SelfIdentifiedLinkResponse { MaskedEmail = maskedEmail });
         }

--- a/src/Authentication/Controllers/SelfIdentifiedAuthenticationController.cs
+++ b/src/Authentication/Controllers/SelfIdentifiedAuthenticationController.cs
@@ -79,7 +79,7 @@ namespace Altinn.Platform.Authentication.Controllers
         /// </summary>
         [HttpPost("link-request")]
         [Authorize(Policy = AuthzConstants.POLICY_SCOPE_PORTAL)]
-        public async Task<ActionResult> RequestLink([FromBody] SelfIdentifiedLinkRequest request, CancellationToken cancellationToken)
+        public async Task<ActionResult> RequestLink([FromQuery] string lang, [FromBody] SelfIdentifiedLinkRequest request, CancellationToken cancellationToken)
         {
             Guid toPartyUuid = AuthenticationHelper.GetPartyUuId(HttpContext);
             if (toPartyUuid == Guid.Empty)
@@ -89,7 +89,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 return AuthProblem.SelfIdentifiedLink_MissingPartyUuid.ToActionResult();
             }
 
-            string? maskedEmail = await _linkService.RequestLinkAsync(request.UserName, toPartyUuid, cancellationToken);
+            string? maskedEmail = await _linkService.RequestLinkAsync(request.UserName, toPartyUuid, lang, cancellationToken);
 
             return Ok(new SelfIdentifiedLinkResponse { MaskedEmail = maskedEmail });
         }

--- a/src/Authentication/Services/Interfaces/ISelfIdentifiedLinkService.cs
+++ b/src/Authentication/Services/Interfaces/ISelfIdentifiedLinkService.cs
@@ -22,7 +22,10 @@ namespace Altinn.Platform.Authentication.Services.Interfaces
         /// <param name="toPartyUuid">
         /// The authenticated person who triggered the request (the connection <c>to</c> party).
         /// </param>
+        /// <param name="lang">
+        /// The language code "no_nb", "no_nn" or "en" for the email text. Defaults to "no_nb" if not set
+        /// </param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        Task<string?> RequestLinkAsync(string? userName, Guid toPartyUuid, CancellationToken cancellationToken = default);
+        Task<string?> RequestLinkAsync(string? userName, Guid toPartyUuid, string lang = "", CancellationToken cancellationToken = default);
     }
 }

--- a/src/Authentication/Services/SelfIdentifiedLinkService.cs
+++ b/src/Authentication/Services/SelfIdentifiedLinkService.cs
@@ -57,7 +57,7 @@ namespace Altinn.Platform.Authentication.Services
         }
 
         /// <inheritdoc/>
-        public async Task<string?> RequestLinkAsync(string? userName, Guid toPartyUuid, CancellationToken cancellationToken = default)
+        public async Task<string?> RequestLinkAsync(string? userName, Guid toPartyUuid, string lang = "", CancellationToken cancellationToken = default)
         {
             SelfIdentifiedLinkTarget? target =
                 await _userProfileService.GetSelfIdentifiedLinkTargetAsync(userName, cancellationToken);
@@ -78,7 +78,8 @@ namespace Altinn.Platform.Authentication.Services
             string token = await _linkTokenService.MintAsync(target.PartyUuid, toPartyUuid, cancellationToken);
             string baseUrl = $"{LandingUrlPrefix}{_generalSettings.HostName.Trim()}{LandingUrlPath}";
             string linkUrl = QueryHelpers.AddQueryString(baseUrl, "token", token);
-            string body = BuildEmailBody(linkUrl);
+            string body = BuildEmailBody(linkUrl, lang);
+            string subject = _settings.EmailSubject.TryGetValue(lang, out var s) ? s : _settings.EmailSubject["no_nb"];
 
             // Idempotency id is bucketed to the minute so accidental double-submits (the same from/to
             // within the same minute) de-duplicate to a single email on the Notifications side, while a
@@ -87,7 +88,7 @@ namespace Altinn.Platform.Authentication.Services
             string idempotencyId = $"si-link_{target.PartyUuid:N}_{toPartyUuid:N}_{minuteBucket}";
 
             bool sent = await _notificationClient.SendEmailAsync(
-                target.Email, _settings.EmailSubject, body, idempotencyId, cancellationToken);
+                target.Email, subject, body, idempotencyId, cancellationToken);
 
             if (!sent)
             {
@@ -125,17 +126,38 @@ namespace Altinn.Platform.Authentication.Services
             return $"{maskedLocal}@{maskedDomain}";
         }
 
-        private static string BuildEmailBody(string linkUrl)
+        private static string BuildEmailBody(string linkUrl, string lang)
         {
-            // Norwegian template; subject/body localization is a tracked follow-up in #2035.
-            return $"""
-                <p>Hei,</p>
-                <p>Det er bedt om å koble denne selvidentifiserte Altinn-brukeren til en innlogget bruker.</p>
-                <p>Hvis dette var deg, følg lenken under for å fullføre koblingen. Lenken er gyldig en kort stund.</p>
-                <p><a href="{linkUrl}">Fullfør koblingen i Altinn</a></p>
-                <p>Hvis du ikke ba om dette, kan du se bort fra denne e-posten.</p>
-                <p>Med vennlig hilsen,<br>Altinn</p>
-                """;
+            return lang switch
+            {
+                "no_nn" => $"""
+                    <p>Hei,</p>
+                    <p>Det er bedt om å kople denne sjølvidentifiserte Altinn-brukaren til ein innlogga brukar.</p>
+                    <p>Viss dette var deg, følg lenkja under for å fullføre koplinga. Lenkja er gyldig ei kort stund.</p>
+                    <p><a href="{linkUrl}">Fullfør koplinga i Altinn</a></p>
+                    <p>Viss du ikkje bad om dette, kan du sjå bort frå denne e-posten.</p>
+                    <p>Med venleg helsing,<br>Altinn</p>
+                    """,
+
+                "en" => $"""
+                    <p>Hello,</p>
+                    <p>A request has been made to link this self-identified Altinn user to a logged-in user.</p>
+                    <p>If this was you, follow the link below to complete the linking. The link is valid for a short time.</p>
+                    <p><a href="{linkUrl}">Complete the linking in Altinn</a></p>
+                    <p>If you did not request this, you can disregard this email.</p>
+                    <p>Best regards,<br>Altinn</p>
+                    """,
+
+                // Default: Norwegian Bokmål
+                _ => $"""
+                    <p>Hei,</p>
+                    <p>Det er bedt om å koble denne selvidentifiserte Altinn-brukeren til en innlogget bruker.</p>
+                    <p>Hvis dette var deg, følg lenken under for å fullføre koblingen. Lenken er gyldig en kort stund.</p>
+                    <p><a href="{linkUrl}">Fullfør koblingen i Altinn</a></p>
+                    <p>Hvis du ikke ba om dette, kan du se bort fra denne e-posten.</p>
+                    <p>Med vennlig hilsen,<br>Altinn</p>
+                    """
+            };
         }
     }
 }

--- a/test/Altinn.Platform.Authentication.Tests/Services/SelfIdentifiedLinkServiceTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Services/SelfIdentifiedLinkServiceTests.cs
@@ -35,7 +35,12 @@ public class SelfIdentifiedLinkServiceTests
 
     private readonly SelfIdentifiedLinkSettings _settings = new()
     {
-        EmailSubject = "Test subject",
+        EmailSubject = new()
+        {
+            ["no_nb"] = "Test subject NB",
+            ["no_nn"] = "Test subject NN",
+            ["en"] = "Test subject EN",
+        },
     };
 
     private readonly GeneralSettings _generalSettings = new()
@@ -44,8 +49,10 @@ public class SelfIdentifiedLinkServiceTests
         OidcRefreshTokenPepper = "unit-test-pepper",
     };
 
-    [Fact]
-    public async Task RequestLink_ValidTarget_MintsTokenAndSendsEmailWithLink()
+    [Theory]
+    [InlineData("", "Test subject NB")]
+    [InlineData("en", "Test subject EN")]
+    public async Task RequestLink_ValidTarget_MintsTokenAndSendsEmailWithLink(string languageCode, string expectedSubject)
     {
         _profile.Setup(p => p.GetSelfIdentifiedLinkTargetAsync(UserName, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SelfIdentifiedLinkTarget { PartyUuid = FromPartyUuid, Email = Email });
@@ -65,11 +72,11 @@ public class SelfIdentifiedLinkServiceTests
             })
             .ReturnsAsync(true);
 
-        string? masked = await CreateService().RequestLinkAsync(UserName, ToPartyUuid);
+        string? masked = await CreateService().RequestLinkAsync(UserName, ToPartyUuid, languageCode);
 
         _tokenService.Verify(t => t.MintAsync(FromPartyUuid, ToPartyUuid, It.IsAny<CancellationToken>()), Times.Once);
         Assert.Equal(Email, sentTo);
-        Assert.Equal("Test subject", sentSubject);
+        Assert.Equal(expectedSubject, sentSubject);
         Assert.NotNull(sentBody);
         Assert.Contains($"https://am.ui.{HostName}/accessmanagement/ui/altinn2account?token={Token}", sentBody!);
 

--- a/test/Altinn.Platform.Authentication.Tests/Services/SelfIdentifiedLinkServiceTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Services/SelfIdentifiedLinkServiceTests.cs
@@ -51,7 +51,10 @@ public class SelfIdentifiedLinkServiceTests
 
     [Theory]
     [InlineData("", "Test subject NB")]
+    [InlineData("no_nb", "Test subject NB")]
+    [InlineData("no_nn", "Test subject NN")]
     [InlineData("en", "Test subject EN")]
+    [InlineData("unsupported", "Test subject NB")]
     public async Task RequestLink_ValidTarget_MintsTokenAndSendsEmailWithLink(string languageCode, string expectedSubject)
     {
         _profile.Setup(p => p.GetSelfIdentifiedLinkTargetAsync(UserName, It.IsAny<CancellationToken>()))


### PR DESCRIPTION
## Description
- add support for nynorsk and english forgot password email template, instead of always sending email in bokmål

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3601

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multilingual support for self-identified account linking emails. Users can now receive authentication emails in Norwegian Bokmål, Norwegian Nynorsk, or English, with localized subject lines and content.

* **Tests**
  * Enhanced test coverage for localized email verification across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->