### PR TITLE
chore: SI provisioning via Register only + local-only SI validation (#2030)

### DIFF
--- a/src/Authentication/Configuration/FeatureFlags.cs
+++ b/src/Authentication/Configuration/FeatureFlags.cs
@@ -16,23 +16,6 @@
         public const string SystemUser = "SystemUser";
 
         /// <summary>
-        /// When enabled, OIDC sign-in provisions self-identified users via register's
-        /// <c>POST /register/api/v2/internal/parties/self-identified</c> endpoint instead of
-        /// calling SBL Bridge directly. Replaces the GetUser+CreateUser two-call flow with
-        /// one atomic call. Tracked under the SBL Bridge decommission (deadline 2026-06-19).
-        /// </summary>
-        public const string RegisterSelfIdentifiedUserProvisioning = "RegisterSelfIdentifiedUserProvisioning";
-
-        /// <summary>
-        /// When enabled, self-identified (SI) user credential validation is performed locally
-        /// against <c>oidcserver.selfidentified_user_credential</c> (SHA1 + salt) instead of
-        /// calling SBL Bridge (<c>POST authentication/api/siuser</c>). Lets the flag be flipped
-        /// per environment once the migrated credentials are imported. Tracked in issue #2025
-        /// (SBL Bridge decommission, deadline 2026-06-19).
-        /// </summary>
-        public const string LocalSelfIdentifiedCredentialValidation = "LocalSelfIdentifiedCredentialValidation";
-
-        /// <summary>
         /// Controls the source of the user fields (UserId/UserName/PartyId/PartyUuid) in the
         /// ID-porten token exchange, replacing the (decommissioned) SBL Bridge
         /// <c>profile/users/</c> lookup. When enabled, the fields are read from Register's

--- a/src/Authentication/Services/OidcServerService.cs
+++ b/src/Authentication/Services/OidcServerService.cs
@@ -255,7 +255,20 @@ namespace Altinn.Platform.Authentication.Services
             // ===== 2) Exchange upstream code for upstream tokens =====
             OidcProvider provider = ChooseProviderByKey(upstreamTx.Provider);
             UserAuthenticationModel userIdenity = await ExtractUserIdentityFromUpstream(input, upstreamTx, provider, cancellationToken);
-            userIdenity = await IdentifyOrCreateAltinnUser(userIdenity, provider);
+            UserAuthenticationModel? identifiedUser = await IdentifyOrCreateAltinnUser(userIdenity, provider, cancellationToken);
+            if (identifiedUser is null)
+            {
+                // Self-identified user provisioning (via register) failed. Do not continue and create
+                // a session from an incomplete identity (missing UserID/PartyID/PartyUuid).
+                return new UpstreamCallbackResult
+                {
+                    Kind = UpstreamCallbackResultKind.LocalError,
+                    StatusCode = 500,
+                    LocalErrorMessage = "Could not provision the self-identified user; sign-in cannot complete."
+                };
+            }
+
+            userIdenity = identifiedUser;
             AddLocalScopes(userIdenity);
 
             // 3. Create or refresh Altinn session session
@@ -1325,7 +1338,7 @@ namespace Altinn.Platform.Authentication.Services
             return ub.Uri;
         }
 
-        private async Task<UserAuthenticationModel> IdentifyOrCreateAltinnUser(UserAuthenticationModel userAuthenticationModel, OidcProvider? provider)
+        private async Task<UserAuthenticationModel?> IdentifyOrCreateAltinnUser(UserAuthenticationModel userAuthenticationModel, OidcProvider? provider, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(userAuthenticationModel);
 
@@ -1376,11 +1389,13 @@ namespace Altinn.Platform.Authentication.Services
                     issExternalIdentity,
                     userName,
                     email: null,
-                    CancellationToken.None);
+                    cancellationToken);
 
                 if (provisioned is null)
                 {
-                    return userAuthenticationModel;
+                    // Provisioning failed - signal the caller to fail the callback rather than
+                    // continuing with an incomplete identity.
+                    return null;
                 }
 
                 userAuthenticationModel.UserID = (int)provisioned.User.Value.UserId.Value;
@@ -1402,11 +1417,13 @@ namespace Altinn.Platform.Authentication.Services
                     issExternalIdentity,
                     userName,
                     userAuthenticationModel.Email,
-                    CancellationToken.None);
+                    cancellationToken);
 
                 if (provisioned is null)
                 {
-                    return userAuthenticationModel;
+                    // Provisioning failed - signal the caller to fail the callback rather than
+                    // continuing with an incomplete identity.
+                    return null;
                 }
 
                 userAuthenticationModel.UserID = (int)provisioned.User.Value.UserId.Value;
