### PR TITLE
chore: remove EnableOidc/ForceOidc rollout flags (#2030)

### DIFF
--- a/src/Authentication/Configuration/GeneralSettings.cs
+++ b/src/Authentication/Configuration/GeneralSettings.cs
@@ -158,19 +158,9 @@ namespace Altinn.Platform.Authentication.Configuration
         }
 
         /// <summary>
-        /// Get or sets the value indicating if OIDC authentication is enabled
-        /// </summary>
-        public bool EnableOidc { get; set; }
-
-        /// <summary>
         /// Get or sets the default oidc provider
         /// </summary>
         public string DefaultOidcProvider { get; set; }
-
-        /// <summary>
-        /// Defines if OIDC is the default authentication
-        /// </summary>
-        public bool ForceOidc { get; set; }
 
         /// <summary>
         /// Scopes set when there is no client id (Altinn Apps) or source is Altinn 2

--- a/src/Authentication/Services/OidcServerService.cs
+++ b/src/Authentication/Services/OidcServerService.cs
@@ -390,12 +390,6 @@ namespace Altinn.Platform.Authentication.Services
         {
             Claim? sidClaim = principal.Claims.FirstOrDefault(c => c.Type == "sid");
             Claim? scopeClaim = principal.Claims.FirstOrDefault(c => c.Type == "scope");
-            
-            // Disable code that forces presence of sid claim. Enable when all users have new token
-            //if (sidClaim == null && _generalSettings.ForceOidc)
-            //{
-            //    throw new InvalidOperationException("No sid claim present in principal");
-            //}
 
             if (sidClaim == null)
             {
@@ -414,7 +408,7 @@ namespace Altinn.Platform.Authentication.Services
 
             await _oidcSessionRepo.SlideExpiryToAsync(sidClaim.Value, _timeProvider.GetUtcNow().AddMinutes(_generalSettings.JwtValidityMinutes), cancellationToken);
             var session = await _oidcSessionRepo.GetBySidAsync(sidClaim.Value, cancellationToken);
-            if (session is null && _generalSettings.ForceOidc)
+            if (session is null)
             {
                 throw new InvalidOperationException("No valid session found for sid");
             }

--- a/src/Authentication/appsettings.Development.json
+++ b/src/Authentication/appsettings.Development.json
@@ -16,8 +16,6 @@
     "OpenIdWellKnownEndpoint": "https://platform.at22.altinn.cloud/authentication/api/v1/openid/",
     "OrganisationRepositoryLocation": "https://altinncdn.no/orgs/altinn-orgs.json",
     "JwtSigningCertificateRolloverDelayHours": 48,
-    "EnableOidc": false,
-    "ForceOidc": false,
     "DefaultOidcProvider": "altinn"
   },
   "PlatformSettings": {

--- a/src/Authentication/appsettings.json
+++ b/src/Authentication/appsettings.json
@@ -27,8 +27,6 @@
     "OpenIdWellKnownEndpoint": "https://platform.at22.altinn.cloud/authentication/api/v1/openid/",
     "OrganisationRepositoryLocation": "https://altinncdn.no/orgs/altinn-orgs.json",
     "JwtSigningCertificateRolloverDelayHours": 48,
-    "EnableOidc": false,
-    "ForceOidc": false,
     "DefaultOidcProvider": "idporten",
     "PartnerScopes": "skatteetaten:formueinntekt/skattemelding;skatteetaten:mvameldinginnsending;skatteetaten:mvameldingvalidering",
     "ProfileAPIEndpoint": "lo"

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerIdPortenRegisterTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerIdPortenRegisterTests.cs
@@ -59,8 +59,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 .AddInMemoryCollection(
                     new Dictionary<string, string>
                     {
-                        { "GeneralSettings:EnableOidc", "false" },
-                        { "GeneralSettings:ForceOidc", "false" },
                         { "GeneralSettings:DefaultOidcProvider", "altinn" }
                     })
                 .Build();

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerTests.cs
@@ -78,8 +78,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
               .AddInMemoryCollection(
                 new Dictionary<string, string>
                 {
-                    { "GeneralSettings:EnableOidc", "false" },
-                    { "GeneralSettings:ForceOidc", "false" },
                     { "GeneralSettings:DefaultOidcProvider", "altinn" }
                 })
               .Build();

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/ChangeRequestControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/ChangeRequestControllerTest.cs
@@ -68,8 +68,6 @@ public class ChangeRequestControllerTest(
     protected override void ConfigureServices(IServiceCollection services)
     {
         base.ConfigureServices(services);
-        bool enableOidc = false;
-        bool forceOidc = false;
         string defaultOidc = "altinn";
 
         string configPath = GetConfigPath();
@@ -85,8 +83,6 @@ public class ChangeRequestControllerTest(
           .AddJsonFile(configPath)
           .Build();
 
-        configuration.GetSection("GeneralSettings:EnableOidc").Value = enableOidc.ToString();
-        configuration.GetSection("GeneralSettings:ForceOidc").Value = forceOidc.ToString();
         configuration.GetSection("GeneralSettings:DefaultOidcProvider").Value = defaultOidc;
 
         IConfigurationSection generalSettingSection = configuration.GetSection("GeneralSettings");

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
@@ -62,8 +62,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
              .AddInMemoryCollection(
                new Dictionary<string, string>
                {
-                    { "GeneralSettings:EnableOidc", "false" },
-                    { "GeneralSettings:ForceOidc", "false" },
                     { "GeneralSettings:DefaultOidcProvider", "altinn" },
                     { "FeatureManagement:EnableAuditLog", "false" }
                })

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEndForceOidc_OidcFrontChannelControllerTest.cs
@@ -97,12 +97,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             services.AddSingleton<IUserProfileService>(_userProfileService.Object);
             services.AddSingleton<IRegisterUserProvisioningClient>(_registerUserProvisioningClient.Object);
             services.AddSingleton<IOidcDownstreamLogout>(_downstreamLogoutClient.Object);
-
-            services.PostConfigure<GeneralSettings>(o =>
-            {
-                o.ForceOidc = true;   // “true” group
-                o.EnableOidc = true;  // must be true for ForceOidc to have effect
-            });
         }
 
         /// <summary>

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEnd_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEnd_OidcFrontChannelControllerTest.cs
@@ -93,12 +93,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             services.AddSingleton<IUserProfileService>(_userProfileService.Object);
             services.AddSingleton(_eventQueue.Object);
             services.AddSingleton<IOidcDownstreamLogout>(_downstreamLogoutClient.Object);
-
-            services.PostConfigure<GeneralSettings>(o =>
-            {
-                o.ForceOidc = false;   // “true” group
-                o.EnableOidc = true;  // must be true for ForceOidc to have effect
-            });
         }
 
         /// <summary>

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/RequestControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/RequestControllerTests.cs
@@ -68,8 +68,6 @@ public class RequestControllerTests(
     protected override void ConfigureServices(IServiceCollection services)
     {
         base.ConfigureServices(services);
-        bool enableOidc = false;
-        bool forceOidc = false;
         string defaultOidc = "altinn";
 
         string configPath = GetConfigPath();
@@ -85,8 +83,6 @@ public class RequestControllerTests(
           .AddJsonFile(configPath)
           .Build();
 
-        configuration.GetSection("GeneralSettings:EnableOidc").Value = enableOidc.ToString();
-        configuration.GetSection("GeneralSettings:ForceOidc").Value = forceOidc.ToString();
         configuration.GetSection("GeneralSettings:DefaultOidcProvider").Value = defaultOidc;
 
         IConfigurationSection generalSettingSection = configuration.GetSection("GeneralSettings");

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemRegisterControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemRegisterControllerTests.cs
@@ -73,8 +73,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         protected override void ConfigureServices(IServiceCollection services)
         {
             base.ConfigureServices(services);
-            bool enableOidc = false;
-            bool forceOidc = false;
             string defaultOidc = "altinn";
 
             string configPath = GetConfigPath();
@@ -87,8 +85,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 .AddJsonFile(configPath)
                 .Build();
 
-            configuration.GetSection("GeneralSettings:EnableOidc").Value = enableOidc.ToString();
-            configuration.GetSection("GeneralSettings:ForceOidc").Value = forceOidc.ToString();
             configuration.GetSection("GeneralSettings:DefaultOidcProvider").Value = defaultOidc;
 
             IConfigurationSection generalSettingSection = configuration.GetSection("GeneralSettings");

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserClientDelegationControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserClientDelegationControllerTest.cs
@@ -78,8 +78,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             var configuration = new ConfigurationBuilder()
               .AddJsonFile(configPath)
               .Build();
-            configuration.GetSection("GeneralSettings:EnableOidc").Value = "false";
-            configuration.GetSection("GeneralSettings:ForceOidc").Value = "false";
             configuration.GetSection("GeneralSettings:DefaultOidcProvider").Value = "altinn";
 
             IConfigurationSection generalSettingSection = configuration.GetSection("GeneralSettings");

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserControllerTest.cs
@@ -65,8 +65,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         protected override void ConfigureServices(IServiceCollection services)
         {
             base.ConfigureServices(services);
-            bool enableOidc = false;
-            bool forceOidc = false;
             string defaultOidc = "altinn";
 
             string configPath = GetConfigPath();
@@ -75,8 +73,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
               .AddJsonFile(configPath)
               .Build();
 
-            configuration.GetSection("GeneralSettings:EnableOidc").Value = enableOidc.ToString();
-            configuration.GetSection("GeneralSettings:ForceOidc").Value = forceOidc.ToString();
             configuration.GetSection("GeneralSettings:DefaultOidcProvider").Value = defaultOidc;
 
             IConfigurationSection generalSettingSection = configuration.GetSection("GeneralSettings");

--- a/test/Altinn.Platform.Authentication.Tests/appsettings.test.json
+++ b/test/Altinn.Platform.Authentication.Tests/appsettings.test.json
@@ -12,8 +12,6 @@
     "MaskinportenWellKnownConfigEndpoint": "https://ver2.maskinporten.no/.well-known/oauth-authorization-server",
     "OpenIdWellKnownEndpoint": "http://localhost:5040/authentication/api/v1/openid",
     "OrganisationRepositoryLocation": "https://altinncdn.no/orgs/altinn-orgs.json",
-    "EnableOidc": false,
-    "ForceOidc": false,
     "DefaultOidcProvider": "altinn",
     "PartnerScopes": "skatteetaten:formueinntekt/skattemelding;skatteetaten:mvameldinginnsending;skatteetaten:mvameldingvalidering",
     "OidcRefreshTokenPepper": "YWRzZmFzZmRhc2ZzYWVmZWY="


### PR DESCRIPTION
> **Stacked on #2098** (base branch `chore/2030-remove-legacy-sbl-logout-cookies`). Review/merge #2098 first; this diff is only the `EnableOidc`/`ForceOidc` removal on top.

## What & why

`EnableOidc` and `ForceOidc` are always `true` in every environment — the OIDC authorization-server rollout is complete — so both are dead config. Part of the #2030 Altinn 2 / authorization-server finalization.

## Changes

**`EnableOidc` — fully dead**
- Never read anywhere in production code. Removed the `GeneralSettings` property and all config entries (app / Development / test).

**`ForceOidc` — one live use, now unconditional**
- The only live use was in [`OidcServerService.HandleSessionRefresh`](src/Authentication/Services/OidcServerService.cs): `if (session is null && _generalSettings.ForceOidc) throw`. With `ForceOidc` always true this becomes `if (session is null) throw` — a sid with no backing session is always an error (the intended post-migration invariant).
- Also removed the long-dead commented-out "force presence of sid claim" block above it.
- Removed the flag from `GeneralSettings` + appsettings.

**Test plumbing**
- Removed the two now-empty `PostConfigure<GeneralSettings>` overrides in the end-to-end OIDC tests and the dead `enableOidc`/`forceOidc` locals + config setters across the controller integration tests.

## Behavioral note

`HandleSessionRefresh` now throws unconditionally on *sid-without-session*:
- The **/authenticate** caller already wraps it in `try/catch` (clears cookies + re-authenticates) — unchanged outcome.
- The **token-refresh** caller surfaces it as an error — the intended invariant now that all tokens carry a valid session.

No test exercised the sid-without-session path with the flag off, so no assertions changed.

## Verification
- Both projects build with 0 errors.
- Ran all affected suites (auth/OIDC/session/logout + the reworked controller integration tests): **all green, 0 failures** (~470 tests across runs).

## Minor follow-up (not done here)
The two end-to-end classes `EndToEndForceOidc_OidcFrontChannelControllerTest` and `EndToEnd_OidcFrontChannelControllerTest` are now functionally identical (the ForceOidc distinction is gone) — candidates for consolidation, left as-is to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
