### PR TITLE
chore: resolve id-porten exchange user from Register only (#2030)

### DIFF
--- a/src/Authentication/Configuration/FeatureFlags.cs
+++ b/src/Authentication/Configuration/FeatureFlags.cs
@@ -14,15 +14,5 @@
         /// Feature flag for SystemUser Controller and functionality
         /// </summary>
         public const string SystemUser = "SystemUser";
-
-        /// <summary>
-        /// Controls the source of the user fields (UserId/UserName/PartyId/PartyUuid) in the
-        /// ID-porten token exchange, replacing the (decommissioned) SBL Bridge
-        /// <c>profile/users/</c> lookup. When enabled, the fields are read from Register's
-        /// <c>POST /register/api/v2/internal/parties/query</c> endpoint; when disabled, from the
-        /// platform Profile API (<c>internal/user</c>). Tracked under the SBL Bridge
-        /// decommission (deadline 2026-06-19).
-        /// </summary>
-        public const string IdPortenUserLookupFromRegister = "IdPortenUserLookupFromRegister";
     }
 }

--- a/src/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/Controllers/AuthenticationController.cs
@@ -687,48 +687,21 @@ namespace Altinn.Platform.Authentication.Controllers
                     authMethod = AuthenticationMethod.NotDefined.ToString();
                 }
 
-                // SBL Bridge user lookup is being decommissioned (deadline 2026-06-19). The user fields
-                // (UserId/UserName/PartyId/PartyUuid) are now resolved from either Register or the platform
-                // Profile API, selected by the IdPortenUserLookupFromRegister feature flag.
-                // UserProfile userProfile = await _userProfileService.GetUser(pid);
+                // SBL Bridge user lookup is decommissioned. The user fields
+                // (UserId/UserName/PartyId/PartyUuid) are resolved from Register:
+                // POST /register/api/v2/internal/parties/query (fields=uuid,id,user).
+                RegisterContracts.Party? party = await _partiesClient.GetPartyIdentifiersAndUsernameByPersonIdentifier(pid);
 
-                int userId;
-                string userName;
-                int partyId;
-                Guid? partyUuid;
-
-                if (await _featureManager.IsEnabledAsync(FeatureFlags.IdPortenUserLookupFromRegister))
+                if (party is null || !party.User.HasValue || !party.User.Value.UserId.HasValue)
                 {
-                    // Register: POST /register/api/v2/internal/parties/query (fields=uuid,id,user).
-                    RegisterContracts.Party? party = await _partiesClient.GetPartyIdentifiersAndUsernameByPersonIdentifier(pid);
-
-                    if (party is null || !party.User.HasValue || !party.User.Value.UserId.HasValue)
-                    {
-                        _logger.LogInformation("ID-porten exchange: person not found in Register, or has no associated Altinn user.");
-                        return Unauthorized();
-                    }
-
-                    userId = (int)party.User.Value.UserId.Value;
-                    userName = party.User.Value.Username.HasValue ? party.User.Value.Username.Value : string.Empty;
-                    partyId = (int)party.PartyId.Value;
-                    partyUuid = party.Uuid;
+                    _logger.LogInformation("ID-porten exchange: person not found in Register, or has no associated Altinn user.");
+                    return Unauthorized();
                 }