@@ -1450,9 +1467,10 @@ namespace Altinn.Platform.Authentication.Services
 
             if (response is null)
             {
+                // The external identity can be email-derived (PII); log only a non-reversible hash.
                 _logger.LogError(
-                    "Register self-identified provisioning returned no result for externalIdentity {ExternalIdentity}; sign-in cannot complete.",
-                    externalIdentity);
+                    "Register self-identified provisioning returned no result for externalIdentity hash {ExternalIdentityHash}; sign-in cannot complete.",
+                    HashIDentity(externalIdentity));
             }
 
             return response;

--- a/src/Authentication/Services/OidcServerService.cs
+++ b/src/Authentication/Services/OidcServerService.cs
@@ -49,7 +49,6 @@ namespace Altinn.Platform.Authentication.Services
         TimeProvider timeProvider,
         IOidcProvider oidcProvider,
         IUpstreamTokenValidator upstreamTokenValidator,
-        IUserProfileService userProfileService,
         IRegisterUserProvisioningClient registerUserProvisioningClient,
         IProfile profile,
         IOidcSessionRepository oidcSessionRepository,
@@ -72,7 +71,6 @@ namespace Altinn.Platform.Authentication.Services
         private readonly TimeProvider _timeProvider = timeProvider;
         private readonly IOidcProvider _oidcProvider = oidcProvider;
         private readonly IUpstreamTokenValidator _upstreamTokenValidator = upstreamTokenValidator;
-        private readonly IUserProfileService _userProfileService = userProfileService;
         private readonly IRegisterUserProvisioningClient _registerUserProvisioningClient = registerUserProvisioningClient;
         private readonly IProfile _profileService = profile;
         private readonly IOidcSessionRepository _oidcSessionRepo = oidcSessionRepository;
@@ -1373,55 +1371,25 @@ namespace Altinn.Platform.Authentication.Services
                 string issExternalIdentity = userAuthenticationModel.Iss + ":" + userAuthenticationModel.ExternalIdentity;
                 string userName = CreateUserName(userAuthenticationModel, provider);
 
-                if (await _featureManager.IsEnabledAsync(FeatureFlags.RegisterSelfIdentifiedUserProvisioning))
+                var provisioned = await GetOrCreateSelfIdentifiedUserViaRegister(
+                    SelfIdentifiedUserType.Educational,
+                    issExternalIdentity,
+                    userName,
+                    email: null,
+                    CancellationToken.None);
+
+                if (provisioned is null)
                 {
-                    var provisioned = await GetOrCreateSelfIdentifiedUserViaRegister(
-                        SelfIdentifiedUserType.Educational,
-                        issExternalIdentity,
-                        userName,
-                        email: null,
-                        CancellationToken.None);
-
-                    if (provisioned is null)
-                    {
-                        return userAuthenticationModel;
-                    }
-
-                    userAuthenticationModel.UserID = (int)provisioned.User.Value.UserId.Value;
-                    userAuthenticationModel.PartyID = (int)provisioned.PartyId.Value;
-                    userAuthenticationModel.PartyUuid = provisioned.Uuid;
-                    userAuthenticationModel.Username = provisioned.User.Value.Username.Value;
-                    userAuthenticationModel.Amr = ["SelfIdentified"];
-                    userAuthenticationModel.Acr = "Selfidentified";
                     return userAuthenticationModel;
                 }
 
-                userProfile = await _userProfileService.GetUser(issExternalIdentity);
-
-                if (userProfile != null)
-                {
-                    userAuthenticationModel.UserID = userProfile.UserId;
-                    userAuthenticationModel.PartyID = userProfile.PartyId;
-                    userAuthenticationModel.PartyUuid = userProfile.UserUuid;
-                    userAuthenticationModel.Username = userProfile.UserName;
-                    userAuthenticationModel.Amr = ["SelfIdentified"];
-                    userAuthenticationModel.Acr = "Selfidentified";
-                    return userAuthenticationModel;
-                }
-
-                UserProfile userToCreate = new()
-                {
-                    ExternalIdentity = issExternalIdentity,
-                    UserName = userName,
-                    UserType = Altinn.Platform.Authentication.Core.Models.Profile.Enums.UserType.SelfIdentified
-                };
-
-                UserProfile userCreated = await _userProfileService.CreateUser(userToCreate);
-                userAuthenticationModel.UserID = userCreated.UserId;
-                userAuthenticationModel.PartyID = userCreated.PartyId;
-                userAuthenticationModel.PartyUuid = userCreated.UserUuid;
+                userAuthenticationModel.UserID = (int)provisioned.User.Value.UserId.Value;
+                userAuthenticationModel.PartyID = (int)provisioned.PartyId.Value;
+                userAuthenticationModel.PartyUuid = provisioned.Uuid;
+                userAuthenticationModel.Username = provisioned.User.Value.Username.Value;
                 userAuthenticationModel.Amr = ["SelfIdentified"];
                 userAuthenticationModel.Acr = "Selfidentified";
