### PR TITLE
chore: always redirect logout to BaseUrl, drop SBL logout redirect (#2030)

### DIFF
--- a/src/Authentication/Configuration/FeatureFlags.cs
+++ b/src/Authentication/Configuration/FeatureFlags.cs
@@ -49,14 +49,5 @@
         /// decommission (deadline 2026-06-19).
         /// </summary>
         public const string IdPortenUserLookupFromRegister = "IdPortenUserLookupFromRegister";
-
-        /// <summary>
-        /// When enabled, every logout path that would otherwise 302 to the Altinn 2 logout
-        /// endpoint (<c>GeneralSettings.SBLLogoutEndpoint</c>) redirects to
-        /// <c>GeneralSettings.BaseUrl</c> instead. Allows the flag to be flipped per
-        /// environment as Altinn 2 servers are switched off, ahead of the longer-term
-        /// frontchannel logout rewrite in #1582. Tracked in issue #2012.
-        /// </summary>
-        public const string Altinn2LogoutRedirectDisabled = "Altinn2LogoutRedirectDisabled";
     }
 }

--- a/src/Authentication/Configuration/GeneralSettings.cs
+++ b/src/Authentication/Configuration/GeneralSettings.cs
@@ -53,11 +53,6 @@ namespace Altinn.Platform.Authentication.Configuration
         public string SBLRedirectEndpoint { get; set; }
 
         /// <summary>
-        /// Gets or sets the sbl logout endpoint
-        /// </summary>
-        public string SBLLogoutEndpoint { get; set; }
-
-        /// <summary>
         /// Gets or sets the platform endpoint
         /// </summary>
         public string PlatformEndpoint { get; set; }

--- a/src/Authentication/Controllers/LogoutController.cs
+++ b/src/Authentication/Controllers/LogoutController.cs
@@ -109,7 +109,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 {
                     DeleteLegacySblCookies();
                     _eventLog.CreateAuthenticationEventAsync(_featureManager, tokenCookie, AuthenticationEventType.Logout, HttpContext.Connection.RemoteIpAddress);
-                    return Redirect(await ResolveLogoutFallbackAsync());
+                    return Redirect(_generalSettings.BaseUrl);
                 }
 
                 CookieOptions opt = new CookieOptions() { Domain = _generalSettings.HostName, Secure = true, HttpOnly = true };
@@ -164,17 +164,7 @@ namespace Altinn.Platform.Authentication.Controllers
             }
 
             DeleteLegacySblCookies();
-            return Redirect(await ResolveLogoutFallbackAsync());
-        }
-
-        private async Task<string> ResolveLogoutFallbackAsync()
-        {
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.Altinn2LogoutRedirectDisabled))
-            {
-                return _generalSettings.BaseUrl;
-            }
-
-            return _generalSettings.SBLLogoutEndpoint;
+            return Redirect(_generalSettings.BaseUrl);
         }
 
         private void DeleteLegacySblCookies()

--- a/src/Authentication/Services/OidcServerService.cs
+++ b/src/Authentication/Services/OidcServerService.cs
@@ -532,7 +532,7 @@ namespace Altinn.Platform.Authentication.Services
 
                 return new EndSessionResult
                 {
-                    RedirectUri = await ResolveLogoutFallbackAsync(),
+                    RedirectUri = new Uri(_generalSettings.BaseUrl),
                     State = input.State,
                     Cookies = noSidCookies
                 };
@@ -568,9 +568,9 @@ namespace Altinn.Platform.Authentication.Services
                 string issuer = oidcSession.UpstreamIssuer;
                 if (issuer.Equals(AuthzConstants.ISSUER_ALTINN_PORTAL, StringComparison.OrdinalIgnoreCase))
                 {
-                    // Session was created based on Altinn 2 ticket. Redirect back to Altinn 2 for logout
-                    // unless the Altinn 2 servers are gone — in which case fall back to BaseUrl.
-                    redirect = await ResolveLogoutFallbackAsync();
+                    // Session was created based on an Altinn 2 ticket. Altinn 2 is shut down, so logout
+                    // falls back to BaseUrl.
+                    redirect = new Uri(_generalSettings.BaseUrl);
                 }
                 else
                 {
@@ -641,16 +641,6 @@ namespace Altinn.Platform.Authentication.Services
                 State = input.State,
                 Cookies = finalCookies
             };
