### PR TITLE
chore: patch NuGet packages (security + maintenance)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:5c559aa5d99337e400d39ab4fa1f6979d126c29b20939d53658ed38300571e74 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:4f9e72be70a2346fe3ac95bf97374dd51e988eb66fc798dbbe56281607f4d0c0 AS build
 WORKDIR /app
 
 # Copy everything and build
@@ -6,7 +6,7 @@ COPY . .
 RUN dotnet build ./src/Authentication/Altinn.Platform.Authentication.csproj -c Release -o app_output \
     && dotnet publish ./src/Authentication/Altinn.Platform.Authentication.csproj -c Release -r linux-x64 -o app_output --no-self-contained
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine@sha256:1e37a8236c558ae31bd6bc8144e38e6036b73cf1b0616fe56d79e60babb9d93b AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine@sha256:57bd717ac18ff6c8a39cc0ee4a76c1f15adc46df50434c73eff0c3f1df4c88f0 AS final
 EXPOSE 5040 
 WORKDIR /app
 COPY --from=build /app/app_output .

--- a/src/Authentication/Altinn.Platform.Authentication.csproj
+++ b/src/Authentication/Altinn.Platform.Authentication.csproj
@@ -36,6 +36,11 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.7" />
     <PackageReference Include="Npgsql" Version="10.0.3" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
+    <!-- Transitive security pins: override vulnerable versions pulled in by dependencies.
+         OpenTelemetry.* (via Altinn.Authorization.ServiceDefaults): GHSA-q834-8qmm-v933, GHSA-mr8r-92fq-pj8p, GHSA-4625-4j76-fww9, GHSA-g94r-2vxg-569j.
+         Microsoft.Rest.ClientRuntime (via Microsoft.Extensions.Configuration.AzureKeyVault): GHSA-whph-446h-6m9v / CVE-2022-26907. -->
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Authentication/Altinn.Platform.Authentication.csproj
+++ b/src/Authentication/Altinn.Platform.Authentication.csproj
@@ -11,31 +11,31 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Altinn.Authorization.ServiceDefaults" Version="5.2.2" />
-	<PackageReference Include="Altinn.Authorization.ServiceDefaults.Npgsql" Version="5.2.2" />
-    <PackageReference Include="Altinn.Common.AccessToken" Version="5.1.0" />
-    <PackageReference Include="Altinn.Common.PEP" Version="4.2.2" />
+	<PackageReference Include="Altinn.Authorization.ServiceDefaults" Version="5.5.0" />
+	<PackageReference Include="Altinn.Authorization.ServiceDefaults.Npgsql" Version="5.5.0" />
+    <PackageReference Include="Altinn.Common.AccessToken" Version="5.1.9" />
+    <PackageReference Include="Altinn.Common.PEP" Version="4.2.3" />
     <PackageReference Include="Altinn.Register.Contracts" Version="1.7.0" />
     <PackageReference Include="AutoMapper" Version="16.1.1" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.5.3" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.26.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.27.1" />
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.4.2" />
     <PackageReference Include="JWTCookieAuthentication" Version="4.0.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Antiforgery" Version="2.3.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Antiforgery" Version="2.3.11" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.24" />
     <PackageReference Include="Microsoft.FeatureManagement" Version="4.5.0" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.5.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.3" />
     <PackageReference Include="Npgsql" Version="10.0.3" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
     <!-- Transitive security pins: override vulnerable versions pulled in by dependencies.
          OpenTelemetry.* (via Altinn.Authorization.ServiceDefaults): GHSA-q834-8qmm-v933, GHSA-mr8r-92fq-pj8p, GHSA-4625-4j76-fww9, GHSA-g94r-2vxg-569j.
          Microsoft.Rest.ClientRuntime (via Microsoft.Extensions.Configuration.AzureKeyVault): GHSA-whph-446h-6m9v / CVE-2022-26907. -->

--- a/src/Core/Altinn.Platform.Authentication.Core.csproj
+++ b/src/Core/Altinn.Platform.Authentication.Core.csproj
@@ -13,12 +13,12 @@
 	<ItemGroup>
 		<PackageReference Include="Altinn.Authorization.ProblemDetails" Version="4.0.1" />
 		<PackageReference Include="Altinn.Authorization.ServiceDefaults.Telemetry" Version="5.5.0" />