+                return userAuthenticationModel;
             }
             else if (userAuthenticationModel.Acr != null && userAuthenticationModel.Acr.Equals("selfregistered-email") && !string.IsNullOrEmpty(userAuthenticationModel.Email))
             {
@@ -1429,50 +1397,23 @@ namespace Altinn.Platform.Authentication.Services
                 string issExternalIdentity = AltinnCoreClaimTypes.IdPortenEmailPrefix + ":" + UrnEncoded.Create(userAuthenticationModel.Email.ToLowerInvariant()).Encoded;
                 string userName = "epost:" + userAuthenticationModel.Email;
 
-                if (await _featureManager.IsEnabledAsync(FeatureFlags.RegisterSelfIdentifiedUserProvisioning))
+                var provisioned = await GetOrCreateSelfIdentifiedUserViaRegister(
+                    SelfIdentifiedUserType.IdPortenEmail,
+                    issExternalIdentity,
+                    userName,
+                    userAuthenticationModel.Email,
+                    CancellationToken.None);
+
+                if (provisioned is null)
                 {
-                    var provisioned = await GetOrCreateSelfIdentifiedUserViaRegister(
-                        SelfIdentifiedUserType.IdPortenEmail,
-                        issExternalIdentity,
-                        userName,
-                        userAuthenticationModel.Email,
-                        CancellationToken.None);
-
-                    if (provisioned is null)
-                    {
-                        return userAuthenticationModel;
-                    }
-
-                    userAuthenticationModel.UserID = (int)provisioned.User.Value.UserId.Value;
-                    userAuthenticationModel.PartyID = (int)provisioned.PartyId.Value;
-                    userAuthenticationModel.PartyUuid = provisioned.Uuid;
-                    userAuthenticationModel.Username = provisioned.User.Value.Username.Value;
                     return userAuthenticationModel;
                 }
 
-                userProfile = await _userProfileService.GetUser(issExternalIdentity);
-
-                if (userProfile != null)
-                {
-                    userAuthenticationModel.UserID = userProfile.UserId;
-                    userAuthenticationModel.PartyID = userProfile.PartyId;
-                    userAuthenticationModel.PartyUuid = userProfile.UserUuid;
-                    userAuthenticationModel.Username = userProfile.UserName;
-                    return userAuthenticationModel;
-                }
-
-                // Todo: Verifiser prefix på brukernavn
-                UserProfile userToCreate = new()
-                {
-                    ExternalIdentity = issExternalIdentity,
-                    UserName = userName,
-                    UserType = Altinn.Platform.Authentication.Core.Models.Profile.Enums.UserType.SelfIdentified
-                };
-
-                UserProfile userCreated = await _userProfileService.CreateUser(userToCreate);
-                userAuthenticationModel.UserID = userCreated.UserId;
-                userAuthenticationModel.PartyID = userCreated.PartyId;
-                userAuthenticationModel.PartyUuid = userCreated.UserUuid;
+                userAuthenticationModel.UserID = (int)provisioned.User.Value.UserId.Value;
+                userAuthenticationModel.PartyID = (int)provisioned.PartyId.Value;
+                userAuthenticationModel.PartyUuid = provisioned.Uuid;
+                userAuthenticationModel.Username = provisioned.User.Value.Username.Value;
+                return userAuthenticationModel;
             }
             else if (userAuthenticationModel.UserID.HasValue && userAuthenticationModel.UserID.Value > 0)
             {

--- a/src/Authentication/Services/OidcServerService.cs
+++ b/src/Authentication/Services/OidcServerService.cs
@@ -1467,10 +1467,11 @@ namespace Altinn.Platform.Authentication.Services
 
             if (response is null)
             {
-                // The external identity can be email-derived (PII); log only a non-reversible hash.
+                // Log the external identity (may be email-derived) verbatim: this is an internal error
+                // log for a failing sign-in, and support needs to identify which user is affected.
                 _logger.LogError(
-                    "Register self-identified provisioning returned no result for externalIdentity hash {ExternalIdentityHash}; sign-in cannot complete.",
-                    HashIDentity(externalIdentity));
+                    "Register self-identified provisioning returned no result for externalIdentity {ExternalIdentity}; sign-in cannot complete.",
+                    externalIdentity);
             }
 
             return response;