-        }
-
-        private async Task<Uri> ResolveLogoutFallbackAsync()
-        {
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.Altinn2LogoutRedirectDisabled))
-            {
-                return new Uri(_generalSettings.BaseUrl);
-            }
-
-            return new Uri(_generalSettings.SBLLogoutEndpoint);
         }
 
         private IEnumerable<CookieInstruction> BuildLegacySblCookieDeletes()

--- a/src/Authentication/appsettings.Development.json
+++ b/src/Authentication/appsettings.Development.json
@@ -8,7 +8,6 @@
     "BridgeAuthnApiEndpoint": "https://at22.altinn.cloud/sblbridge/authentication/api/",
     "BridgeProfileApiEndpoint": "https://at22.altinn.cloud/sblbridge/profile/api/",
     "SBLRedirectEndpoint": "https://at22.altinn.cloud/ui/authentication/",
-    "SBLLogoutEndpoint": "https://at22.altinn.cloud/ui/authentication/logout",
     "PlatformEndpoint": "https://platform.at22.altinn.cloud/",
     "ApiAccessManagementEndpoint": "http://platform.at22.altinn.cloud/accessmanagement/api/v1/",
     "ClaimsIdentity": "UserLogin",

--- a/src/Authentication/appsettings.json
+++ b/src/Authentication/appsettings.json
@@ -18,7 +18,6 @@
     "BridgeAuthnApiEndpoint": "https://at22.altinn.cloud/sblbridge/authentication/api/",
     "BridgeProfileApiEndpoint": "https://at22.altinn.cloud/sblbridge/profile/api/",
     "SBLRedirectEndpoint": "https://at22.altinn.cloud/ui/authentication/",
-    "SBLLogoutEndpoint": "https://at22.altinn.cloud/ui/authentication/logout",
     "PlatformEndpoint": "https://platform.at22.altinn.cloud/",
     "ClaimsIdentity": "UserLogin",
     "JwtValidityMinutes": 30,
@@ -68,7 +67,6 @@
     "RegisterSelfIdentifiedUserProvisioning": false,
     "LocalSelfIdentifiedCredentialValidation": true,
     "CookieTicketDecryptionDisabled": false,
-    "Altinn2LogoutRedirectDisabled": false,
     "IdPortenUserLookupFromRegister": true
   },
   "PostgreSQLSettings": {

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
@@ -107,7 +107,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         /// Validates that a user that is not authenticated is forward to SBL logout (not possible to identify any issorg)
         /// </summary>
         [Fact]
-        public async Task Logout_TimedOut_RedirectToSBL()
+        public async Task Logout_TimedOut_RedirectToBaseUrl()
         {
             // Arrange
             HttpClient client = CreateClient();
@@ -123,7 +123,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             IEnumerable<string> values;
             if (response.Headers.TryGetValues("location", out values))
             {
-                Assert.Equal("http://localhost/ui/authentication/logout", values.First());
+                Assert.Equal("http://localhost", values.First());
             }
         }
 
@@ -131,7 +131,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         /// Validates that a user that is not authenticated is forward to SBL logout (not possible to identify any issorg)
         /// </summary>
         [Fact]
-        public async Task Logout_LogedIn_RedirectToSBL()
+        public async Task Logout_LogedIn_RedirectToBaseUrl()
         {
             string token = PrincipalUtil.GetToken(1337, null);
 
@@ -149,7 +149,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             IEnumerable<string> values;
             if (response.Headers.TryGetValues("location", out values))
             {
-                Assert.Equal("http://localhost/ui/authentication/logout", values.First());
+                Assert.Equal("http://localhost", values.First());
             }
         }
 
@@ -157,7 +157,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         /// Validates that a user that is not authenticated is forward to SBL logout (not possible to identify any issorg)
         /// </summary>
         [Fact]
-        public async Task Logout_LogedIn_RedirectToSBL_SelfIdentifiedUser()
+        public async Task Logout_LogedIn_RedirectToBaseUrl_SelfIdentifiedUser()
         {
             string token = PrincipalUtil.GetSelfIdentifiedUserToken("siusertest", "12345", "2345678");
 
@@ -175,7 +175,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             IEnumerable<string> values;
             if (response.Headers.TryGetValues("location", out values))
             {
-                Assert.Equal("http://localhost/ui/authentication/logout", values.First());
+                Assert.Equal("http://localhost", values.First());
             }
         }
 
@@ -345,7 +345,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         }
 
         [Fact]
