### PR TITLE
ci: fix incompatible download-artifact version in fork coverage job

### DIFF
--- a/.github/workflows/build-and-analyze-fork.yml
+++ b/.github/workflows/build-and-analyze-fork.yml
@@ -42,7 +42,7 @@ jobs:
     needs: test
     steps:
       - name: Download Coverage Results
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: code-coverage-report
           path: dist/

--- a/.github/workflows/build-and-analyze-fork.yml
+++ b/.github/workflows/build-and-analyze-fork.yml
@@ -42,7 +42,7 @@ jobs:
     needs: test
     steps:
       - name: Download Coverage Results
-        uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: code-coverage-report
           path: dist/


### PR DESCRIPTION
## Summary

While auditing the GitHub Actions workflows, found a broken artifact version pairing in the fork coverage workflow.

In [build-and-analyze-fork.yml](.github/workflows/build-and-analyze-fork.yml), the `test` job uploads coverage with `actions/upload-artifact@v7`, but the `code-coverage` job downloaded it with `actions/download-artifact` pinned to commit `2a59741` — which is **v2 from July 2020** (mislabeled `# master`). `upload-artifact` v4+ and `download-artifact` v2 use **incompatible artifact backends**, so the "Report code coverage" job fails whenever it actually runs (fork / dependabot PRs). It also runs on the deprecated Node 12/16 runtime.

Pinned `download-artifact` to **v7** (`37930b1`) to match `upload-artifact@v7`.

## Audit of the other actions (no change needed)

The rest are SHA-pinned to current majors: `checkout@v6`, `setup-dotnet@v5`, `cache@v5`, `setup-java@v5`, `upload-artifact@v7`, `codeql-action@v4`, `azure/login@v3`, `add-to-project@v2`, `setup-k6@v1.2.1`, `CodeCoverageSummary@v1.3.0`.

## Noted but not changed here

- **`Azure/container-scan@v0.1`** ([container-scan.yml](.github/workflows/container-scan.yml)) is a **deprecated/archived** action (last release v0.1, runs on the deprecated Node runtime — source of the "Node 20 deprecated" warning) and powers the perennially-red `scan` job. Replacing it (e.g. with `aquasecurity/trivy-action` directly) is a larger change to the scanning approach and is left for a separate decision.
- A couple of pins use misleading `# main` / `# master` comments while pinning a specific SHA (cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the coverage download step in the fork build-and-analyze workflow to use a pinned, maintained release of the artifact download action.
  * This helps make automated coverage processing more reliable and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->