--- a/src/Authentication/Services/UserProfileService.cs
+++ b/src/Authentication/Services/UserProfileService.cs
@@ -14,7 +14,6 @@ using Altinn.Platform.Authentication.Services.Interfaces;
 using Altinn.Register.Contracts.V1;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.FeatureManagement;
 
 namespace Altinn.Platform.Authentication.Services
 {
@@ -26,7 +25,6 @@ namespace Altinn.Platform.Authentication.Services
         private readonly GeneralSettings _settings;
         private readonly HttpClient _client;
         private readonly ILogger _logger;
-        private readonly IFeatureManager _featureManager;
         private readonly ISelfIdentifiedUserCredentialRepository _selfIdentifiedUserCredentialRepository;
         private readonly TimeProvider _timeProvider;
 
@@ -36,21 +34,18 @@ namespace Altinn.Platform.Authentication.Services
         /// <param name="httpClient">Httpclient from httpclientfactory</param>
         /// <param name="settings">General settings for the authentication application</param>
         /// <param name="logger">A generic logger</param>
-        /// <param name="featureManager">Feature manager used to switch SI credential validation to the local database</param>
         /// <param name="selfIdentifiedUserCredentialRepository">Repository for locally stored SI credentials</param>
         /// <param name="timeProvider">Time provider used for lockout comparison (injectable for testing)</param>
         public UserProfileService(
             HttpClient httpClient,
             IOptions<GeneralSettings> settings,
             ILogger<IUserProfileService> logger,
-            IFeatureManager featureManager,
             ISelfIdentifiedUserCredentialRepository selfIdentifiedUserCredentialRepository,
             TimeProvider timeProvider)
         {
             _client = httpClient;
             _settings = settings.Value;
             _logger = logger;
-            _featureManager = featureManager;
             _selfIdentifiedUserCredentialRepository = selfIdentifiedUserCredentialRepository;
             _timeProvider = timeProvider;
         }
@@ -102,67 +97,14 @@ namespace Altinn.Platform.Authentication.Services
         }
 
         /// <summary>
-        /// Validates a self identified user's credentials. When the
-        /// <see cref="FeatureFlags.LocalSelfIdentifiedCredentialValidation"/> flag is enabled the
-        /// check is performed locally against <c>oidcserver.selfidentified_user_credential</c>
-        /// (SHA1 + salt); otherwise it is delegated to the SBL Bridge authentication API
-        /// (<c>authentication/api/siuser</c>). On success the user profile is returned.
+        /// Validates a self identified user's credentials locally against
+        /// <c>oidcserver.selfidentified_user_credential</c> (SHA1 + salt). This is the permanent
+        /// path following the SBL Bridge decommission (the legacy <c>authentication/api/siuser</c>
+        /// delegation has been removed). On success the user profile is returned.
         /// </summary>
         public async Task<UserCredentialVerificationResult> ValidateCredentialsAsync(string username, string password)
         {
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.LocalSelfIdentifiedCredentialValidation))
-            {
-                return await ValidateCredentialsLocallyAsync(username, password);
-            }
-
-            UserProfile identifedProfile = null;
-
-            SiUserCredentials credentials = new SiUserCredentials()
-            {
-                UserName = username,
-                Password = password
-            };
-
-            Uri endpointUrl = new Uri($"{_settings.BridgeAuthnApiEndpoint}siuser");
-            using StringContent requestBody = new StringContent(JsonSerializer.Serialize(credentials), Encoding.UTF8, "application/json");
-
-            using HttpResponseMessage response = await _client.PostAsync(endpointUrl, requestBody);
-            if (response.StatusCode == System.Net.HttpStatusCode.OK)
-            {
-                identifedProfile = await response.Content.ReadFromJsonAsync<UserProfile>(_options);
-            }
-            else if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
-            {
-                // Bridge returns 429 when the account is locked out due to too many failed attempts.
-                return new UserCredentialVerificationResult()
-                {
-                    IsLocked = true
-                };
-            }
-            else if (response.StatusCode is System.Net.HttpStatusCode.NotFound or System.Net.HttpStatusCode.BadRequest)
-            {
-                // Bridge returns 404 when the credentials are not authenticated and 400 for empty
-                // username/password. Both are expected outcomes - not errors, and the username must not be logged.
-                return new UserCredentialVerificationResult();
-            }
-            else
-            {
-                _logger.LogError("Validating user credentials failed with statuscode {StatusCode}", response.StatusCode);
-                return new UserCredentialVerificationResult();
-            }
-
-            if (identifedProfile != null && identifedProfile.UserType != Core.Models.Profile.Enums.UserType.SelfIdentified)
-            {
-                return new UserCredentialVerificationResult()
-                {
-                    WrongUserType = true
-                };
-            }
-
-            UserCredentialVerificationResult result = new UserCredentialVerificationResult();
-            result.UserProfile = identifedProfile;
-
-            return result;
+            return await ValidateCredentialsLocallyAsync(username, password);
         }
 
         // Maximum number of consecutive failed attempts before the account is locked.