-        public async Task Logout_HandleLoggedOut_RedirectToSBL()
+        public async Task Logout_HandleLoggedOut_RedirectToBaseUrl()
         {
             // Arrange
             HttpClient client = CreateClient();
@@ -362,7 +362,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             Assert.Equal("AltinnLogoutInfo=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=localhost; path=/; secure; httponly", cookieValues?.First());
 
             response.Headers.TryGetValues("location", out IEnumerable<string> locationValues);
-            Assert.Equal("http://localhost/ui/authentication/logout", locationValues?.First());
+            Assert.Equal("http://localhost", locationValues?.First());
         }
 
         /// <summary>

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
@@ -123,7 +123,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             IEnumerable<string> values;
             if (response.Headers.TryGetValues("location", out values))
             {
-                Assert.Equal("http://localhost", values.First());
+                Assert.Equal("http://localhost/", values.First());
             }
         }
 
@@ -149,7 +149,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             IEnumerable<string> values;
             if (response.Headers.TryGetValues("location", out values))
             {
-                Assert.Equal("http://localhost", values.First());
+                Assert.Equal("http://localhost/", values.First());
             }
         }
 
@@ -175,7 +175,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             IEnumerable<string> values;
             if (response.Headers.TryGetValues("location", out values))
             {
-                Assert.Equal("http://localhost", values.First());
+                Assert.Equal("http://localhost/", values.First());
             }
         }
 
@@ -362,7 +362,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             Assert.Equal("AltinnLogoutInfo=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=localhost; path=/; secure; httponly", cookieValues?.First());
 
             response.Headers.TryGetValues("location", out IEnumerable<string> locationValues);
-            Assert.Equal("http://localhost", locationValues?.First());
+            Assert.Equal("http://localhost/", locationValues?.First());
         }
 
         /// <summary>

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
@@ -120,11 +120,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Assert
             Assert.Equal(System.Net.HttpStatusCode.Found, response.StatusCode);
 
-            IEnumerable<string> values;
-            if (response.Headers.TryGetValues("location", out values))
-            {
-                Assert.Equal("http://localhost/", values.First());
-            }
+            Assert.True(response.Headers.TryGetValues("location", out IEnumerable<string>? values));
+            Assert.Equal("http://localhost/", values!.First());
         }
 
         /// <summary>
@@ -146,11 +143,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Assert
             Assert.Equal(System.Net.HttpStatusCode.Found, response.StatusCode);
 
-            IEnumerable<string> values;
-            if (response.Headers.TryGetValues("location", out values))
-            {
-                Assert.Equal("http://localhost/", values.First());
-            }
+            Assert.True(response.Headers.TryGetValues("location", out IEnumerable<string>? values));
+            Assert.Equal("http://localhost/", values!.First());
         }
 
         /// <summary>
@@ -172,11 +166,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Assert
             Assert.Equal(System.Net.HttpStatusCode.Found, response.StatusCode);
 
-            IEnumerable<string> values;
-            if (response.Headers.TryGetValues("location", out values))
-            {
-                Assert.Equal("http://localhost/", values.First());
-            }
+            Assert.True(response.Headers.TryGetValues("location", out IEnumerable<string>? values));
+            Assert.Equal("http://localhost/", values!.First());
         }
 
         /// <summary>

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
@@ -981,7 +981,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             string content = await logoutResp.Content.ReadAsStringAsync();
 
             Assert.Equal(HttpStatusCode.Found, logoutResp.StatusCode);
-            Assert.StartsWith("http://localhost/ui/authentication/logout", logoutResp.Headers.Location!.ToString());
+            Assert.StartsWith("http://localhost/", logoutResp.Headers.Location!.ToString());
             OidcAssertHelper.AssertLogoutRedirect(logoutResp, testScenario);
 
             OidcSession? loggedOutSession = await OidcServerDatabaseUtil.GetOidcSessionAsync(sidFromCodeResponse, DataSource);
@@ -1045,7 +1045,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             string content = await logoutResp.Content.ReadAsStringAsync();
 
             Assert.Equal(HttpStatusCode.Found, logoutResp.StatusCode);
-            Assert.StartsWith("http://localhost/ui/authentication/logout", logoutResp.Headers.Location!.ToString());
+            Assert.StartsWith("http://localhost/", logoutResp.Headers.Location!.ToString());
             OidcAssertHelper.AssertLogoutRedirect(logoutResp, testScenario);
 
             OidcSession? loggedOutSession = await OidcServerDatabaseUtil.GetOidcSessionAsync(sidFromCodeResponse, DataSource);
@@ -1129,7 +1129,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             string content = await logoutResp.Content.ReadAsStringAsync();
 
             Assert.Equal(HttpStatusCode.Found, logoutResp.StatusCode);
