### PR TITLE
map UnitType for agent systemuser client, so frontend can display correct avatar for subunits

### DIFF
--- a/src/Authentication/Services/SystemUserService.cs
+++ b/src/Authentication/Services/SystemUserService.cs
@@ -1321,7 +1321,8 @@ namespace Altinn.Platform.Authentication.Services
                     DisplayName = item.Party.Name,
                     OrganizationIdentifier = item.Party.OrganizationNumber,
                     PartyUuid = item.Party.Id,
-                    Access = item.Access
+                    Access = item.Access,
+                    UnitType = item.Party.UnitType
                 };
                 result.Add(newCustomer);
             }
@@ -1380,23 +1381,6 @@ namespace Altinn.Platform.Authentication.Services
             }
 
             return primitiveList;
-        }
-
-        private static Result<List<Customer>> ConvertPartyCustomerToClient(CustomerList value)
-        {
-            List<Customer> result = [];
-            foreach (var item in value.Data)
-            {
-                var newCustomer = new Customer()
-                {
-                    DisplayName = item.DisplayName,
-                    OrganizationIdentifier = item.OrganizationIdentifier,
-                    PartyUuid = item.PartyUuid,
-                };
-                result.Add(newCustomer);
-            }
-
-            return result;
         }
 
         private async Task<Result<Guid>> GetPartyUuId(int partyId, CancellationToken cancellationToken)

--- a/src/Core/Models/Rights/Customer.cs
+++ b/src/Core/Models/Rights/Customer.cs
@@ -31,6 +31,11 @@ namespace Altinn.Platform.Authentication.Core.Models.Rights
         public required string OrganizationIdentifier { get; set; }
 
         /// <summary>
+        /// Gets or sets the unit type if the party is an organization
+        /// </summary>
+        public required string UnitType { get; set; }
+
+        /// <summary>
         /// Gets or sets a collection of all access information for the client 
         /// </summary>
         public List<ClientRoleAccessPackages> Access { get; set; } = [];

--- a/src/Core/Models/Rights/Customer.cs
+++ b/src/Core/Models/Rights/Customer.cs
@@ -33,7 +33,7 @@ namespace Altinn.Platform.Authentication.Core.Models.Rights
         /// <summary>
         /// Gets or sets the unit type if the party is an organization
         /// </summary>
-        public required string UnitType { get; set; }
+        public string? UnitType { get; set; }
 
         /// <summary>
         /// Gets or sets a collection of all access information for the client 


### PR DESCRIPTION
## Description
- map UniType for agent systemuser client, so frontend can display correct avatar for subunits
- remove dead method (instead of changing it to fix build)

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Customer details now include the correct unit type for organization-related records.
  * Fixed a mapping issue so access-related information is handled consistently when customer data is converted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->