--- a/src/Authentication/appsettings.json
+++ b/src/Authentication/appsettings.json
@@ -64,8 +64,6 @@
   "FeatureManagement": {
     "AuditLog": false,
     "SystemUser": true,
-    "RegisterSelfIdentifiedUserProvisioning": false,
-    "LocalSelfIdentifiedCredentialValidation": true,
     "IdPortenUserLookupFromRegister": true
   },
   "PostgreSQLSettings": {

--- a/src/Core/Clients/Interfaces/IRegisterUserProvisioningClient.cs
+++ b/src/Core/Clients/Interfaces/IRegisterUserProvisioningClient.cs
@@ -6,9 +6,8 @@ namespace Altinn.Authentication.Core.Clients.Interfaces
     /// <summary>
     /// Client for register's permanent self-identified-user provisioning endpoint
     /// (<c>POST /register/api/v2/internal/parties/self-identified</c>). Replaces the
-    /// SBL Bridge <c>users/</c> + <c>users/create/</c> two-call flow with one
-    /// atomic get-or-create call. Gated by the
-    /// <c>RegisterSelfIdentifiedUserProvisioning</c> feature flag.
+    /// (decommissioned) SBL Bridge <c>users/</c> + <c>users/create/</c> two-call flow
+    /// with one atomic get-or-create call.
     /// </summary>
     public interface IRegisterUserProvisioningClient
     {

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
@@ -2201,12 +2201,38 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
         private async Task ConfigureProfileMock(OidcTestScenario oidcTestScenario)
         {
             ProfileFileMock profileMock = new ProfileFileMock();
+
+            // Live self-identified provisioning (UIDP and idporten-email external identities) always
+            // goes through the Register provisioning client now - for both new and already-existing
+            // SI users. Set it up for every scenario; it is simply never invoked for SSN / userId
+            // person logins (those resolve via the profile service). The token assertions only require
+            // a non-empty user id, so fixed ids are sufficient.
+            Guid partyGuid = Guid.NewGuid();
+            _registerUserProvisioningClient
+                    .Setup(c => c.GetOrCreateUser(
+                        It.IsAny<SelfIdentifiedUserProvisioningRequest>(),
+                        It.IsAny<System.Threading.CancellationToken>()))
+                    .ReturnsAsync((SelfIdentifiedUserProvisioningRequest req, System.Threading.CancellationToken _) =>
+                        new Altinn.Register.Contracts.SelfIdentifiedUser
+                        {
+                            Uuid = partyGuid,
+                            VersionId = 1UL,
+                            PartyId = 123456U,
+                            DisplayName = req.UserName,
+                            CreatedAt = DateTimeOffset.UtcNow,
+                            ModifiedAt = DateTimeOffset.UtcNow,
+                            IsDeleted = false,
+                            DeletedAt = Altinn.Authorization.ModelUtils.FieldValue.Null,
+                            User = new Altinn.Register.Contracts.PartyUser(
+                                userId: 123456U,
+                                username: req.UserName,
+                                userIds: Altinn.Authorization.ModelUtils.ImmutableValueArray.Create(123456U)),
+                        });
+
             if ((!string.IsNullOrEmpty(oidcTestScenario.ExternalIdentity) || !string.IsNullOrEmpty(oidcTestScenario.Email)) && oidcTestScenario.UserId == null)
             {
                 UserProfile? profile = null;
                 _userProfileService.Setup(u => u.GetUser(It.IsAny<string>())).ReturnsAsync(profile);
-
-                Guid partyGuid = Guid.NewGuid();
 
                 _userProfileService
                         .Setup(s => s.CreateUser(It.IsAny<UserProfile>()))
@@ -2217,35 +2243,13 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
                             ExternalIdentity = input.ExternalIdentity,
                             UserId = 123456,
                             PartyId = 123456,
-                           
+
                             Party = new Party()
                             {
                                 PartyUuid = partyGuid
                             },
                             UserUuid = partyGuid
                         });
-
-                // Live SI provisioning now goes through the Register provisioning client.
-                _registerUserProvisioningClient
-                        .Setup(c => c.GetOrCreateUser(
-                            It.IsAny<SelfIdentifiedUserProvisioningRequest>(),
-                            It.IsAny<System.Threading.CancellationToken>()))
-                        .ReturnsAsync((SelfIdentifiedUserProvisioningRequest req, System.Threading.CancellationToken _) =>
-                            new Altinn.Register.Contracts.SelfIdentifiedUser
-                            {
-                                Uuid = partyGuid,
-                                VersionId = 1UL,
-                                PartyId = 123456U,
-                                DisplayName = req.UserName,
-                                CreatedAt = DateTimeOffset.UtcNow,
-                                ModifiedAt = DateTimeOffset.UtcNow,
-                                IsDeleted = false,
-                                DeletedAt = Altinn.Authorization.ModelUtils.FieldValue.Null,
-                                User = new Altinn.Register.Contracts.PartyUser(
-                                    userId: 123456U,
-                                    username: req.UserName,
-                                    userIds: Altinn.Authorization.ModelUtils.ImmutableValueArray.Create(123456U)),
-                            });
             }
             else
             {

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
@@ -2244,7 +2244,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
                                 User = new Altinn.Register.Contracts.PartyUser(
                                     userId: 123456U,
                                     username: req.UserName,
-                                    userIds: Altinn.Authorization.ModelUtils.FieldValue.Unset),
+                                    userIds: Altinn.Authorization.ModelUtils.ImmutableValueArray.Create(123456U)),
                             });
             }
             else

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
@@ -2176,6 +2176,52 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
                 response: oidcCodeResponse);
         }
 
