### PR TITLE
build: add root Directory.Build.props to silence NU1510 solution-wide (#488)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,15 @@
+<Project>
+
+  <!--
+    Repo-wide MSBuild defaults, imported by every project under the repository root.
+
+    NU1510 ("PackageReference will not be pruned; consider removing it") is silenced
+    solution-wide per team guidance: the flagged references are kept intentionally, and
+    the warning otherwise breaks any project that opts into <TreatWarningsAsErrors>
+    (see #488). Suppress it centrally so each project doesn't have to.
+  -->
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);NU1510</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/src/Persistance/Altinn.Platform.Authentication.Persistance.csproj
+++ b/src/Persistance/Altinn.Platform.Authentication.Persistance.csproj
@@ -44,8 +44,7 @@
 
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<!-- NU1510: "PackageReference will not be pruned" — silenced per team guidance rather than removing the reference. -->
-		<NoWarn>$(NoWarn);1591;NU1510</NoWarn>
+		<NoWarn>$(NoWarn);1591</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Follow-up from the #488 ratchet learnings (Persistance, #2106).

## What & why

`TreatWarningsAsErrors` surfaces **NU1510** ("PackageReference will not be pruned; consider removing it") in any project that opts in — Persistance hit it, and every future ratchet project would too. Per @Alxandr the flagged references are intentional and NU1510 should be **silenced**, so do it **once, repo-wide** rather than per-project.

## Changes

- Add a root **`Directory.Build.props`** with `<NoWarn>$(NoWarn);NU1510</NoWarn>` (imported by every project under the repo root).
- Drop the now-redundant per-project `NU1510` from Persistance's `NoWarn` — it inherits the global suppression.

## Verification

- Full **Debug** solution build (CI-equivalent) is clean: **0 errors, 0 NU1510 warnings**.
- Persistance (which has `TreatWarningsAsErrors`) still builds clean, now relying on the global suppression.

Groundwork for the remaining ratchet projects and the eventual global `TreatWarningsAsErrors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