-                else
-                {
-                    // Platform Profile API: POST {ApiProfileEndpoint}internal/user (lookup by SSN).
-                    UserProfile profile = await _profileService.GetUserProfile(new UserProfileLookup { Ssn = pid });
 
-                    if (profile is null)
-                    {
-                        _logger.LogInformation("ID-porten exchange: user profile not found.");
-                        return Unauthorized();
-                    }
-
-                    userId = profile.UserId;
-                    userName = profile.UserName;
-                    partyId = profile.PartyId;
-                    partyUuid = profile.UserUuid;
-                }
+                int userId = (int)party.User.Value.UserId.Value;
+                string userName = party.User.Value.Username.HasValue ? party.User.Value.Username.Value : string.Empty;
+                int partyId = (int)party.PartyId.Value;
+                Guid? partyUuid = party.Uuid;
 
                 if (!partyUuid.HasValue)
                 {

--- a/src/Authentication/appsettings.json
+++ b/src/Authentication/appsettings.json
@@ -63,8 +63,7 @@
   },
   "FeatureManagement": {
     "AuditLog": false,
-    "SystemUser": true,
-    "IdPortenUserLookupFromRegister": true
+    "SystemUser": true
   },
   "PostgreSQLSettings": {
     "EnableDBConnection": true,

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerIdPortenRegisterTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerIdPortenRegisterTests.cs
@@ -30,11 +30,8 @@ using RegisterContracts = Altinn.Register.Contracts;
 namespace Altinn.Platform.Authentication.Tests.Controllers
 {
     /// <summary>
-    /// Covers the Register branch of the ID-porten token exchange, i.e. when the
-    /// <see cref="FeatureFlags.IdPortenUserLookupFromRegister"/> flag is enabled and the user fields
-    /// are resolved from Register (<see cref="IPartiesClient.GetPartyIdentifiersAndUsernameByPersonIdentifier"/>) instead of the
-    /// platform Profile API. The flag-off (Profile) branch is covered by
-    /// <see cref="AuthenticationControllerTests"/>.
+    /// Covers the ID-porten token exchange resolving the user fields
+    /// (<see cref="IPartiesClient.GetPartyIdentifiersAndUsernameByPersonIdentifier"/>) from Register.
     /// </summary>
     public class AuthenticationControllerIdPortenRegisterTests(DbFixture dbFixture, WebApplicationFixture webApplicationFixture)
         : WebApplicationTests(dbFixture, webApplicationFixture)
@@ -48,10 +45,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         {
             builder.UseSetting("feature_management:feature_flags:0:id", "AuditLog");
             builder.UseSetting("feature_management:feature_flags:0:enabled", "true");
-
-            // Enable the Register-based ID-porten user lookup for this test class.
-            builder.UseSetting("feature_management:feature_flags:1:id", FeatureFlags.IdPortenUserLookupFromRegister);
-            builder.UseSetting("feature_management:feature_flags:1:enabled", "true");
             base.ConfigureHost(builder);
         }
 

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerTests.cs
@@ -1495,8 +1495,26 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             identity.AddClaims(claims);
             ClaimsPrincipal externalPrincipal = new ClaimsPrincipal(identity);
 
-            UserProfile userProfile = new UserProfile { UserId = 20000, PartyId = 50001, UserName = "steph" };
-            _userProfileService.Setup(u => u.GetUser(It.IsAny<string>())).ReturnsAsync(userProfile);
+            RegisterContracts.Party party = System.Text.Json.JsonSerializer.Deserialize<RegisterContracts.Party>(
+                """
+                {
+                  "partyType": "person",
+                  "partyUuid": "5c0656db-cf51-43a9-bd68-d8a55e7b6f3b",
+                  "versionId": 1,
+                  "partyId": 50001,
+                  "personIdentifier": "19108000239",
+                  "displayName": "Test Testesen",
+                  "createdAt": "2020-01-01T00:00:00Z",
+                  "modifiedAt": "2020-01-01T00:00:00Z",
+                  "isDeleted": false,
+                  "user": { "userId": 20000, "username": "steph", "userIds": [ 20000 ] }
+                }
+                """,
+                new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+
+            _partiesClient
+                .Setup(p => p.GetPartyIdentifiersAndUsernameByPersonIdentifier(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(party);
 
             HttpClient client = CreateClient();
 

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerTests.cs
@@ -35,6 +35,7 @@ using Microsoft.Net.Http.Headers;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
+using RegisterContracts = Altinn.Register.Contracts;
 
 namespace Altinn.Platform.Authentication.Tests.Controllers
 {
@@ -56,11 +57,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         {
             builder.UseSetting("feature_management:feature_flags:0:id", "AuditLog");
             builder.UseSetting("feature_management:feature_flags:0:enabled", "true");
-
-            // The ID-porten exchange tests in this class exercise the Profile-API branch, so the
-            // Register lookup flag must be off here regardless of its (now enabled-by-default) value.
-            builder.UseSetting("feature_management:feature_flags:1:id", FeatureFlags.IdPortenUserLookupFromRegister);
-            builder.UseSetting("feature_management:feature_flags:1:enabled", "false");
             base.ConfigureHost(builder);
         }
 
@@ -1118,8 +1114,26 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             identity.AddClaims(claims);
             ClaimsPrincipal externalPrincipal = new ClaimsPrincipal(identity);
 
-            UserProfile userProfile = new UserProfile { UserId = 20000, PartyId = 50001, UserName = "steph" };
-            _userProfileService.Setup(u => u.GetUser(It.IsAny<string>())).ReturnsAsync(userProfile);
+            RegisterContracts.Party party = System.Text.Json.JsonSerializer.Deserialize<RegisterContracts.Party>(
+                """
+                {
+                  "partyType": "person",
+                  "partyUuid": "5c0656db-cf51-43a9-bd68-d8a55e7b6f3b",
+                  "versionId": 1,
+                  "partyId": 50001,
+                  "personIdentifier": "19108000239",
+                  "displayName": "Test Testesen",
+                  "createdAt": "2020-01-01T00:00:00Z",
+                  "modifiedAt": "2020-01-01T00:00:00Z",
+                  "isDeleted": false,
+                  "user": { "userId": 20000, "username": "steph", "userIds": [ 20000 ] }
+                }
+                """,
+                new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+
+            _partiesClient
+                .Setup(p => p.GetPartyIdentifiersAndUsernameByPersonIdentifier(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(party);
 
             _eventQueue.Setup(q => q.EnqueueAuthenticationEvent(It.IsAny<string>()));
 
@@ -1174,8 +1188,26 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             identity.AddClaims(claims);
             ClaimsPrincipal externalPrincipal = new ClaimsPrincipal(identity);
 
-            UserProfile userProfile = new UserProfile { UserId = 20000, PartyId = 50001, UserName = "steph" };
-            _userProfileService.Setup(u => u.GetUser(It.IsAny<string>())).ReturnsAsync(userProfile);
+            RegisterContracts.Party party = System.Text.Json.JsonSerializer.Deserialize<RegisterContracts.Party>(
+                """
+                {
+                  "partyType": "person",
+                  "partyUuid": "5c0656db-cf51-43a9-bd68-d8a55e7b6f3b",
+                  "versionId": 1,
+                  "partyId": 50001,
+                  "personIdentifier": "19108000239",
+                  "displayName": "Test Testesen",
+                  "createdAt": "2020-01-01T00:00:00Z",
+                  "modifiedAt": "2020-01-01T00:00:00Z",
+                  "isDeleted": false,
+                  "user": { "userId": 20000, "username": "steph", "userIds": [ 20000 ] }
+                }
+                """,
+                new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+
+            _partiesClient
+                .Setup(p => p.GetPartyIdentifiersAndUsernameByPersonIdentifier(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(party);
 
             HttpClient client = CreateClient();
 
@@ -1261,8 +1293,26 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             identity.AddClaims(claims);
             ClaimsPrincipal externalPrincipal = new ClaimsPrincipal(identity);
 
-            UserProfile userProfile = new UserProfile { UserId = 20000, PartyId = 50001, UserName = "steph" };
-            _userProfileService.Setup(u => u.GetUser(It.IsAny<string>())).ReturnsAsync(userProfile);
+            RegisterContracts.Party party = System.Text.Json.JsonSerializer.Deserialize<RegisterContracts.Party>(
+                """
+                {
+                  "partyType": "person",
+                  "partyUuid": "5c0656db-cf51-43a9-bd68-d8a55e7b6f3b",
+                  "versionId": 1,
+                  "partyId": 50001,
+                  "personIdentifier": "19108000239",
+                  "displayName": "Test Testesen",
+                  "createdAt": "2020-01-01T00:00:00Z",
+                  "modifiedAt": "2020-01-01T00:00:00Z",
+                  "isDeleted": false,
+                  "user": { "userId": 20000, "username": "steph", "userIds": [ 20000 ] }
+                }
+                """,
+                new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+
+            _partiesClient
+                .Setup(p => p.GetPartyIdentifiersAndUsernameByPersonIdentifier(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(party);
 
             HttpClient client = CreateClient();
 
@@ -1332,7 +1382,9 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             ClaimsPrincipal externalPrincipal = new ClaimsPrincipal(identity);
 
             string externalToken = JwtTokenMock.GenerateToken(externalPrincipal, TimeSpan.FromMinutes(2), now: TimeProvider.GetUtcNow());
-            _userProfileService.Setup(u => u.GetUser(It.IsAny<string>())).Throws(new Exception());
+            _partiesClient
+                .Setup(p => p.GetPartyIdentifiersAndUsernameByPersonIdentifier(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception());
 
             string url = "/authentication/api/v1/exchange/id-porten";
 


### PR DESCRIPTION
## What

The **ID-porten token exchange** (`/authentication/api/v1/exchange/id-porten`) resolved the user fields (`UserId`/`UserName`/`PartyId`/`PartyUuid`) from **either Register or the platform Profile API**, selected by the `IdPortenUserLookupFromRegister` feature flag. (The original SBL Bridge lookup was already removed — both flag branches were live Altinn-3 sources.)

Register is the agreed permanent source of truth; the Profile-API branch was only a fallback in case Register didn't work. This makes Register **unconditional** and removes the flag.

## Changes
- `AuthenticationController`: removed the flag check and the Profile-API `else` branch. The exchange now always resolves via `_partiesClient.GetPartyIdentifiersAndUsernameByPersonIdentifier` (register `parties/query`).
- Removed the `IdPortenUserLookupFromRegister` feature flag from `FeatureFlags.cs` and `appsettings.json`.
- `_profileService`/`IProfile` is unchanged and still used by the OIDC-server sign-in path; only this one exchange call site is gone.

## Tests
- `AuthenticationControllerTests`: dropped the `flag=off` host setting; the `AuthenticateEndUser_*` success tests now stub the register parties client (returning a `Party` with userId 20000 / partyId 50001) instead of the dead profile/SBL lookup.
  - `..._ServiceThrowsException...` now points the throw at the parties client — the controller's `catch` still yields 401 (its long-standing assertion).
  - `..._MissingClaim...` (401) and `..._UsingDigDirScope` (403) are unchanged — both short-circuit before the lookup.
- `AuthenticationControllerIdPortenRegisterTests` already covers the Register exchange path; dropped its now-redundant `flag=on` setting and the flag references in its doc.

Part of #2030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ID-porten token exchange now consistently resolves user details from Register and returns unauthorized when no matching user is found.
  * Removed an alternate lookup path, making sign-in behavior more predictable.
  * Updated test coverage to match the new lookup flow and error handling.

* **Chores**
  * Cleaned up an unused feature flag from configuration and public settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->