-            Assert.StartsWith("http://localhost/ui/authentication/logout", logoutResp.Headers.Location!.ToString());
+            Assert.StartsWith("http://localhost/", logoutResp.Headers.Location!.ToString());
             OidcAssertHelper.AssertLogoutRedirect(logoutResp, testScenario);
 
             OidcSession? loggedOutSession = await OidcServerDatabaseUtil.GetOidcSessionAsync(sidFromCodeResponse, DataSource);
@@ -1231,7 +1231,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             string content = await logoutResp.Content.ReadAsStringAsync();
 
             Assert.Equal(HttpStatusCode.Found, logoutResp.StatusCode);
-            Assert.StartsWith("http://localhost/ui/authentication/logout", logoutResp.Headers.Location!.ToString());
+            Assert.StartsWith("http://localhost/", logoutResp.Headers.Location!.ToString());
             OidcAssertHelper.AssertLogoutRedirect(logoutResp, testScenario);
 
             OidcSession? loggedOutSession = await OidcServerDatabaseUtil.GetOidcSessionAsync(sidFromCodeResponse, DataSource);

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEnd_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEnd_OidcFrontChannelControllerTest.cs
@@ -613,7 +613,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             string content = await logoutResp.Content.ReadAsStringAsync();
 
             Assert.Equal(HttpStatusCode.Found, logoutResp.StatusCode);
-            Assert.StartsWith("http://localhost/ui/authentication/logout", logoutResp.Headers.Location!.ToString());
+            Assert.StartsWith("http://localhost/", logoutResp.Headers.Location!.ToString());
             OidcAssertHelper.AssertLogoutRedirect(logoutResp, testScenario);
 
             OidcSession? loggedOutSession = await OidcServerDatabaseUtil.GetOidcSessionAsync(sidFromCodeResponse, DataSource);

--- a/test/Altinn.Platform.Authentication.Tests/appsettings.test.json
+++ b/test/Altinn.Platform.Authentication.Tests/appsettings.test.json
@@ -6,7 +6,6 @@
     "BaseUrl": "http://localhost",
     "BridgeAuthnApiEndpoint": "http://localhost/sblbridge/authentication/api/",
     "SBLRedirectEndpoint": "http://localhost/ui/authentication",
-    "SBLLogoutEndpoint": "http://localhost/ui/authentication/logout",
     "PlatformEndpoint": "http://localhost/",
     "ClaimsIdentity": "UserLogin",
     "JwtValidityMinutes": 30,


### PR DESCRIPTION
@
Next slice of **#2030** (remove Altinn 2 / SBL Bridge code). Self-contained: the **logout redirect**.

## What & why
Altinn 2 is shut down, so redirecting logout to the Altinn 2 logout endpoint (`GeneralSettings.SBLLogoutEndpoint`) is dead. It was gated behind `Altinn2LogoutRedirectDisabled` (now permanently on in prod) — this makes the `BaseUrl` redirect permanent and removes the SBL path + flag.

## Changes
- **`LogoutController`** + **`OidcServerService`**: the logout fallback now always redirects to `GeneralSettings.BaseUrl`. Removed both `ResolveLogoutFallbackAsync` helpers.
- Removed **`GeneralSettings.SBLLogoutEndpoint`** and the **`Altinn2LogoutRedirectDisabled`** feature flag, plus their `appsettings.json` / `appsettings.Development.json` / `appsettings.test.json` keys.
- **Tests**: the `Logout_*_RedirectToSBL` fallback tests now assert `BaseUrl` and are renamed `*_RedirectToBaseUrl`. The provider-redirect test (`...ExternalAuthenticationMethod` → idporten) is correctly **unchanged** — it never used the SBL fallback.

## Scope / notes
- Both projects build with **0 errors**. Logout tests are Docker-backed integration tests → CI to run.
- **Deliberately narrow**: does not touch the legacy SBL cookie deletes (`SblAuthCookieName` / `BuildLegacySblCookieDeletes` / `DeleteLegacySblCookies`) or the A2-ticket / cookie-decryption paths — those come in the next slice (`CookieTicketDecryptionDisabled`), since `SblAuthCookieName` is part of that cookie story.

Refs #2030 · #2012

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated logout handling to always redirect users to the main application URL instead of the previous logout UI page.
  * Simplified logout fallback behavior for both standard and legacy sign-out flows.
  * Removed an outdated logout-related feature toggle and the corresponding configuration entries.
  * Aligned automated tests with the new redirect behavior across controller and end-to-end scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->