-		<PackageReference Include="Altinn.Common.AccessToken" Version="5.1.0" />
-		<PackageReference Include="Altinn.Common.PEP" Version="4.2.2" />
-		<PackageReference Include="Altinn.Common.AccessTokenClient" Version="3.2.0" />
+		<PackageReference Include="Altinn.Common.AccessToken" Version="5.1.9" />
+		<PackageReference Include="Altinn.Common.PEP" Version="4.2.3" />
+		<PackageReference Include="Altinn.Common.AccessTokenClient" Version="3.2.8" />
 		<PackageReference Include="Altinn.Register.Contracts" Version="1.7.0" />
 		<PackageReference Include="Altinn.Urn" Version="4.3.0" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
 		<PackageReference Include="Npgsql" Version="10.0.3" />
 	</ItemGroup>
 

--- a/src/Integration/Altinn.Platform.Authentication.Integration.csproj
+++ b/src/Integration/Altinn.Platform.Authentication.Integration.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.Register.Contracts" Version="1.7.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Persistance/Altinn.Platform.Authentication.Persistance.csproj
+++ b/src/Persistance/Altinn.Platform.Authentication.Persistance.csproj
@@ -27,6 +27,10 @@
 	  <PackageReference Include="Npgsql" Version="10.0.3" />
 	  <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
 	  <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.8" />
+	  <!-- Transitive security pins (via Altinn.Authorization.ServiceDefaults.Npgsql):
+	       GHSA-q834-8qmm-v933, GHSA-mr8r-92fq-pj8p, GHSA-4625-4j76-fww9, GHSA-g94r-2vxg-569j. -->
+	  <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+	  <PackageReference Include="OpenTelemetry.Api" Version="1.16.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Persistance/Altinn.Platform.Authentication.Persistance.csproj
+++ b/src/Persistance/Altinn.Platform.Authentication.Persistance.csproj
@@ -19,14 +19,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Altinn.Authorization.ServiceDefaults.Npgsql" Version="5.2.2" />
-	  <PackageReference Include="Altinn.Authorization.ServiceDefaults.Npgsql.Yuniql" Version="5.2.2" />
+	  <PackageReference Include="Altinn.Authorization.ServiceDefaults.Npgsql" Version="5.5.0" />
+	  <PackageReference Include="Altinn.Authorization.ServiceDefaults.Npgsql.Yuniql" Version="5.5.0" />
 	  <PackageReference Include="Altinn.Register.Contracts" Version="1.7.0" />
 	  <PackageReference Include="Azure.Identity" Version="1.21.0" />
-	  <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.8" />
+	  <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.9" />
 	  <PackageReference Include="Npgsql" Version="10.0.3" />
-	  <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
-	  <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.8" />
+	  <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
+	  <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.9" />
 	  <!-- Transitive security pins (via Altinn.Authorization.ServiceDefaults.Npgsql):
 	       GHSA-q834-8qmm-v933, GHSA-mr8r-92fq-pj8p, GHSA-4625-4j76-fww9, GHSA-g94r-2vxg-569j. -->
 	  <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />

--- a/src/jwtcookie/Authentication/Altinn.Common.Authentication.csproj
+++ b/src/jwtcookie/Authentication/Altinn.Common.Authentication.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Altinn.Platform.Authentication.SystemIntegrationTests.csproj
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Altinn.Platform.Authentication.SystemIntegrationTests.csproj
@@ -10,13 +10,13 @@
     <ItemGroup>
       <PackageReference Include="Altinn.Register.Contracts" Version="1.7.0" />
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-      <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+      <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
       <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
+      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
       <PackageReference Include="xunit" Version="2.9.3" />
     </ItemGroup>
 

--- a/test/Altinn.Platform.Authentication.Tests/Altinn.Platform.Authentication.Tests.csproj
+++ b/test/Altinn.Platform.Authentication.Tests/Altinn.Platform.Authentication.Tests.csproj
@@ -9,11 +9,11 @@
     <PackageReference Include="Altinn.Authorization.ABAC" Version="0.1.1" />
     <PackageReference Include="Altinn.Platform.Storage.Interface" Version="4.7.1" />
     <PackageReference Include="Altinn.Register.Contracts" Version="1.7.0" />
-	  <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
+	  <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageReference Include="Testcontainers" Version="4.12.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.12.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/ChangeRequestControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/ChangeRequestControllerTest.cs
@@ -6,7 +6,9 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Security.Claims;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Altinn.AccessManagement.Tests.Mocks;
 using Altinn.Authentication.Core.Clients.Interfaces;
