### PR TITLE
chore: remove dead BridgeAuthnApiEndpoint setting (#2030)

### DIFF
--- a/src/Authentication/Configuration/GeneralSettings.cs
+++ b/src/Authentication/Configuration/GeneralSettings.cs
@@ -40,11 +40,6 @@ namespace Altinn.Platform.Authentication.Configuration
         /// <summary>
         /// Gets or sets the bridge authentication api endpoint
         /// </summary>
-        public string BridgeAuthnApiEndpoint { get; set; }
-
-        /// <summary>
-        /// Gets or sets the bridge authentication api endpoint
-        /// </summary>
         public string BridgeProfileApiEndpoint { get; set; }
 
         /// <summary>

--- a/src/Authentication/appsettings.Development.json
+++ b/src/Authentication/appsettings.Development.json
@@ -5,7 +5,6 @@
     "SblAuthCookieEnvSpecificName": ".ASPXAUTH",
     "JwtCookieName": "AltinnStudioRuntime",
     "BaseUrl": "http://localhost",
-    "BridgeAuthnApiEndpoint": "https://at22.altinn.cloud/sblbridge/authentication/api/",
     "BridgeProfileApiEndpoint": "https://at22.altinn.cloud/sblbridge/profile/api/",
     "SBLRedirectEndpoint": "https://at22.altinn.cloud/ui/authentication/",
     "PlatformEndpoint": "https://platform.at22.altinn.cloud/",

--- a/src/Authentication/appsettings.json
+++ b/src/Authentication/appsettings.json
@@ -15,7 +15,6 @@
     "SblAuthCookieEnvSpecificName": ".ASPXAUTH",
     "JwtCookieName": "AltinnStudioRuntime",
     "BaseUrl": "http://localhost",
-    "BridgeAuthnApiEndpoint": "https://at22.altinn.cloud/sblbridge/authentication/api/",
     "BridgeProfileApiEndpoint": "https://at22.altinn.cloud/sblbridge/profile/api/",
     "SBLRedirectEndpoint": "https://at22.altinn.cloud/ui/authentication/",
     "PlatformEndpoint": "https://platform.at22.altinn.cloud/",

--- a/test/Altinn.Platform.Authentication.Tests/appsettings.test.json
+++ b/test/Altinn.Platform.Authentication.Tests/appsettings.test.json
@@ -4,7 +4,6 @@
     "SblAuthCookieName": ".ASPXAUTH",
     "JwtCookieName": "AltinnStudioRuntime",
     "BaseUrl": "http://localhost",
-    "BridgeAuthnApiEndpoint": "http://localhost/sblbridge/authentication/api/",
     "SBLRedirectEndpoint": "http://localhost/ui/authentication",
     "PlatformEndpoint": "http://localhost/",
     "ClaimsIdentity": "UserLogin",


### PR DESCRIPTION
## What

Removes the now-unused `GeneralSettings.BridgeAuthnApiEndpoint` setting and its appsettings keys. Its last consumer was the SBL Bridge `authentication/api/siuser` call, which was removed when self-identified credential validation went local-only (#2067).

- `GeneralSettings.cs`: dropped the property.
- `appsettings.json`, `appsettings.Development.json`, `appsettings.test.json`: dropped the key.

No code references remain.

## Deliberately kept (not dead)

This is the small, safe slice of the SBL config cleanup. The following are **kept** because they still serve a purpose:
- `SblAuthCookieName` / `SblAuthCookieEnvSpecificName` + the legacy-cookie delete paths (`DeleteLegacySblCookies`, `BuildLegacySblCookieDeletes`) — these still **clear stale Altinn 2 cookies** on logout/session creation.
- `ForceOidc` / `EnableOidc` — live OIDC logic.
- `SBLRedirectEndpoint` / `sblRedirectUrl` and the legacy `AuthenticateUser` branches — a separate, carefully-scoped collapse (touches the live sign-in entrypoint).

Part of #2030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the authentication configuration to use the new bridge profile API endpoint setting.
  * Removed the older bridge authentication API endpoint setting from runtime and test configuration files.
  * Kept the surrounding authentication and redirect settings unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->