+        /// <summary>
+        /// When register self-identified provisioning fails (returns null) during an external-identity
+        /// sign-in, the upstream callback must fail closed (HTTP 500) and not establish a session from
+        /// an incomplete identity.
+        /// </summary>
+        [Fact]
+        public async Task UIDP_NewUser_RegisterProvisioningFails_FailsClosed_NoSession()
+        {
+            using HttpClient client = CreateClientWithHeaders();
+            OidcTestScenario testScenario = OidcScenarioHelper.GetScenario("New_UidpUser");
+
+            OidcClientCreate create = OidcServerTestUtils.NewClientCreate(testScenario);
+            _ = await Repository.InsertClientAsync(create);
+
+            HttpResponseMessage app2RedirectResponse = await client.GetAsync(
+               "/authentication/api/v1/authentication?iss=uidp-anonym&goto=https%3A%2F%2Fudir.apps.localhost%2Ftad%2Fpagaendesak%3FDONTCHOOSEREPORTEE%3Dtrue%23%2Finstance%2F51441547%2F26cbe3f0-355d-4459-b085-7edaa899b6ba");
+            Assert.Equal(HttpStatusCode.Redirect, app2RedirectResponse.StatusCode);
+
+            string location = app2RedirectResponse.Headers.Location!.ToString();
+            string redirectUri = HttpUtility.ParseQueryString(new Uri(location).Query)["redirect_uri"]!;
+            Uri redirectUriParsed = new Uri(redirectUri!);
+
+            (string? upstreamState, UpstreamLoginTransaction? createdUpstreamLogingTransaction) =
+                await AssertAutorizeRequestResult(testScenario, app2RedirectResponse, _fakeTime.GetUtcNow());
+            Debug.Assert(createdUpstreamLogingTransaction != null);
+
+            _fakeTime.Advance(TimeSpan.FromMinutes(1));
+
+            ConfigureMockUidpProviderTokenResponseUidp(testScenario, createdUpstreamLogingTransaction, _fakeTime.GetUtcNow());
+            await ConfigureProfileMock(testScenario);
+
+            // Register provisioning fails for this attempt.
+            _registerUserProvisioningClient
+                    .Setup(c => c.GetOrCreateUser(
+                        It.IsAny<SelfIdentifiedUserProvisioningRequest>(),
+                        It.IsAny<System.Threading.CancellationToken>()))
+                    .ReturnsAsync((Altinn.Register.Contracts.SelfIdentifiedUser?)null);
+
+            string callbackUrl = $"{redirectUriParsed.AbsolutePath}?code={Uri.EscapeDataString(testScenario.GetUpstreamProviderCode()!)}&state={Uri.EscapeDataString(upstreamState!)}";
+            HttpResponseMessage callbackResp = await client.GetAsync(callbackUrl);
+
+            // Fails closed: server error, and crucially NOT a redirect that would mean a session was created.
+            Assert.Equal(HttpStatusCode.InternalServerError, callbackResp.StatusCode);
+            Assert.Null(callbackResp.Headers.Location);
+        }
+
         private HttpClient CreateClientWithHeaders(Dictionary<string, string>? cookies = null)
         {
             var client = CreateClient();
@@ -2231,25 +2277,13 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
 
             if ((!string.IsNullOrEmpty(oidcTestScenario.ExternalIdentity) || !string.IsNullOrEmpty(oidcTestScenario.Email)) && oidcTestScenario.UserId == null)
             {
-                UserProfile? profile = null;
-                _userProfileService.Setup(u => u.GetUser(It.IsAny<string>())).ReturnsAsync(profile);
-
-                _userProfileService
-                        .Setup(s => s.CreateUser(It.IsAny<UserProfile>()))
-                        .ReturnsAsync((UserProfile input) => new UserProfile
-                        {
-                            // copy from the input
-                            UserName = input.UserName,
-                            ExternalIdentity = input.ExternalIdentity,
-                            UserId = 123456,
-                            PartyId = 123456,
-
-                            Party = new Party()
-                            {
-                                PartyUuid = partyGuid
-                            },
-                            UserUuid = partyGuid
-                        });
+                // SI provisioning must go through the register client (set up above). Guard the legacy
+                // SBL GetUser/CreateUser path so a regression back to it fails the test loudly instead
+                // of silently passing.
+                _userProfileService.Setup(u => u.GetUser(It.IsAny<string>()))
+                        .ThrowsAsync(new InvalidOperationException("Legacy SBL GetUser must not be called; SI provisioning goes through register."));
+                _userProfileService.Setup(s => s.CreateUser(It.IsAny<UserProfile>()))
+                        .ThrowsAsync(new InvalidOperationException("Legacy SBL CreateUser must not be called; SI provisioning goes through register."));
             }
             else
             {

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
@@ -10,6 +10,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Web;
+using Altinn.Authentication.Core.Clients.Interfaces;
 using Altinn.Common.AccessToken.Services;
 using Altinn.Platform.Authentication.Configuration;
 using Altinn.Platform.Authentication.Core.Clients.Interfaces;
@@ -52,6 +53,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
         protected NpgsqlDataSource DataSource => Services.GetRequiredService<NpgsqlDataSource>();
 
         private readonly Mock<IUserProfileService> _userProfileService = new();
+        private readonly Mock<IRegisterUserProvisioningClient> _registerUserProvisioningClient = new();
         private readonly Mock<IOidcDownstreamLogout> _downstreamLogoutClient = new();
 
         private FakeTimeProvider _fakeTime = null!;
@@ -93,6 +95,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             services.AddSingleton<IPublicSigningKeyProvider, SigningKeyResolverStub>();
             services.AddSingleton<IProfile, ProfileFileMock>();
             services.AddSingleton<IUserProfileService>(_userProfileService.Object);
+            services.AddSingleton<IRegisterUserProvisioningClient>(_registerUserProvisioningClient.Object);
             services.AddSingleton<IOidcDownstreamLogout>(_downstreamLogoutClient.Object);
 
             services.PostConfigure<GeneralSettings>(o =>
@@ -2222,6 +2225,27 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
                             UserUuid = partyGuid
                         });
 
+                // Live SI provisioning now goes through the Register provisioning client.
+                _registerUserProvisioningClient
+                        .Setup(c => c.GetOrCreateUser(
+                            It.IsAny<SelfIdentifiedUserProvisioningRequest>(),
+                            It.IsAny<System.Threading.CancellationToken>()))
+                        .ReturnsAsync((SelfIdentifiedUserProvisioningRequest req, System.Threading.CancellationToken _) =>
+                            new Altinn.Register.Contracts.SelfIdentifiedUser
+                            {
+                                Uuid = partyGuid,
+                                VersionId = 1UL,
+                                PartyId = 123456U,
+                                DisplayName = req.UserName,
+                                CreatedAt = DateTimeOffset.UtcNow,
+                                ModifiedAt = DateTimeOffset.UtcNow,
+                                IsDeleted = false,
+                                DeletedAt = Altinn.Authorization.ModelUtils.FieldValue.Null,
+                                User = new Altinn.Register.Contracts.PartyUser(
+                                    userId: 123456U,
+                                    username: req.UserName,
+                                    userIds: Altinn.Authorization.ModelUtils.FieldValue.Unset),
+                            });
             }
             else
             {

--- a/test/Altinn.Platform.Authentication.Tests/Services/UserProfileServiceLocalSiTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Services/UserProfileServiceLocalSiTests.cs
@@ -11,7 +11,6 @@ using Altinn.Platform.Authentication.Services;
 using Altinn.Platform.Authentication.Services.Interfaces;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Microsoft.FeatureManagement;
 using Moq;
 using Xunit;
 
@@ -34,14 +33,6 @@ public class UserProfileServiceLocalSiTests
     private static readonly Guid PartyUuid = Guid.Parse("2c3bb12a-5e41-4cc9-9a36-7b5ac6f9f102");
 
     private readonly Mock<ISelfIdentifiedUserCredentialRepository> _repo = new();
-    private readonly Mock<IFeatureManager> _featureManager = new();
-
-    public UserProfileServiceLocalSiTests()
-    {
-        _featureManager
-            .Setup(f => f.IsEnabledAsync(FeatureFlags.LocalSelfIdentifiedCredentialValidation))
-            .ReturnsAsync(true);
-    }
 
     [Fact]
     public async Task ValidateCredentials_Local_ValidCredentials_ReturnsProfileWithPartyUuid()
@@ -231,7 +222,6 @@ public class UserProfileServiceLocalSiTests
             client,
             settings,
             NullLogger<IUserProfileService>.Instance,
-            _featureManager.Object,
             _repo.Object,
             TimeProvider.System);
     }