@@ -105,6 +107,17 @@ public class ChangeRequestControllerTest(
         services.AddSingleton(guidService.Object);
         services.AddSingleton<IUserProfileService>(_userProfileService.Object);
         services.AddSingleton(_pdpMock.Object);
+
+        // Altinn.Common.PEP 4.2.3 added CancellationToken overloads to IPDP, and the PEP
+        // authorization handler now invokes the token overload. The individual tests only
+        // configure the non-token overloads, so forward the token overloads to them.
+        _pdpMock
+            .Setup(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>()))
+            .Returns((XacmlJsonRequestRoot request, CancellationToken _) => _pdpMock.Object.GetDecisionForRequest(request));
+        _pdpMock
+            .Setup(p => p.GetDecisionForUnvalidateRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<ClaimsPrincipal>(), It.IsAny<CancellationToken>()))
+            .Returns((XacmlJsonRequestRoot request, ClaimsPrincipal user, CancellationToken _) => _pdpMock.Object.GetDecisionForUnvalidateRequest(request, user));
+
         services.AddSingleton<IPartiesClient, PartiesClientMock>();
         services.AddSingleton<ISystemUserService, SystemUserService>();
         services.AddSingleton<ISystemRegisterService, SystemRegisterService>();

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/ChangeRequestControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/ChangeRequestControllerTest.cs
@@ -6,7 +6,6 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using System.Security.Claims;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -108,15 +107,12 @@ public class ChangeRequestControllerTest(
         services.AddSingleton<IUserProfileService>(_userProfileService.Object);
         services.AddSingleton(_pdpMock.Object);
 
-        // Altinn.Common.PEP 4.2.3 added CancellationToken overloads to IPDP, and the PEP
-        // authorization handler now invokes the token overload. The individual tests only
-        // configure the non-token overloads, so forward the token overloads to them.
+        // Altinn.Common.PEP 4.2.3 added a CancellationToken overload to IPDP, and the PEP
+        // authorization handler now invokes it. The individual tests only configure the
+        // non-token GetDecisionForRequest, so forward the token overload to it.
         _pdpMock
             .Setup(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>()))
             .Returns((XacmlJsonRequestRoot request, CancellationToken _) => _pdpMock.Object.GetDecisionForRequest(request));
-        _pdpMock
-            .Setup(p => p.GetDecisionForUnvalidateRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<ClaimsPrincipal>(), It.IsAny<CancellationToken>()))
-            .Returns((XacmlJsonRequestRoot request, ClaimsPrincipal user, CancellationToken _) => _pdpMock.Object.GetDecisionForUnvalidateRequest(request, user));
 
         services.AddSingleton<IPartiesClient, PartiesClientMock>();
         services.AddSingleton<ISystemUserService, SystemUserService>();

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/PDPPermitMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/PDPPermitMock.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
 using Altinn.Common.PEP.Interfaces;
@@ -54,9 +55,21 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
         }
 
         /// <inheritdoc/>
+        public Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest, CancellationToken cancellationToken)
+        {
+            return GetDecisionForRequest(xacmlJsonRequest);
+        }
+
+        /// <inheritdoc/>
         public Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user)
         {
             return Task.FromResult(true);
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user, CancellationToken cancellationToken)
+        {
+            return GetDecisionForUnvalidateRequest(xacmlJsonRequest, user);
         }
     }
 }

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/PepWithPDPAuthorizationMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/PepWithPDPAuthorizationMock.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Altinn.AccessManagement.Core.Constants;
@@ -52,6 +53,12 @@ namespace Altinn.AccessManagement.Tests.Mocks
             }
 
             return await Authorize(xacmlJsonRequest.Request);
+        }
+
+        /// <inheritdoc />
+        public Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest, CancellationToken cancellationToken)
+        {
+            return GetDecisionForRequest(xacmlJsonRequest);
         }
 
         private async Task<XacmlJsonResponse> Authorize(XacmlJsonRequest decisionRequest)
@@ -141,6 +148,12 @@ namespace Altinn.AccessManagement.Tests.Mocks
         {
             XacmlJsonResponse response = await GetDecisionForRequest(xacmlJsonRequest);
             return DecisionHelper.ValidatePdpDecision(response.Response, user);
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user, CancellationToken cancellationToken)
+        {
+            return GetDecisionForUnvalidateRequest(xacmlJsonRequest, user);
         }
 
         private async Task<XacmlContextRequest> Enrich(XacmlContextRequest request)


