### PR TITLE
chore(persistance): clear warnings + enable WarnAsError (#488)

### DIFF
--- a/src/Persistance/Altinn.Platform.Authentication.Persistance.csproj
+++ b/src/Persistance/Altinn.Platform.Authentication.Persistance.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
 	</PropertyGroup>
@@ -43,7 +44,8 @@
 
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<NoWarn>$(NoWarn);1591</NoWarn>
+		<!-- NU1510: "PackageReference will not be pruned" — silenced per team guidance rather than removing the reference. -->
+		<NoWarn>$(NoWarn);1591;NU1510</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Persistance/RepositoryImplementations/OidcServer/LoginTransactionRepository.cs
+++ b/src/Persistance/RepositoryImplementations/OidcServer/LoginTransactionRepository.cs
@@ -265,7 +265,7 @@ namespace Altinn.Platform.Authentication.Persistance.RepositoryImplementations.O
             values is string[] arr ? arr
             : values.Select(s => s?.Trim())
                     .Where(s => !string.IsNullOrWhiteSpace(s))
-                    .Select(s => s!)                // safe after filter
+                    .Select(s => s!) // safe after filter
                     .ToArray();
 
         private static string[]? ToStringArrayOrNull(IReadOnlyCollection<string>? values) =>

--- a/src/Persistance/RepositoryImplementations/RequestRepository.cs
+++ b/src/Persistance/RepositoryImplementations/RequestRepository.cs
@@ -851,5 +851,4 @@ public class RequestRepository : IRequestRepository
 
         return new ValueTask<bool>(true);
     }
-    
 }

--- a/src/Persistance/RepositoryImplementations/SystemChangeLogRepository.cs
+++ b/src/Persistance/RepositoryImplementations/SystemChangeLogRepository.cs
@@ -59,7 +59,7 @@ public class SystemChangeLogRepository : ISystemChangeLogRepository
                 Value = JsonSerializer.Serialize(systemChangeLog.ChangedData)
             });
             command.Parameters.AddWithValue("client_id", (object?)systemChangeLog.ClientId ?? DBNull.Value);
-            command.Parameters.AddWithValue("created", NpgsqlTypes.NpgsqlDbType.TimestampTz, systemChangeLog.Created.Value.ToOffset(TimeSpan.Zero));
+            command.Parameters.AddWithValue("created", NpgsqlTypes.NpgsqlDbType.TimestampTz, (systemChangeLog.Created ?? throw new InvalidOperationException("SystemChangeLog.Created must be set before logging a change.")).ToOffset(TimeSpan.Zero));
             await command.ExecuteNonQueryAsync(cancellationToken);
         }
         catch (Exception ex)
@@ -104,7 +104,8 @@ public class SystemChangeLogRepository : ISystemChangeLogRepository
                         ? null
                         : reader.GetString(reader.GetOrdinal("changedby_orgnumber")),
                     ChangeType = Enum.Parse<SystemChangeType>(enumValue, true),
-                    ChangedData = JsonSerializer.Deserialize<object>(reader.GetString(reader.GetOrdinal("changed_data"))),
+                    // changed_data is a NOT NULL jsonb column holding a serialized payload, so deserialization is non-null.
+                    ChangedData = JsonSerializer.Deserialize<object>(reader.GetString(reader.GetOrdinal("changed_data")))!,
                     ClientId = reader.IsDBNull(reader.GetOrdinal("client_id"))
                         ? null
                         : reader.GetString(reader.GetOrdinal("client_id")),

--- a/src/Persistance/RepositoryImplementations/SystemChangeLogRepository.cs
+++ b/src/Persistance/RepositoryImplementations/SystemChangeLogRepository.cs
@@ -104,8 +104,7 @@ public class SystemChangeLogRepository : ISystemChangeLogRepository
                         ? null
                         : reader.GetString(reader.GetOrdinal("changedby_orgnumber")),
                     ChangeType = Enum.Parse<SystemChangeType>(enumValue, true),
-                    // changed_data is a NOT NULL jsonb column holding a serialized payload, so deserialization is non-null.
-                    ChangedData = JsonSerializer.Deserialize<object>(reader.GetString(reader.GetOrdinal("changed_data")))!,
+                    ChangedData = JsonSerializer.Deserialize<object>(reader.GetString(reader.GetOrdinal("changed_data")))!, // changed_data is a NOT NULL jsonb column; deserialization is non-null.
                     ClientId = reader.IsDBNull(reader.GetOrdinal("client_id"))
                         ? null
                         : reader.GetString(reader.GetOrdinal("client_id")),

--- a/src/Persistance/RepositoryImplementations/SystemRegisterRepository.cs
+++ b/src/Persistance/RepositoryImplementations/SystemRegisterRepository.cs
@@ -31,6 +31,7 @@ internal class SystemRegisterRepository : ISystemRegisterRepository
     /// <param name="dataSource">Needs connection to a Postgres db</param>
     /// <param name="logger">The logger</param>
     /// <param name="systemChangeLogRepository"> The system change log repository</param>
+    /// <param name="timeProvider">The time provider</param>
     public SystemRegisterRepository(NpgsqlDataSource dataSource, ILogger<SystemRegisterRepository> logger, ISystemChangeLogRepository systemChangeLogRepository, TimeProvider timeProvider)
     {
         _datasource = dataSource;


### PR DESCRIPTION
First project on the **#488** warning-cleanup ratchet: bring **Persistance** to **zero warnings** and lock it with `TreatWarningsAsErrors` so it can't regress. This is the **template** for the remaining projects.

## Fixes (3 distinct warnings)

- **CS8629** — `SystemChangeLogRepository` insert: `Created.Value` could be null. Replaced with an explicit `?? throw` so the required-ness is expressed and the write can't silently NRE (behavior-neutral — `.Value` already threw on null).
- **CS8601** — `SystemChangeLogRepository` read: `Deserialize<object>` of the **NOT NULL** `changed_data` jsonb column is non-null → null-forgiving `!` with an explanatory comment.
- **CS1573** — `SystemRegisterRepository`: added the missing `<param name="timeProvider">` XML doc.

## Enforcement

- `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` on the project.
- **NU1510** (which WarnAsError surfaced for `System.Linq.AsyncEnumerable`) **silenced via `NoWarn`** per team guidance (@Alxandr) — not removed.

## Verification

- Persistance builds under WarnAsError with **0 errors**.
- Full solution builds clean; 87 repo-exercising tests pass (SystemRegister + repository DB tests).

## The pattern this establishes

Fix a project to zero → turn on `TreatWarningsAsErrors` for it → it's ratcheted (can't backslide) while the rest are cleaned. Next: `SystemIntegrationTests` (32), `Integration` (64), then the big buckets (Core, host, Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving and reading change log entries by handling missing timestamps and null JSON data more safely.
  * Added a project-level warning setting so builds fail on compiler warnings, helping catch issues earlier.

* **Documentation**
  * Updated constructor documentation to include a previously missing parameter description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->