### PR DESCRIPTION
## What

Altinn 2 / SBL Bridge is shut down. Two **self-identified (SI) user** flows in the live OIDC sign-in path were behind feature flags whose *legacy* branch called SBL Bridge. This makes the Altinn-3 path permanent and deletes the dead SBL branches.

| Flag (removed) | New permanent behaviour |
|---|---|
| `RegisterSelfIdentifiedUserProvisioning` (confirmed enabled in prod) | OIDC sign-in always provisions SI users (educational + idporten-email) via the **Register** provisioning client |
| `LocalSelfIdentifiedCredentialValidation` | SI credential validation is always **local** (`oidcserver.selfidentified_user_credential`) |

## Changes
- `OidcServerService.IdentifyOrCreateAltinnUser`: Register provisioning is now unconditional in both SI branches; removed the SBL `GetUser`/`CreateUser` fallback. Dropped the now-unused `IUserProfileService` dependency from `OidcServerService`.
- `UserProfileService.ValidateCredentialsAsync`: collapsed to always-local; removed the SBL `authentication/api/siuser` call. The local path (`ValidateCredentialsLocallyAsync`) is **kept permanently** — it's used for linking old SI profiles to email users. Dropped the now-unused `IFeatureManager`.
- Removed both flags from `FeatureFlags.cs` + `appsettings.json`; fixed the stale flag reference in the `IRegisterUserProvisioningClient` doc.

