### PR TITLE
docs: architecture docs, flow guides, ADRs and agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md — guide for AI coding agents
+
+Operational guide for AI agents (Claude Code, Cursor, Copilot, …) working in this repo. Humans: see [`README.md`](README.md) and [`docs/`](docs/README.md). Keep this file **short and high-signal** — it is loaded into limited context.
+
+## What this is
+
+Altinn Platform Authentication — an ASP.NET Core (.NET 10) service that authenticates users/orgs/systems and issues Altinn JWTs, and acts as a small OIDC authorization server for browser sign-in. Read [`docs/architecture.md`](docs/architecture.md) first.
+
+## Commands
+
+```bash
+# Build
+dotnet build Altinn.Platform.Authentication.sln
+
+# Test (Docker MUST be running — Testcontainers PostgreSQL)
+dotnet test test/Altinn.Platform.Authentication.Tests/Altinn.Platform.Authentication.Tests.csproj
+
+# Compile-only check of one project (fast)
+dotnet build src/Authentication/Altinn.Platform.Authentication.csproj -clp:ErrorsOnly --nologo
+```
+
+## Critical workflow rules
+
+- **A green local `dotnet build` is NOT sufficient.** The integration tests need Docker, and compilation passing says nothing about them. The authoritative gate is the CI **Build and Test** job. If you can't run Docker, push and watch CI before claiming done.
+- **Branch per change; never commit to `main`.** Commit/push only when asked.
+- Update the relevant [`docs/`](docs/README.md) page or ADR **in the same PR** as a behaviour change.
+- Respond to CodeRabbit/CodeQL review comments; don't silently ignore them.
+
+## Where things live
+
+- `src/Authentication` — host, controllers, app services, config. `src/Core` — models/interfaces/pure helpers (no I/O). `src/Integration` — outbound clients (Register/`PartiesClient`, Access Management, Profile). `src/Persistance` — Postgres + SQL migrations. `src/jwtcookie` — shared JWT-cookie library.
+- Auth flows are documented in [`docs/flows/`](docs/flows/). The **why** behind the design is in [`docs/adr/`](docs/adr/) — **read the relevant ADR before changing an auth flow.**
+
+## Landmines — do NOT "fix" these without understanding
+
+- **Production runs `EnableOidc=true`, `ForceOidc=true`, `AuthorizationServerEnabled=true`** in every environment. The authorization-server flow is the only live browser path ([ADR-0002](docs/adr/0002-authorization-server-is-the-live-auth-path.md)). The checked-in `appsettings.json` says `AuthorizationServerEnabled=false` — that is **not** prod.
+- **`IsSafeSameOrSubdomainHttps`** (`AuthenticationController`) is an intentional open-redirect guard. The CodeQL "URL redirection" alerts on the `goTo`/upstream redirects are **dismissed false positives** — don't rewrite the redirects to appease a scanner.
+- **`IsValidIssuer`** is *misnamed* (returns `true` for an invalid issuer) but its control flow is **correct**. Fix the name/substring-match if asked, but do not "invert" the logic — that would break it.
+- **`SblAuthCookie*` names + the legacy-cookie delete logic are intentionally kept** to drain stale Altinn 2 cookies, even though the rest of the SBL integration is gone ([ADR-0004](docs/adr/0004-sbl-bridge-altinn2-decommission.md)).
+- Token-validation in the exchange path disables issuer/audience checks — flagged for review in [#2074](https://github.com/Altinn/altinn-authentication/issues/2074); **verify intent against tests before changing.**
+
+## Test gotchas
+
+- Build Register contract types (`Altinn.Register.Contracts`) via JSON deserialization in tests. A `PartyUser` with `userId` set **must** also set `userIds` (e.g. `"userIds": [ <id> ]`) or its constructor throws at runtime.
+- Mock outbound clients with a mocked `HttpMessageHandler` (see `AccessManagementClientTests`); unit-test pure logic directly (see `AuthenticationHelperTests`).
+
+## Known tech debt
+
+A prioritised top-30 lives in [#2074](https://github.com/Altinn/altinn-authentication/issues/2074). Open follow-ups: [#2072](https://github.com/Altinn/altinn-authentication/issues/2072).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,10 @@ dotnet build src/Authentication/Altinn.Platform.Authentication.csproj -clp:Error
 
 ## Landmines — do NOT "fix" these without understanding
 
-- **Production runs `EnableOidc=true`, `ForceOidc=true`, `AuthorizationServerEnabled=true`** in every environment. The authorization-server flow is the only live browser path ([ADR-0002](docs/adr/0002-authorization-server-is-the-live-auth-path.md)). The checked-in `appsettings.json` says `AuthorizationServerEnabled=false` — that is **not** prod.
+- **`AuthenticateUser` no longer branches on `EnableOidc`/`ForceOidc`/`AuthorizationServerEnabled`** — those legacy browser-sign-in branches were collapsed in #2071 ([ADR-0002](docs/adr/0002-authorization-server-is-the-live-auth-path.md)); the authorization-server flow is the only live browser path. Don't reintroduce branching on these in `AuthenticateUser`. The settings still exist (checked-in value `false` — **not** prod), with differing real usage:
+  - `ForceOidc` — still read in `OidcServerService` (session logic).
+  - `AuthorizationServerEnabled` — still read in `LogoutController`, which still has a legacy branch (dead only if prod sets it `true`; a collapse candidate like #2071).
+  - `EnableOidc` — now read **nowhere**; a dead property / safe-removal candidate.
 - **`IsSafeSameOrSubdomainHttps`** (`AuthenticationController`) is an intentional open-redirect guard. The CodeQL "URL redirection" alerts on the `goTo`/upstream redirects are **dismissed false positives** — don't rewrite the redirects to appease a scanner.
 - **`IsValidIssuer`** is *misnamed* (returns `true` for an invalid issuer) but its control flow is **correct**. Fix the name/substring-match if asked, but do not "invert" the logic — that would break it.
 - **`SblAuthCookie*` names + the legacy-cookie delete logic are intentionally kept** to drain stale Altinn 2 cookies, even though the rest of the SBL integration is gone ([ADR-0004](docs/adr/0004-sbl-bridge-altinn2-decommission.md)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+This project's agent guidance lives in **[AGENTS.md](AGENTS.md)** — read it first (commands, conventions, and known landmines).
+
+@AGENTS.md
+
+Architecture and the *why* behind the design are in [docs/](docs/README.md), with decision records in [docs/adr/](docs/adr/). Read the relevant ADR before changing an authentication flow.

--- a/README.md
+++ b/README.md
@@ -1,41 +1,65 @@
 # Altinn Platform Authentication
 
-This repository covers the Altinn Platform Authentication component. This component is responsible for authentication of users, systems and organizations that access the Altinn 3 platform. 
+This repository contains the **Altinn Platform Authentication** component. It is responsible for authenticating the users, systems and organisations that access the Altinn 3 platform, and for issuing the Altinn JSON Web Tokens (JWT) that the rest of the platform trusts.
 
-Read more about the component on docs.altinn.studio
+It does two things:
 
-- [Authentication capabilities](https://docs.altinn.studio/technology/architecture/capabilities/runtime/security/authentication/) supported by this component
+- **Browser sign-in** — a small OIDC authorization server that delegates identity proofing to upstream providers (ID-porten, FEIDE, UIDP) and establishes an Altinn session.
+- **Token exchange** — exchanges a trusted external token (ID-porten / Maskinporten / Altinn Studio) for an Altinn JWT.
+
+Read more on docs.altinn.studio:
+
+- [Authentication capabilities](https://docs.altinn.studio/technology/architecture/capabilities/runtime/security/authentication/)
 - [Solution components](https://docs.altinn.studio/technology/architecture/components/application/solution/altinn-platform/authentication/)
 - [Construction components](https://docs.altinn.studio/technology/architecture/components/application/construction/altinn-platform/authentication/)
 
-
 ## Build status
-[![Storage build status](https://dev.azure.com/brreg/altinn-studio/_apis/build/status/altinn-platform/authentication-master?label=platform/authentication)](https://dev.azure.com/brreg/altinn-studio/_build/latest?definitionId=41)
+[![Build status](https://dev.azure.com/brreg/altinn-studio/_apis/build/status/altinn-platform/authentication-master?label=platform/authentication)](https://dev.azure.com/brreg/altinn-studio/_build/latest?definitionId=41)
 
+## Documentation
 
-## Getting Started
+In-repo documentation lives in **[`docs/`](docs/README.md)**:
 
-These instructions will get you a copy of the authentication component up and running on your machine for development and testing purposes.
+| Doc | What |
+| --- | --- |
+| [docs/architecture.md](docs/architecture.md) | The big picture: components, dependencies, code layout |
+| [docs/flows/](docs/flows/) | The auth flows (browser sign-in, token exchange, sessions/cookies) |
+| [docs/operations.md](docs/operations.md) | Config, feature flags, secrets, health, runbook |
+| [docs/development.md](docs/development.md) | Local setup, build, run, tests |
+| [docs/adr/](docs/adr/) | Architecture Decision Records — the *why* |
+| [AGENTS.md](AGENTS.md) | Guide for AI coding agents |
+
+## Getting started
 
 ### Prerequisites
 
-1. [.NET 9.0 SDK](https://dotnet.microsoft.com/download/dotnet/9.0)
-2. Code editor of your choice
+1. [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
+2. [Docker](https://www.docker.com/get-docker) — required to run the integration tests
 3. Newest [Git](https://git-scm.com/downloads)
-4. [Docker CE](https://www.docker.com/get-docker)
-5. Solution is cloned
+4. A code editor / IDE of your choice
 
+### Run locally
 
-## Running the storage component
+Clone the repo and run the component from `src/Authentication`:
 
-Clone [Altinn Authentication repo](https://github.com/Altinn/altinn-authentication) and navigate to the root folder.
-
-The Authentication components can be run locally when developing/debugging. Follow the install steps above if this has not already been done.
-
-Navigate to the src/Authentication, and build and run the code from there, or run the solution using you selected code editor
-
-```cmd
+```bash
+cd src/Authentication
 dotnet run
 ```
 
-The Authentication component is now available locally at http://localhost:5040/api/v1
+Swagger UI is then available under `http://localhost:<port>/authentication/swagger`.
+
+### Build & test
+
+```bash
+dotnet build Altinn.Platform.Authentication.sln
+dotnet test test/Altinn.Platform.Authentication.Tests/Altinn.Platform.Authentication.Tests.csproj   # needs Docker
+```
+
+See [docs/development.md](docs/development.md) for details — note that a passing local build does **not** substitute for the Docker-backed test suite.
+
+## Contributing
+
+- Branch per change; open a pull request.
+- Keep [`docs/`](docs/README.md) / ADRs updated in the same PR as behaviour changes.
+- Known tech debt is tracked in [#2074](https://github.com/Altinn/altinn-authentication/issues/2074).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,30 @@
+# Altinn Authentication — Documentation
+
+Documentation for the **Altinn Platform Authentication** component: the service that authenticates users, systems and organisations accessing the Altinn 3 platform, and that issues Altinn JSON Web Tokens (JWT).
+
+These docs are written for **both humans and AI coding agents** — the conceptual pages below are the single source of truth. Agents should also read [`../AGENTS.md`](../AGENTS.md) for operational conventions and known landmines.
+
+## Map
+
+| Doc | What it covers |
+| --- | --- |
+| [architecture.md](architecture.md) | The big picture: components, dependencies, where things live in the codebase |
+| [flows/oidc-authorization-server.md](flows/oidc-authorization-server.md) | Browser sign-in: the OIDC authorization-server flow and upstream callback |
+| [flows/token-exchange.md](flows/token-exchange.md) | Exchanging an external token (ID-porten / Maskinporten / Altinn Studio) for an Altinn JWT |
+| [flows/sessions-and-cookies.md](flows/sessions-and-cookies.md) | Sessions, the cookie model, refresh, and logout |
+| [operations.md](operations.md) | Configuration, feature flags, secrets, health, observability, runbook |
+| [development.md](development.md) | Local setup, build, run, and the (Docker-backed) test strategy |
+| [adr/](adr/) | Architecture Decision Records — the **why** behind the design |
+
+## Where to start
+
+- **New to the service?** Read [architecture.md](architecture.md), then the flow that matches your task.
+- **Changing an auth flow?** Read the relevant [ADR](adr/) first — several behaviours that look removable are load-bearing (or were deliberately kept).
+- **Operating it?** [operations.md](operations.md).
+- **An agent picking up a task?** [`../AGENTS.md`](../AGENTS.md) + the relevant ADR.
+
+## Conventions
+
+- Diagrams are [Mermaid](https://mermaid.js.org/) — they render on GitHub and diff cleanly in PRs. No binary images.
+- Decisions are recorded as immutable, numbered [ADRs](adr/); a decision is never edited, only superseded.
+- Keep these docs updated **in the same PR** as the change that invalidates them.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ These docs are written for **both humans and AI coding agents** — the conceptu
 | [flows/oidc-authorization-server.md](flows/oidc-authorization-server.md) | Browser sign-in: the OIDC authorization-server flow and upstream callback |
 | [flows/token-exchange.md](flows/token-exchange.md) | Exchanging an external token (ID-porten / Maskinporten / Altinn Studio) for an Altinn JWT |
 | [flows/sessions-and-cookies.md](flows/sessions-and-cookies.md) | Sessions, the cookie model, refresh, and logout |
+| [flows/system-user.md](flows/system-user.md) | System users (Systembruker): system register, request/approval, agent delegation |
 | [operations.md](operations.md) | Configuration, feature flags, secrets, health, observability, runbook |
 | [development.md](development.md) | Local setup, build, run, and the (Docker-backed) test strategy |
 | [adr/](adr/) | Architecture Decision Records — the **why** behind the design |

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,23 @@
+# ADR-0001: Record architecture decisions
+
+- **Status:** Accepted
+- **Date:** 2026-06-30
+
+## Context
+
+This service carries a lot of implicit knowledge — which code paths are live vs. dead, why certain "removable-looking" behaviour is load-bearing, what production assumes about configuration. That knowledge lived only in people's heads and in scattered PR discussions, and was repeatedly and expensively re-derived (including during the Altinn 2 decommission, where confirming "is this branch actually dead?" gated every change). Both human contributors and AI coding agents need the *why*, not just the *what*.
+
+## Decision
+
+We will record significant architectural and behavioural decisions as **Architecture Decision Records** in `docs/adr/`, following the lightweight format in [template.md](template.md). ADRs are immutable and superseded rather than edited. Decisions that affect how an auth flow behaves, what is intentionally kept/removed, or what production configuration is assumed, are in scope.
+
+## Consequences
+
+- Contributors and agents have a durable, greppable record of *why*, reducing re-derivation and accidental regressions.
+- A small ongoing cost: a decision-worthy change should add or supersede an ADR in the same PR.
+- The first ADRs (0002–0004) backfill the most important recent decisions.
+
+## References
+
+- `docs/` documentation set
+- Tech-debt tracking: [#2074](https://github.com/Altinn/altinn-authentication/issues/2074)

--- a/docs/adr/0002-authorization-server-is-the-live-auth-path.md
+++ b/docs/adr/0002-authorization-server-is-the-live-auth-path.md
@@ -1,0 +1,31 @@
+# ADR-0002: The OIDC authorization server is the only live browser sign-in path
+
+- **Status:** Accepted
+- **Date:** 2026-06-30
+
+## Context
+
+`AuthenticationController.AuthenticateUser` historically contained several browser sign-in branches gated by three settings:
+
+- `EnableOidc` — OIDC sign-in enabled at all.
+- `ForceOidc` — OIDC is the default (no `iss` required).
+- `AuthorizationServerEnabled` — use the modern authorization-server flow (vs. an older OIDC-redirect-here flow, vs. a legacy Altinn 2 SBL redirect).
+
+The branches included: an OIDC **code-exchange handled at this endpoint**, an older **redirect-to-OIDC-provider** branch, and an `EnableOidc=false` **SBL redirect** fallback. In the authorization-server model the upstream callback goes to `GET /upstream/callback` — never back to `/authentication` with a `code` — so the code-exchange branch was unreachable in production.
+
+Production runs **`EnableOidc=true`, `ForceOidc=true`, `AuthorizationServerEnabled=true` in every environment** (confirmed with the team), which makes all of those legacy branches dead.
+
+## Decision
+
+We will treat the **authorization-server flow as the single live browser sign-in path** and collapse `AuthenticateUser` to it, removing the legacy code-exchange / OIDC-redirect / SBL-redirect branches and the dead helpers, settings usage (`sblRedirectUrl`/`SBLRedirectEndpoint`), and the legacy `IUserProfileService.GetUser`/`CreateUser` provisioning path they pulled in.
+
+## Consequences
+
+- `AuthenticateUser` is now a single, readable flow (see [flows/oidc-authorization-server.md](../flows/oidc-authorization-server.md)); ~1400 lines of dead code/tests removed.
+- This **depends on the three settings staying true in all environments.** If a new environment ever sets one false, the removed behaviour does not come back — that would need a deliberate redesign.
+- The `EnableOidc`/`ForceOidc`/`AuthorizationServerEnabled` settings still exist because other components (`OidcServerService`, `LogoutController`) read them; they were not deleted.
+
+## References
+
+- Implemented in PR #2073 (issue [#2071](https://github.com/Altinn/altinn-authentication/issues/2071)).
+- Part of the Altinn 2 decommission, [ADR-0004](0004-sbl-bridge-altinn2-decommission.md).

--- a/docs/adr/0002-authorization-server-is-the-live-auth-path.md
+++ b/docs/adr/0002-authorization-server-is-the-live-auth-path.md
@@ -23,7 +23,7 @@ We will treat the **authorization-server flow as the single live browser sign-in
 
 - `AuthenticateUser` is now a single, readable flow (see [flows/oidc-authorization-server.md](../flows/oidc-authorization-server.md)); ~1400 lines of dead code/tests removed.
 - This **depends on the three settings staying true in all environments.** If a new environment ever sets one false, the removed behaviour does not come back — that would need a deliberate redesign.
-- The `EnableOidc`/`ForceOidc`/`AuthorizationServerEnabled` settings still exist because other components (`OidcServerService`, `LogoutController`) read them; they were not deleted.
+- The three settings still exist in `GeneralSettings`/appsettings (they were not deleted), but their usage now differs: `ForceOidc` is still read by `OidcServerService`, `AuthorizationServerEnabled` by `LogoutController` (which still has its own legacy branch — a future collapse candidate), while `EnableOidc` is now read **nowhere** and is a dead-property cleanup candidate.
 
 ## References
 

--- a/docs/adr/0003-register-is-canonical-for-user-and-org-lookup.md
+++ b/docs/adr/0003-register-is-canonical-for-user-and-org-lookup.md
@@ -1,0 +1,30 @@
+# ADR-0003: Register is the canonical source for user/party/org lookup
+
+- **Status:** Accepted
+- **Date:** 2026-06-30
+
+## Context
+
+Resolving a person/organisation to their Altinn identifiers (`userId`, `partyId`, `partyUuid`, username) historically went through the Altinn 2 **SBL Bridge** profile API. As part of the Altinn 2 decommission ([ADR-0004](0004-sbl-bridge-altinn2-decommission.md)), that lookup was first moved behind feature flags with two live Altinn-3 sources:
+
+- **Register** — `POST /register/api/v2/internal/parties/query` (via `PartiesClient`).
+- The platform **Profile API** — used as a fallback.
+
+For self-identified (SI) user provisioning during sign-in there was similarly a Register path vs. an SBL path.
+
+The Profile API path was only ever a safety net in case Register did not work.
+
+## Decision
+
+We will use **Register as the single, canonical source** for ID-porten token-exchange user lookup and for SI user provisioning, and remove the Profile-API fallback and the associated feature flags (`IdPortenUserLookupFromRegister`, `RegisterSelfIdentifiedUserProvisioning`). SI **credential validation** is performed locally (`LocalSelfIdentifiedCredentialValidation` removed; the local path is permanent, used to link old SI profiles to email users).
+
+## Consequences
+
+- One code path, no flag — simpler and matching production behaviour.
+- The id-porten exchange now depends entirely on Register availability. A Register **outage** currently surfaces as `401` (because `PartiesClient` returns `null` for both "not found" and infra failures, and the controller maps `null` → `Unauthorized`). This is a known gap tracked in [#2072](https://github.com/Altinn/altinn-authentication/issues/2072) — it should return `5xx` for infra failures.
+- `IUserProfileService.GetUser`/`CreateUser` (the last SBL profile calls) were removed once unused.
+
+## References
+
+- PRs #2067 (SI provisioning + local validation) and #2068 (id-porten exchange).
+- Follow-up: [#2072](https://github.com/Altinn/altinn-authentication/issues/2072).

--- a/docs/adr/0004-sbl-bridge-altinn2-decommission.md
+++ b/docs/adr/0004-sbl-bridge-altinn2-decommission.md
@@ -1,0 +1,32 @@
+# ADR-0004: Remove the Altinn 2 / SBL Bridge integration
+
+- **Status:** Accepted
+- **Date:** 2026-06-30
+
+## Context
+
+Altinn Authentication depended on the Altinn 2 backend (the **"SBL Bridge"**) for several things: cookie/ticket-based authentication, enterprise-user (`virksomhetsbruker`) authentication, self-identified credential validation, and user/profile lookups. Altinn 2 was **shut down in 2026**, making all of those integrations dead or non-functional. The work was tracked under umbrella issue [#2030](https://github.com/Altinn/altinn-authentication/issues/2030).
+
+## Decision
+
+We will remove the Altinn 2 / SBL Bridge integration entirely, in incremental, independently-shippable PRs, replacing each path with its Altinn-3 equivalent and deleting the feature flags that selected between them. Specifically:
+
+- **Enterprise-user auth** → permanently `410 Gone` (replaced by system users / ID-porten).
+- **Logout** → always redirect to `BaseUrl` (dropped the SBL logout redirect).
+- **Cookie-ticket decryption / A2-ticket auth** → removed.
+- **SI provisioning + credential validation** → Register-only + local ([ADR-0003](0003-register-is-canonical-for-user-and-org-lookup.md)).
+- **ID-porten exchange user lookup** → Register-only ([ADR-0003](0003-register-is-canonical-for-user-and-org-lookup.md)).
+- **Legacy browser sign-in branches** → collapsed to the authorization-server flow ([ADR-0002](0002-authorization-server-is-the-live-auth-path.md)).
+- Removed dead config: `BridgeAuthnApiEndpoint`, `BridgeProfileApiEndpoint`, `SBLRedirectEndpoint`, and all SBL-decommission feature flags.
+
+## Consequences
+
+- The SBL Bridge HTTP surface and all six decommission feature flags are gone; the Altinn-3 behaviour is now permanent and unconditional.
+- **Deliberately kept:** the `SblAuthCookieName` / `SblAuthCookieEnvSpecificName` cookie *names* and the legacy-cookie **delete** logic (`DeleteLegacySblCookies` / `BuildLegacySblCookieDeletes`). These still run on logout/session creation to **drain stale Altinn 2 cookies** from users' browsers. Do not remove this until the team decides those cookies are fully drained.
+- A few latent issues were exposed (not introduced) by becoming the sole path — e.g. the Register-outage→`401` behaviour ([#2072](https://github.com/Altinn/altinn-authentication/issues/2072)).
+
+## References
+
+- Umbrella: [#2030](https://github.com/Altinn/altinn-authentication/issues/2030).
+- PRs: #2063, #2065, #2066, #2067, #2068, #2070, #2073.
+- Related: [ADR-0002](0002-authorization-server-is-the-live-auth-path.md), [ADR-0003](0003-register-is-canonical-for-user-and-org-lookup.md).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,19 @@
+# Architecture Decision Records (ADRs)
+
+An ADR captures a single architectural decision: its **context**, the **decision**, and its **consequences**. ADRs explain the *why* — the thing source code and git history don't preserve and that humans and agents otherwise re-derive at great cost.
+
+## Rules
+
+- ADRs are **immutable**. Once accepted, a decision is never edited — if it changes, write a **new** ADR that supersedes the old one and mark the old one `Superseded by ADR-XXXX`.
+- Numbered sequentially, zero-padded: `0001`, `0002`, …
+- Keep them short (one page). Link to code/PRs/issues for detail.
+- Use [template.md](template.md) for new ADRs.
+
+## Index
+
+| ADR | Title | Status |
+| --- | --- | --- |
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
+| [0002](0002-authorization-server-is-the-live-auth-path.md) | The OIDC authorization server is the only live browser sign-in path | Accepted |
+| [0003](0003-register-is-canonical-for-user-and-org-lookup.md) | Register is the canonical source for user/party/org lookup | Accepted |
+| [0004](0004-sbl-bridge-altinn2-decommission.md) | Remove the Altinn 2 / SBL Bridge integration | Accepted |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,21 @@
+# ADR-XXXX: <short title of the decision>
+
+- **Status:** Proposed | Accepted | Superseded by ADR-YYYY
+- **Date:** YYYY-MM-DD
+- **Deciders:** <who>
+
+## Context
+
+What is the situation/problem? What forces are at play (technical, organisational, security)? What constraints?
+
+## Decision
+
+What did we decide to do? State it in active voice: "We will …".
+
+## Consequences
+
+What becomes easier, harder, or riskier as a result? What must be kept/changed because of this? Any follow-ups or new debt.
+
+## References
+
+Links to code, PRs, issues, external docs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,134 @@
+# Architecture
+
+Altinn Authentication is an ASP.NET Core service (.NET 10) that does two distinct jobs:
+
+1. **Authenticates** users, organisations and systems, and **issues Altinn JWTs** that the rest of the Altinn 3 platform trusts.
+2. Acts as a small **OIDC authorization server** for browser sign-in (Arbeidsflate, Altinn Apps, Access Management UI), delegating the actual identity proofing to upstream providers (ID-porten, FEIDE, UIDP).
+
+All endpoints are served under the route prefix `authentication/api/v1`.
+
+## Context — the service and its neighbours
+
+```mermaid
+flowchart TB
+    subgraph clients[Clients]
+      browser[Browser: Arbeidsflate / Altinn Apps / AM UI]
+      system[Systems & vendors: API clients]
+    end
+
+    auth[Altinn Authentication]
+
+    subgraph upstream[Upstream identity providers]
+      idporten[ID-porten]
+      maskinporten[Maskinporten]
+      feide[FEIDE / UIDP]
+      studio[Altinn Studio Designer]
+    end
+
+    subgraph altinn[Altinn platform services]
+      register[Register: users / parties / orgs]
+      accessmgmt[Access Management]
+      profile[Profile]
+    end
+
+    subgraph infra[Infrastructure]
+      pg[(PostgreSQL)]
+      kv[Azure Key Vault: signing certs]
+      queue[Azure Storage Queue: audit events]
+      ai[App Insights / OpenTelemetry]
+    end
+
+    browser --> auth
+    system --> auth
+    auth -->|redirect & validate id_token| idporten
+    auth -->|redirect & validate id_token| feide
+    auth -->|validate access token| maskinporten
+    auth -->|validate designer token| studio
+    auth -->|resolve user/party/org| register
+    auth -->|delegations / system users| accessmgmt
+    auth -->|user profile| profile
+    auth --> pg
+    auth --> kv
+    auth --> queue
+    auth --> ai
+```
+
+## Solution layout
+
+The solution (`Altinn.Platform.Authentication.sln`) is layered:
+
+| Project | Responsibility |
+| --- | --- |
+| `src/Authentication` | The web host: controllers, application services (OIDC server, token issuing, sessions, system-user), DI wiring, configuration. |
+| `src/Core` | Domain models, interfaces, and pure helpers (e.g. PKCE, hashing, claim helpers). No I/O. |
+| `src/Integration` | Outbound clients to other systems (Register/`PartiesClient`, Access Management, Profile, Maskinporten/OIDC providers). |
+| `src/Persistance` | PostgreSQL repositories and SQL migrations (versioned directories under `Migration/`). |
+| `src/jwtcookie` | `Altinn.Common.Authentication` — the shared JWT-cookie authentication handler library. |
+| `test/Altinn.Platform.Authentication.Tests` | Unit + integration tests (integration tests use Testcontainers PostgreSQL — **Docker required**). |
+| `test/Altinn.Platform.Authentication.SystemIntegrationTests` | Live end-to-end tests against deployed environments (opt-in). |
+| `test/Altinn.Platform.Authentication.PerformanceTests` | k6/performance tests. |
+
+**Layering rule:** dependencies point inward — `Authentication` → `Integration` → `Core`, and `Persistance` → `Core`. `Core` depends on nothing in the solution.
+
+## Endpoint surface
+
+All under `authentication/api/v1`. The most important controllers:
+
+| Controller | Key endpoints | Purpose |
+| --- | --- | --- |
+| `AuthenticationController` | `GET authentication`, `GET refresh`, `GET exchange/{tokenProvider}` | Browser sign-in entry point; refresh the Altinn JWT; exchange an external token for an Altinn JWT. |
+| `OidcFrontChannelController` | `GET authorize`, `GET upstream/callback`, `GET upstream/frontchannel-logout`, `GET openid/logout` | The OIDC authorization-server endpoints + the callback from the upstream IdP. |
+| `OidcTokenController` | `POST token` | OIDC token endpoint for registered downstream clients. |
+| `OpenIdController` | `GET openid/.well-known/openid-configuration`, `.../jwks` | OIDC discovery + the public signing keys (JWKS) for verifying Altinn JWTs. |
+| `LogoutController` | `GET logout`, `GET logout/handleloggedout`, `GET frontchannel_logout` | Session teardown + cookie cleanup. |
+| `IntrospectionController` | `POST introspection` | RFC 7662 token introspection. |
+| `SelfIdentifiedAuthenticationController` | `POST link`, `POST link-request`, `POST redeem-link` | Self-identified (SI) credential validation + the account-link / "forgotten password" flow. |
+| `SystemRegisterController` | `.../systemregister/...` | Registers the *systems* that can act as system users. |
+| `RequestSystemUserController`, `ChangeRequestSystemUserController`, `SystemUserClientDelegationController` | `.../systemuser/...` | The system-user request / change-request / agent / delegation lifecycle. |
+
+## The two faces of the service
+
+The cleanest mental model is to split the service in two:
+
+```mermaid
+flowchart LR
+    subgraph A[Face 1: Browser sign-in - OIDC authorization server]
+      a1[GET authentication] --> a2[AuthorizeUnregisteredClient]
+      a2 --> a3[redirect to upstream IdP]
+      a3 --> a4[GET upstream/callback]
+      a4 --> a5[create session + cookies]
+    end
+    subgraph B[Face 2: Token exchange - API]
+      b1[GET exchange/tokenProvider] --> b2[validate external token]
+      b2 --> b3[build Altinn claims]
+      b3 --> b4[issue Altinn JWT]
+    end
+```
+
+- **Face 1 (browser)** is stateful: it manages a session and sets cookies. See [flows/oidc-authorization-server.md](flows/oidc-authorization-server.md) and [flows/sessions-and-cookies.md](flows/sessions-and-cookies.md).
+- **Face 2 (API)** is stateless: a caller presents a trusted external token and gets an Altinn JWT in the response body. See [flows/token-exchange.md](flows/token-exchange.md).
+
+Both faces ultimately call the **token issuer** (`TokenIssuerService` / the `GenerateToken` path), which signs the Altinn JWT with a certificate selected from Key Vault. The public keys are published at the JWKS endpoint so every other Altinn service can verify the token offline.
+
+## Key application services
+
+| Service | Role |
+| --- | --- |
+| `OidcServerService` | The heart of Face 1: `/authorize`, the upstream callback + token exchange, session create/refresh/end, logout. (Large — a decomposition candidate; see [issue #2074](https://github.com/Altinn/altinn-authentication/issues/2074).) |
+| `TokenService` / `TokenIssuerService` | Mint and rotate Altinn JWTs and refresh tokens. |
+| `UpstreamTokenValidator` | Validates upstream `id_token`s (issuer + nonce) — the correct validation pattern for the service. |
+| `PartiesClient` (Integration) | Resolves users / parties / orgs from **Register** (the canonical source — see [ADR-0003](adr/0003-register-is-canonical-for-user-and-org-lookup.md)). |
+| `EventLogService` | Writes authentication audit events to an Azure Storage Queue. |
+| `SystemUserService`, `SystemRegisterService`, `RequestSystemUserService` | The system-user domain. |
+
+## Cross-cutting concerns
+
+- **Token signing**: certificates from Azure Key Vault, selected with a rollover delay so a freshly-published cert propagates to verifiers before it signs. Public keys served at JWKS.
+- **Sessions**: session handles are random 256-bit values, stored only as an HMAC-SHA256 with a server-side pepper; refresh tokens rotate with reuse-detection.
+- **Audit**: authentication events are enqueued to Azure Storage Queue, gated by the `AuditLog` feature flag.
+- **Observability**: OpenTelemetry tracing + metrics across all assemblies, exported to Application Insights. Structured logging via `Logging:LogLevel`.
+- **Health**: `GET /health` (liveness). (Readiness/dependency checks are a known gap — see [operations.md](operations.md).)
+
+## History worth knowing
+
+The service used to depend on the **Altinn 2 "SBL Bridge"** backend for cookie/ticket authentication, enterprise-user auth, and user/profile lookups. Altinn 2 was shut down in 2026 and that integration was fully removed (umbrella [#2030](https://github.com/Altinn/altinn-authentication/issues/2030)). The authorization-server flow is now the **only** live browser sign-in path, and **Register** is the only source for user/party/org lookups. See [ADR-0004](adr/0004-sbl-bridge-altinn2-decommission.md) and [ADR-0002](adr/0002-authorization-server-is-the-live-auth-path.md). This matters because some remaining code (e.g. legacy SBL-cookie *deletion* on logout) is intentionally kept to drain stale cookies, even though the rest of the SBL integration is gone.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,6 +108,8 @@ flowchart LR
 - **Face 1 (browser)** is stateful: it manages a session and sets cookies. See [flows/oidc-authorization-server.md](flows/oidc-authorization-server.md) and [flows/sessions-and-cookies.md](flows/sessions-and-cookies.md).
 - **Face 2 (API)** is stateless: a caller presents a trusted external token and gets an Altinn JWT in the response body. See [flows/token-exchange.md](flows/token-exchange.md).
 
+Beyond authentication itself, the service also owns the **system-user (Systembruker)** domain — the catalogue of registered systems, the request/approval lifecycle by which a customer grants a vendor's system access, and agent/client delegation. This is a substantial feature in its own right; see [flows/system-user.md](flows/system-user.md).
+
 Both faces ultimately call the **token issuer** (`TokenIssuerService` / the `GenerateToken` path), which signs the Altinn JWT with a certificate selected from Key Vault. The public keys are published at the JWKS endpoint so every other Altinn service can verify the token offline.
 
 ## Key application services

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,51 @@
+# Development
+
+## Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
+- [Docker](https://www.docker.com/get-docker) — **required for the integration tests** (they spin up PostgreSQL via Testcontainers).
+- Git, and a code editor / IDE.
+
+## Build & run
+
+```bash
+# Build the whole solution
+dotnet build Altinn.Platform.Authentication.sln
+
+# Run the service locally
+cd src/Authentication
+dotnet run
+# Swagger UI: http://localhost:<port>/authentication/swagger
+```
+
+Local runtime config comes from `appsettings.Development.json`; secrets should come from user-secrets, not committed files.
+
+## Tests
+
+```bash
+# Unit + integration tests (Docker MUST be running)
+dotnet test test/Altinn.Platform.Authentication.Tests/Altinn.Platform.Authentication.Tests.csproj
+```
+
+- **Integration tests need Docker.** Most controller tests run through a `WebApplicationFixture` backed by a Testcontainers PostgreSQL instance, applying migrations on startup. They are slow but cover real request/DB behaviour.
+- **A green local `dotnet build` is not enough.** Compilation passing does not mean the tests pass. The authoritative signal is the CI **Build and Test** job (it runs the Docker-backed suite). When you can't run Docker locally, push and watch CI.
+- `test/.../SystemIntegrationTests` and `.../PerformanceTests` are **opt-in** suites that hit deployed environments / load — not part of the normal loop.
+
+### Testing patterns
+
+- Pure logic (claim mapping, ACR parsing, scope checks, helpers) should be unit-tested directly — see `AuthenticationHelperTests`.
+- Outbound clients should be tested with a mocked `HttpMessageHandler` — see `AccessManagementClientTests` for the pattern.
+- The Register contract types (`Altinn.Register.Contracts`) are easiest to build via JSON deserialization in tests. ⚠️ Gotcha: a `PartyUser` with a `userId` set **must** also set `userIds` (e.g. `"userIds": [ <id> ]`), or its constructor throws at runtime.
+
+## Migrations
+
+SQL migrations live under `src/Persistance/Migration/` in versioned directories (`v0.xx-...`), plus lifecycle folders (`_pre`, `_post`, `_init`, `_erase`, `_draft`). They are applied automatically when the test/host database starts.
+
+## Conventions
+
+- **Branch per change**; never commit straight to `main`.
+- Conventional-ish commit subjects (`chore:`, `fix:`, `docs:`, `test:`); reference the issue/PR.
+- Keep public APIs documented with XML doc comments.
+- Update the relevant doc/ADR **in the same PR** as a behaviour change.
+
+See [`../AGENTS.md`](../AGENTS.md) for the agent-facing version of these conventions, including the known landmines.

--- a/docs/flows/oidc-authorization-server.md
+++ b/docs/flows/oidc-authorization-server.md
@@ -1,0 +1,64 @@
+# Flow: OIDC authorization server (browser sign-in)
+
+**Entry point:** `GET authentication/api/v1/authentication`
+**Upstream callback:** `GET authentication/api/v1/upstream/callback`
+**Code:** `AuthenticationController.AuthenticateUser`, `OidcFrontChannelController`, `OidcServerService`
+
+This is the stateful, browser-facing face of the service. An unauthenticated user is redirected to an upstream identity provider (ID-porten by default, or FEIDE/UIDP), proofs their identity there, and is sent back; the service then establishes an Altinn **session**, sets cookies, and redirects the user to where they wanted to go (`goTo`).
+
+> **Important:** this is the **only** live browser sign-in path. Production runs `EnableOidc=true`, `ForceOidc=true` and `AuthorizationServerEnabled=true`, so the legacy non-authorization-server branches have been removed. See [ADR-0002](../adr/0002-authorization-server-is-the-live-auth-path.md).
+
+## The happy path
+
+```mermaid
+sequenceDiagram
+    participant U as User (browser)
+    participant App as Altinn App / Arbeidsflate
+    participant Auth as Authentication (authorization server)
+    participant IdP as Upstream IdP (ID-porten / FEIDE / UIDP)
+
+    U->>App: open protected page
+    App->>Auth: redirect to GET /authentication?goto=...
+    Note over Auth: goTo is validated by IsSafeSameOrSubdomainHttps (open-redirect guard)
+    alt already has a valid Altinn session/cookie at the requested level
+        Auth-->>U: 302 redirect to goTo (reuse session)
+    else not authenticated (or step-up needed)
+        Auth->>Auth: AuthorizeUnregisteredClient (pick provider, build state/nonce/PKCE)
+        Auth-->>U: 302 redirect to IdP /authorize
+        U->>IdP: authenticate
+        IdP-->>U: 302 redirect to GET /upstream/callback?code=...&state=...
+        U->>Auth: GET /upstream/callback
+        Auth->>IdP: exchange code -> id_token (+ validate issuer/nonce)
+        Auth->>Auth: resolve user, create session, set cookies
+        Auth-->>U: 302 redirect to goTo
+    end
+```
+
+## Steps in detail
+
+1. **`GET /authentication?goto=<url>`** (`AuthenticateUser`):
+   - Validates `goTo` with `IsSafeSameOrSubdomainHttps` — an **open-redirect guard** that only allows an absolute `https` URL whose host equals or is a subdomain of the service host, with no embedded credentials. Anything else redirects to `BaseUrl`. *(This guard is intentional; the CodeQL "URL redirection" alerts on the subsequent redirects are dismissed false positives.)*
+   - Sets `no-store`/`no-cache` headers (auth responses must never be cached).
+   - If the user already has a valid session (auth cookie or Altinn session cookie) that meets the requested `acr` level, redirects straight to `goTo`.
+   - Otherwise calls `OidcServerService.AuthorizeUnregisteredClient`, which selects the upstream provider (from the `iss` query param, the requested `acr`, or the configured default `idporten`), builds the upstream authorize URL (state, nonce, PKCE S256), persists an upstream login transaction, and redirects the browser to the IdP.
+
+2. **Upstream callback** — **`GET /upstream/callback`** (`OidcFrontChannelController` → `OidcServerService.HandleUpstreamCallback`):
+   - Looks up the persisted upstream transaction by `state`.
+   - Exchanges the `code` for the upstream `id_token`, validates it (issuer + nonce) via `UpstreamTokenValidator`.
+   - Resolves/provisions the Altinn user (from Register), creates an Altinn **session** and the cookie set, and redirects to the client / `goTo`.
+   - On failure it returns a `LocalError` (e.g. `500`) rather than establishing a partial session.
+
+3. **`acr_values` / step-up:** the entry point accepts an optional space-separated `acr_values` query parameter (allowed values validated by `AuthenticationHelper.TryParseAcrValues`). If the existing session does not meet the requested level, the user is re-authenticated upstream at the higher level.
+
+## Registered downstream clients
+
+Beyond the "unregistered client" browser flow above, the service is also a small OIDC provider for **registered** downstream clients (e.g. Arbeidsflate) via `GET /authorize` + `POST /token` (`OidcFrontChannelController` / `OidcTokenController`), with discovery at `GET /openid/.well-known/openid-configuration` and keys at `.../jwks`.
+
+## acr_values
+
+The `acrValues` parameter accepts (validated set, see `AuthenticationHelper.AllowedAcrValues`): `idporten-loa-substantial`, `idporten-loa-high`, `selfregistered-email`. The legacy `level0` / `level1` / `level2` values are still accepted but **deprecated**. Any other value yields `400 Bad Request`.
+
+## Related
+
+- The session + cookie mechanics, refresh, and logout: [sessions-and-cookies.md](sessions-and-cookies.md).
+- The API token-exchange face: [token-exchange.md](token-exchange.md).

--- a/docs/flows/sessions-and-cookies.md
+++ b/docs/flows/sessions-and-cookies.md
@@ -1,0 +1,58 @@
+# Flow: Sessions, cookies, refresh & logout
+
+The browser sign-in flow ([oidc-authorization-server.md](oidc-authorization-server.md)) establishes an Altinn **session** and a set of **cookies**. This page describes that state, how the JWT is refreshed, and how logout tears it down.
+
+## Cookies
+
+| Cookie (setting) | Purpose |
+| --- | --- |
+| `JwtCookieName` (default `AltinnStudioRuntime`) | Holds the Altinn JWT used by Altinn Apps / the runtime. |
+| `AltinnSessionCookieName` (default `altinnsession`) | The Altinn session handle; lets the service re-issue a JWT without a full upstream round-trip. |
+| `AltinnPartyCookieName` / `AltinnPartyUuidCookieName` | The currently-selected party (reportee). |
+| `AltinnLogoutInfoCookieName` | Carries post-logout redirect info. |
+| `OidcNonceCookieName`, `AuthnGoToCookieName` | Transient state for the OIDC round-trip (nonce, original `goTo`). |
+| `SblAuthCookieName` / `SblAuthCookieEnvSpecificName` (`.ASPXAUTH`) | **Legacy Altinn 2 cookie.** No longer *issued*. It is still *deleted* on logout/session creation to drain stale cookies left over from Altinn 2. See [ADR-0004](../adr/0004-sbl-bridge-altinn2-decommission.md) — do not remove this cleanup yet. |
+
+All first-party cookies are set `HttpOnly` + `Secure`.
+
+## Sessions
+
+- A **session handle** is a random 256-bit (CSPRNG) value handed to the browser in the session cookie.
+- The server never stores the raw handle — it stores an **HMAC-SHA256** of the handle with a server-side **pepper** (`GeneralSettings.OidcRefreshTokenPepper`). A presented handle is hashed and compared.
+- **Refresh tokens** are rotated on use, with reuse-detection across a token "family"; stored hashed (PBKDF2, opportunistically migrated to HMAC).
+
+```mermaid
+flowchart LR
+    h[Raw session handle - 256-bit, in cookie] -->|HMAC-SHA256 + pepper| stored[Stored hash in DB]
+    present[Presented handle] -->|hash & compare| stored
+```
+
+## Refresh
+
+**Endpoint:** `GET authentication/api/v1/refresh` (`AuthenticationController.RefreshJwtCookie`)
+
+Re-issues an Altinn JWT for an already-authenticated principal (e.g. when the JWT has expired but the session is still valid). `enrichPid=true` will additionally look up the party and inject the `pid` (SSN) claim.
+
+> Note: gating of `enrichPid` is flagged for review in [issue #2074](https://github.com/Altinn/altinn-authentication/issues/2074) (it injects PII based on a self-asserted flag).
+
+## Logout
+
+**Endpoints:** `GET logout`, `GET logout/handleloggedout`, `GET frontchannel_logout` (`LogoutController`), and `GET openid/logout` / `GET upstream/frontchannel-logout` (`OidcFrontChannelController`).
+
+- `GET logout` ends the Altinn session, clears the Altinn cookies **and the legacy SBL cookies**, and redirects (to the upstream provider's logout, or to `BaseUrl`).
+- Front-channel logout endpoints support upstream-initiated single logout.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant Auth as Authentication
+    participant IdP as Upstream IdP
+    U->>Auth: GET /logout
+    Auth->>Auth: end session, delete JWT/session/SBL cookies
+    alt provider logout configured
+        Auth-->>U: 302 redirect to IdP logout
+        U->>IdP: logout
+    else
+        Auth-->>U: 302 redirect to BaseUrl
+    end
+```

--- a/docs/flows/system-user.md
+++ b/docs/flows/system-user.md
@@ -1,0 +1,78 @@
+# Flow: System user (Systembruker)
+
+**Concept docs:** [System User — Altinn](https://docs.altinn.studio/authentication/what-do-you-get/systemuser/) · [System user guide](https://docs.altinn.studio/en/authorization/guides/system-vendor/system-user/) · [System authentication for system providers](https://docs.altinn.studio/authentication/guides/systemauthentication-for-systemproviders/)
+
+**Controllers:** `SystemRegisterController`, `RequestSystemUserController`, `ChangeRequestSystemUserController`, `SystemUserController`, `SystemUserClientDelegationController`
+**Services:** `SystemRegisterService`, `RequestSystemUserService`, `ChangeRequestSystemUserService`, `SystemUserService`
+
+## What it is
+
+A **system user** (Norwegian *systembruker*) lets an **end-user system** — e.g. an accounting or payroll product built by a **system vendor** — act on behalf of a **customer organisation** towards Altinn and other public-sector APIs, with fine-grained authorization and **without exchanging certificates/passwords per customer**. It is the Altinn 3 replacement for the Altinn 2 *enterprise user* (`virksomhetsbruker`), which this service now rejects with `410 Gone` (see [ADR-0004](../adr/0004-sbl-bridge-altinn2-decommission.md)).
+
+**Maskinporten is central** to the runtime: the end-user system authenticates to Maskinporten with a JWT grant identifying the customer and the system; Maskinporten verifies *with Altinn* that the customer has granted that system access, and issues a **system-user token**. This authentication component owns the **Altinn side** of that picture — the system catalogue, the request/approval lifecycle, and the delegations that Maskinporten checks against — and it exchanges the resulting Maskinporten token for an Altinn JWT (see [token-exchange.md](token-exchange.md), `maskinporten` path).
+
+```mermaid
+flowchart LR
+    vendor[System vendor] -->|1. register system| sr[System Register]
+    vendor -->|2. request system user for a customer| req[System User Request]
+    customer[Customer org admin] -->|3. approve in portal| req
+    req -->|creates| su[System User + delegated rights]
+    eus[End-user system] -->|4. JWT grant| mp[Maskinporten]
+    mp -->|verifies grant| su
+    mp -->|system-user token| eus
+    eus -->|5. exchange token| auth[Altinn Authentication]
+    auth -->|Altinn JWT| eus
+```
+
+## This service's responsibilities
+
+| Area | Controller (route under `authentication/api/v1`) | What it does |
+| --- | --- | --- |
+| **System register** | `systemregister` | The catalogue of *registered systems* a vendor offers — system id, the rights and access packages a system needs, change log. CRUD for vendors + read for everyone. |
+| **System user request** | `systemuser/request` | A vendor requests that a specific customer org set up a (standard or **agent**) system user; the customer's authorised person approves/rejects it; on approval the system user + its delegated rights are created. |
+| **Change request** | `systemuser/changerequest` | Request a change to the rights of an existing system user (same approve/reject lifecycle). |
+| **System user management** | `systemuser`, `enduser/systemuser` | List / get / delete system users for a party; vendor lookups (by system, by query, by external id); an internal change stream; and agent-system-user **client delegation** management. |
+
+## The request → approval lifecycle
+
+The core flow is a vendor-initiated request that a customer must approve. Both **standard** and **agent** variants exist (`.../request/vendor` and `.../request/vendor/agent`).
+
+```mermaid
+sequenceDiagram
+    participant V as System vendor
+    participant Auth as Authentication
+    participant Cust as Customer org admin (browser)
+    participant AM as Access Management
+
+    V->>Auth: POST systemuser/request/vendor (systemId, customer org, rights, externalRef)
+    Auth-->>V: 201 request created (+ confirmation URL)
+    V->>Cust: send the customer to the confirmation URL
+    Cust->>Auth: open confirmation URL (authenticated)
+    Cust->>Auth: POST .../{party}/{requestId}/approve
+    Auth->>AM: create the delegation(s) for the system user
+    Auth-->>Cust: redirect back (request Accepted)
+    Note over V,Auth: vendor can poll GET .../request/vendor/{requestId} for status
+```
+
+- **Idempotency / dedup:** a request is keyed by `ExternalRequestId(OrgNo, ExternalRef, SystemId)` — re-posting the same triple returns the existing request rather than creating a duplicate.
+- **Status:** a request moves from a pending state to `Accepted` / `Rejected` (see `RequestStatus`). The vendor reads status via the `vendor/...` GET endpoints; the customer approves/rejects via the `{party}/{requestId}/approve|reject` endpoints.
+- **Confirmation URL:** built from the host + request id (with the `DONTCHOOSEREPORTEE` parameter for the portal), this is where the customer is sent to approve. The portal redirects through to the Access Management UI.
+
+## Agent system users & client delegation
+
+An **agent** system user acts on behalf of **multiple clients** — the classic case being an accountant/auditor firm whose system manages many customers. Beyond the standard flow:
+
+- `systemuser/request/vendor/agent` creates an *agent* request.
+- `enduser/systemuser` + the `systemuser/agent/...` endpoints manage **client delegations** — which clients (customers) a given agent system user may act for, plus the agent's own ("self") delegations and the customer list. See `SystemUserClientDelegationController` and the `agent/...` routes in `SystemUserController`.
+
+## Where to look in code
+
+- **Models:** `src/Core/Models/SystemUsers/` (e.g. `CreateRequestSystemUser`, `CreateAgentRequestSystemUser`, `RequestStatus`, `ExternalRequestId`, `AgentDelegation*`, `ClientDto`) and `src/Core/Models/SystemRegisters/`.
+- **Services:** `SystemUserService` (large — a decomposition candidate, see [#2074](https://github.com/Altinn/altinn-authentication/issues/2074)), `SystemRegisterService`, `RequestSystemUserService`, `ChangeRequestSystemUserService`.
+- **Persistence:** repositories + migrations under `src/Persistance` (the `systemuserprofile` / system-register tables).
+
+## Related
+
+- The Maskinporten token that a system user ultimately presents is exchanged for an Altinn JWT in [token-exchange.md](token-exchange.md).
+- Why enterprise users were removed in favour of system users: [ADR-0004](../adr/0004-sbl-bridge-altinn2-decommission.md).
+- Authoritative concept + onboarding docs: [docs.altinn.studio — System User](https://docs.altinn.studio/authentication/what-do-you-get/systemuser/).

--- a/docs/flows/token-exchange.md
+++ b/docs/flows/token-exchange.md
@@ -1,0 +1,78 @@
+# Flow: Token exchange
+
+**Endpoint:** `GET authentication/api/v1/exchange/{tokenProvider}`
+**Code:** `AuthenticationController.ExchangeExternalSystemToken` → `AuthenticateIdPortenToken` / `AuthenticateMaskinportenToken` / `AuthenticateAltinnStudioToken`
+
+A caller that already holds a token from a **trusted external provider** presents it as a `Bearer` token in the `Authorization` header and receives a freshly-minted **Altinn JWT** in the response body. This is the stateless, API-facing face of the service — no cookies, no session.
+
+`{tokenProvider}` is one of (case-insensitive): `id-porten`, `maskinporten`, `altinnstudio`.
+
+```mermaid
+sequenceDiagram
+    participant C as Caller
+    participant A as AuthenticationController
+    participant V as Token validation (JWKS)
+    participant R as Register (PartiesClient)
+    participant I as Token issuer
+
+    C->>A: GET exchange/{provider}\nAuthorization: Bearer <external token>
+    A->>A: read & sanity-check bearer token
+    alt unknown provider
+        A-->>C: 400 Bad Request
+    else missing / unreadable token
+        A-->>C: 401 Unauthorized
+    end
+    A->>V: validate signature against provider JWKS
+    A->>A: extract claims, build Altinn claim set
+    opt id-porten
+        A->>R: resolve user/party by pid
+        R-->>A: party (userId, partyId, uuid, username)
+    end
+    A->>I: GenerateToken(principal)
+    I-->>A: signed Altinn JWT
+    A-->>C: 200 OK + Altinn JWT
+```
+
+## Per-provider specifics
+
+### `id-porten`
+End-user (person) login exchange.
+1. Validate the ID-porten token signature (primary JWKS, falling back to the alternative well-known endpoint).
+2. Require an Altinn or partner scope, and a `pid` + `acr`.
+3. Resolve the user from **Register** (`PartiesClient.GetPartyIdentifiersAndUsernameByPersonIdentifier(pid)`) → `userId`, `userName`, `partyId`, `partyUuid`. See [ADR-0003](../adr/0003-register-is-canonical-for-user-and-org-lookup.md).
+4. Map `acr` → Altinn authentication level, build the claim set, and issue the Altinn JWT.
+
+### `maskinporten`
+System/organisation login exchange.
+1. Validate the Maskinporten token (primary + alternative signing keys) and the issuer.
+2. Read the organisation number from the `consumer` claim (ISO 6523).
+3. If the token carries the `altinn:serviceowner` scope, look up the org and add the `urn:altinn:org` claim.
+4. **Enterprise users (`virksomhetsbruker`) are no longer supported** — a request with the `X-Altinn-EnterpriseUser-Authentication` header is rejected with `410 Gone` (see [ADR-0004](../adr/0004-sbl-bridge-altinn2-decommission.md)).
+5. Build the org claim set and issue the Altinn JWT.
+
+### `altinnstudio`
+Altinn Studio Designer login exchange.
+1. Require issuer `studio` / `dev-studio` / `staging-studio`.
+2. Validate the signature against the designer signing keys.
+3. Copy the original claims and issue an Altinn JWT.
+
+## Responses
+
+| Status | When |
+| --- | --- |
+| `200 OK` | Token valid; body contains the Altinn JWT. |
+| `400 Bad Request` | Unknown `{tokenProvider}`. |
+| `401 Unauthorized` | Missing/unreadable/invalid token, missing required claims, or (currently) any downstream failure caught by the catch-all. |
+| `403 Forbidden` | id-porten token without a required Altinn/partner scope. |
+| `410 Gone` | Maskinporten request asking for enterprise-user authentication. |
+| `429 Too Many Requests` | A self-identified account is locked out. |
+
+## Verification & known issues
+
+Token validation here is security-critical. Several aspects are flagged for review in [issue #2074](https://github.com/Altinn/altinn-authentication/issues/2074):
+
+- The shared validation disables `ValidateIssuer`/`ValidateAudience` and uses a **substring** issuer check; the id-porten path has no issuer check. **Verify intent before changing** — the OIDC-server side (`UpstreamTokenValidator`) does the stricter, correct validation and is the pattern to follow.
+- A Register **outage** is currently mapped to `401` rather than `5xx` (see [#2072](https://github.com/Altinn/altinn-authentication/issues/2072)).
+- `IsValidIssuer` is **misnamed** (returns `true` for an *invalid* issuer) but its control flow is correct — do not "fix" the control flow.
+
+> The companion browser-sign-in path is in [oidc-authorization-server.md](oidc-authorization-server.md); how the issued token lives in cookies/sessions is in [sessions-and-cookies.md](sessions-and-cookies.md).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,57 @@
+# Operations
+
+How the service is configured, observed, and operated.
+
+## Configuration
+
+Configuration is standard ASP.NET Core layered config: `appsettings.json` (base) → `appsettings.{Environment}.json` → environment variables / Key Vault. Settings are bound into option classes, the largest being `GeneralSettings` (`src/Authentication/Configuration/GeneralSettings.cs`).
+
+Notable settings:
+
+| Setting | Meaning |
+| --- | --- |
+| `GeneralSettings:OidcRefreshTokenPepper` | **Secret.** Server-side pepper for hashing session handles / refresh tokens. Required; supply via Key Vault / env. |
+| `GeneralSettings:JwtCookieName`, `SblAuthCookieName`, `AltinnSessionCookieName`, … | Cookie names (see [flows/sessions-and-cookies.md](flows/sessions-and-cookies.md)). |
+| `GeneralSettings:EnableOidc`, `ForceOidc`, `AuthorizationServerEnabled` | All **true** in every environment; the authorization-server flow is the only live path (see [ADR-0002](adr/0002-authorization-server-is-the-live-auth-path.md)). |
+| `GeneralSettings:MaskinportenWellKnownConfigEndpoint`, `IdPortenWellKnownConfigEndpoint` (+ `*Alternative*`) | Upstream discovery endpoints used to fetch signing keys. |
+| `PlatformSettings:Api*Endpoint` | URLs of the Altinn platform dependencies (Register, Access Management, Profile, …). |
+| `kvSetting` / Key Vault | Source of the JWT **signing certificates**. |
+
+> ⚠️ The base `appsettings.json` currently pins concrete AT22-test endpoints and contains placeholder secrets (`CertificatePwd`, an Azurite key, DB passwords). Moving secrets out of source and making base config environment-neutral are tracked in [issue #2074](https://github.com/Altinn/altinn-authentication/issues/2074).
+
+## Feature flags
+
+Uses `Microsoft.FeatureManagement`; flags are defined in `src/Authentication/Configuration/FeatureFlags.cs`.
+
+| Flag | Effect |
+| --- | --- |
+| `AuditLog` | When on, authentication events are written to the audit queue. **Note: off by default in base/prod config** — confirm this is intended. |
+| `SystemUser` | Gates the system-user controller. Effectively always on. |
+
+The SBL-decommission flags (`EnterpriseUserAuthenticationDisabled`, `CookieTicketDecryptionDisabled`, `RegisterSelfIdentifiedUserProvisioning`, `LocalSelfIdentifiedCredentialValidation`, `IdPortenUserLookupFromRegister`, `Altinn2LogoutRedirectDisabled`) have all been **removed** — the Altinn-3 behaviour is now permanent (see [ADR-0004](adr/0004-sbl-bridge-altinn2-decommission.md)).
+
+## Secrets & certificates
+
+- **JWT signing certs** come from Azure Key Vault. The newest certificate that has been valid for at least the configured *rollover delay* is used to sign, so new certs propagate to verifiers (via JWKS) before they sign. Public keys are published at `GET /openid/.well-known/openid-configuration/jwks`.
+- **Pepper** (`OidcRefreshTokenPepper`) and DB credentials must come from secret stores, not committed config.
+
+## Health & observability
+
+- **Health:** `GET /health` — currently **liveness only** (always returns healthy). Readiness/dependency checks (PostgreSQL, Key Vault, the audit queue, upstream well-known endpoints) are a known gap; see [issue #2074](https://github.com/Altinn/altinn-authentication/issues/2074).
+- **Telemetry:** OpenTelemetry tracing + metrics across all assemblies, exported to Application Insights (`Azure.Monitor.OpenTelemetry.AspNetCore`).
+- **Logging:** structured logging configured per category under `Logging:LogLevel`.
+- **Audit:** authentication events → Azure Storage Queue via `EventLogService` (gated by `AuditLog`).
+
+## Runbook — common situations
+
+| Symptom | Likely cause / where to look |
+| --- | --- |
+| Users get `401` on `exchange/id-porten` despite valid login | Could be a **Register outage** mis-mapped to `401` (see [#2072](https://github.com/Altinn/altinn-authentication/issues/2072)). Check Register health and the logs around `PartiesClient`. |
+| Token-exchange failures after a deploy | Check whether the upstream **issuer/JWKS** config changed, and whether the **signing certificate** rolled (a too-fresh or expired cert breaks verification). |
+| Notifications/emails (SI link) going to the wrong environment | Per-environment `PlatformSettings__ApiNotificationsEndpoint` override missing (base default is AT22). |
+| Audit events missing | `AuditLog` flag off, or the (currently fire-and-forget) audit write was dropped under load — see [#2074](https://github.com/Altinn/altinn-authentication/issues/2074). |
+| `scan` CI job red on every PR | Known: the archived `Azure/container-scan` action flags base-image CVEs. Not a regression — see [#2074](https://github.com/Altinn/altinn-authentication/issues/2074). |
+
+## CI/CD
+
+GitHub Actions: **Build and Test** (Docker-backed integration tests), **Analyze**/**Analyze (csharp)** (CodeQL), **SonarCloud**, **CodeRabbit**, and **scan** (container scan). The Docker-backed *Build and Test* job is the authoritative gate — a green local `dotnet build` is **not** sufficient (see [development.md](development.md)).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -12,7 +12,7 @@ Notable settings:
 | --- | --- |
 | `GeneralSettings:OidcRefreshTokenPepper` | **Secret.** Server-side pepper for hashing session handles / refresh tokens. Required; supply via Key Vault / env. |
 | `GeneralSettings:JwtCookieName`, `SblAuthCookieName`, `AltinnSessionCookieName`, … | Cookie names (see [flows/sessions-and-cookies.md](flows/sessions-and-cookies.md)). |
-| `GeneralSettings:EnableOidc`, `ForceOidc`, `AuthorizationServerEnabled` | All **true** in every environment; the authorization-server flow is the only live path (see [ADR-0002](adr/0002-authorization-server-is-the-live-auth-path.md)). |
+| `GeneralSettings:ForceOidc`, `AuthorizationServerEnabled` | The legacy browser-sign-in branches were collapsed (see [ADR-0002](adr/0002-authorization-server-is-the-live-auth-path.md)); `AuthenticateUser` no longer reads these. `ForceOidc` is still used by `OidcServerService`; `AuthorizationServerEnabled` by `LogoutController` (which still has a legacy branch). `EnableOidc` is now unused (dead-property cleanup candidate). |
 | `GeneralSettings:MaskinportenWellKnownConfigEndpoint`, `IdPortenWellKnownConfigEndpoint` (+ `*Alternative*`) | Upstream discovery endpoints used to fetch signing keys. |
 | `PlatformSettings:Api*Endpoint` | URLs of the Altinn platform dependencies (Register, Access Management, Profile, …). |
 | `kvSetting` / Key Vault | Source of the JWT **signing certificates**. |


### PR DESCRIPTION
Adds a documentation set for **both humans and AI coding agents**, with the conceptual pages as the single source of truth and a thin agent guide pointing into them.

> A few small code patches may be added to this same PR before merge.

## What's included

**Agent + human guidance**
- `AGENTS.md` — concise agent guide: commands, workflow rules, and the **landmines** (prod runs `EnableOidc`/`ForceOidc`/`AuthorizationServerEnabled=true`; the intentional `IsSafeSameOrSubdomainHttps` open-redirect guard + dismissed CodeQL alerts; the misnamed-but-correct `IsValidIssuer`; the deliberately-kept SBL-cookie cleanup; the `PartyUser.userIds` test gotcha).
- `CLAUDE.md` — thin pointer that `@`-imports `AGENTS.md`.
- `README.md` — refreshed (corrected .NET 9 → 10, removed the stale "storage component" copy-paste, added a docs map).

**`docs/`**
- `architecture.md` — context + "two faces" Mermaid diagrams, solution layout, endpoint table, key services.
- `flows/` — `token-exchange.md`, `oidc-authorization-server.md`, `sessions-and-cookies.md` (with sequence/flow diagrams).
- `operations.md` — config, feature flags, secrets/certs, health, runbook.
- `development.md` — setup, the Docker-test reality, testing patterns/gotchas.
- `adr/` — ADR-0001 (record ADRs), 0002 (authorization-server is the only live path), 0003 (Register is canonical), 0004 (Altinn 2 / SBL Bridge decommission), plus a template + contribution rules.

## Why

Most of the cost in recent work was re-deriving *why* — which paths are live vs. dead, what production assumes, what's intentionally kept. The ADRs and flow docs capture exactly that, and the agent guide encodes the conventions/landmines learned the hard way. Diagrams are Mermaid (render on GitHub, diff cleanly).

Cross-links the open follow-ups (#2072, #2074) so they're discoverable from the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new documentation hub for the authentication service, including architecture, development, operations, flows, and ADR guidance.
  * Expanded setup and build instructions, with clearer local run steps, testing requirements, and Swagger endpoint details.
  * Added multiple ADRs and flow documents covering sign-in, token exchange, sessions, cookies, and operational behavior.
  * Updated contributor guidance to better reflect repo conventions and required documentation practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->