### PR DESCRIPTION
## Summary

Patches NuGet packages: security fixes for vulnerable transitive dependencies plus same-major maintenance updates across the solution.

## Security fixes (transitive pins)

Moderate-severity vulnerabilities surfaced by `dotnet list package --vulnerable --include-transitive`, resolved by pinning patched versions as direct `PackageReference`s:

| Package | Was | Now | Advisories |
|---|---|---|---|
| OpenTelemetry.Exporter.OpenTelemetryProtocol | 1.15.0 | 1.16.0 | GHSA-q834-8qmm-v933, GHSA-mr8r-92fq-pj8p, GHSA-4625-4j76-fww9 |
| OpenTelemetry.Api | 1.15.0 | 1.16.0 | GHSA-g94r-2vxg-569j |
| Microsoft.Rest.ClientRuntime | 2.3.8 | 2.3.24 | GHSA-whph-446h-6m9v / CVE-2022-26907 |

- OpenTelemetry.* came in via `Altinn.Authorization.ServiceDefaults(.Npgsql)`.
- Microsoft.Rest.ClientRuntime came in via `Microsoft.Extensions.Configuration.AzureKeyVault`.

After the change all 7 projects report **no vulnerable packages**.

## Maintenance updates (same-major, non-breaking)

| Package | Was | Now |
|---|---|---|
| Altinn.Authorization.ServiceDefaults(.Npgsql/.Yuniql) | 5.2.2 | 5.5.0 |
| Altinn.Common.AccessToken | 5.1.0 | 5.1.9 |
| Altinn.Common.AccessTokenClient | 3.2.0 | 3.2.8 |
| Altinn.Common.PEP | 4.2.2 | 4.2.3 |
| System.IdentityModel.Tokens.Jwt / Microsoft.IdentityModel.* | 8.18.0 | 8.19.1 |
| Azure.Storage.Queues | 12.26.0 | 12.27.1 |
| Microsoft.AspNetCore.Antiforgery | 2.3.10 | 2.3.11 |
| Swashbuckle.AspNetCore(.Annotations) | 10.1.7 | 10.2.3 |
| Microsoft.Extensions.FileProviders.Embedded | 10.0.8 | 10.0.9 |
| System.Linq.AsyncEnumerable | 10.0.8 | 10.0.9 |
| Microsoft.Extensions.TimeProvider.Testing | 10.6.0 | 10.7.0 |
| Microsoft.AspNetCore.Mvc.Testing | 10.0.8 | 10.0.9 |
| Microsoft.NET.Test.Sdk | 18.6.0 | 18.7.0 |

**Note:** PEP 4.2.3 expanded the `IPDP` interface with `CancellationToken` overloads. Production code is unaffected (the non-token overloads remain), but the two test mocks (`PDPPermitMock`, `PepWithPDPAuthorizationMock`) implement `IPDP` directly and were updated to add the new overloads, delegating to the existing implementations.

## Verification

- `dotnet restore` — no NU1902/NU1903 warnings
- `dotnet list package --vulnerable --include-transitive` — clean across all 7 projects
- `dotnet build -c Release` — **succeeds, 0 errors** (only pre-existing StyleCop/deprecation warnings)

## Held back / follow-ups (not in this PR)

- **Major bumps**, likely breaking — left for a dedicated PR:
  - `Altinn.Authorization.ProblemDetails` 4.0.1 -> 5.4.0
  - `Microsoft.ApplicationInsights.AspNetCore` 2.23.0 -> 3.1.2
- **Deprecated packages** (code migration, not a version bump):
  - `Microsoft.Extensions.Configuration.AzureKeyVault` (3.1.24) and `Microsoft.Azure.Services.AppAuthentication` (1.6.2) — source of the legacy `Microsoft.Rest.ClientRuntime` chain. Migrating to `Azure.Extensions.AspNetCore.Configuration.Secrets` + `Azure.Identity` would remove it entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several dependency versions across the authentication projects and test suites.
  * Included newer security and maintenance releases for token handling, OpenID Connect, Swagger, Azure Storage, and testing packages.
  * Added support for cancellation-aware authorization calls in test mocks, improving compatibility with newer library behavior.
  * Refreshed integration and system test dependencies to stay aligned with the latest package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->