## Kept intentionally
- `IUserProfileService.GetUser`/`CreateUser` — still used by the **legacy** `AuthenticationController.IdentifyOrCreateAltinnUser` (reachable only via the `AuthorizationServerEnabled=false` branch, removed in the deferred SBL-config slice).
- `SiUserCredentials` — request DTO for the SI account-link endpoint.

## Tests
- `UserProfileServiceLocalSiTests`: dropped the feature-manager wiring (local validation is now unconditional); all local-validation assertions unchanged.
- ForceOidc OIDC e2e fixture: SI provisioning now flows through a mocked `IRegisterUserProvisioningClient` (returns the same UserId/PartyId `123456` + party UUID as the old `CreateUser` stub), instead of the dead `GetUser`/`CreateUser` mocks. The non-ForceOidc e2e fixture was left unchanged (its scenarios are SSN-based id-porten person logins, not SI provisioning).

## Follow-up
The now-dead `GeneralSettings.BridgeAuthnApiEndpoint` (its only consumer was the removed `siuser` call) is tracked for the SBL-config cleanup slice.

Part of #2030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Self-identified account provisioning now uses a streamlined, always-on flow for supported sign-in paths.
  * Self-identified credential checks now use local validation by default.

* **Bug Fixes**
  * Removed reliance on feature toggles that could block self-identified sign-in and validation behavior.
  * Updated service wiring to simplify authentication handling and reduce unnecessary fallback logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->