### PR TITLE
chore(systemintegrationtests): clear warnings + enable WarnAsError (#488)

### DIFF
--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Altinn.Platform.Authentication.SystemIntegrationTests.csproj
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Altinn.Platform.Authentication.SystemIntegrationTests.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Clients/PlatformAuthenticationClient.cs
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Clients/PlatformAuthenticationClient.cs
@@ -30,8 +30,6 @@ public class PlatformAuthenticationClient
     public AccessManagementClient AccessManagementClient { get; set; }
     public Common Common { get; set; }
 
-    private static string? _cachedToken;
-    private static DateTime _tokenExpiry;
 
     /// <summary>
     /// Base class for running requests
@@ -231,8 +229,9 @@ public class PlatformAuthenticationClient
     /// <param name="user">User read from test config (testusers.at.json)</param>
     /// <param name="scopes">space separated list of scopes</param>
     /// <returns>The Altinn test token as a string</returns>
-    public async Task<string?> GetPersonalAltinnToken(Testuser user, string scopes = "")
+    public async Task<string?> GetPersonalAltinnToken(Testuser? user, string scopes = "")
     {
+        ArgumentNullException.ThrowIfNull(user);
         var url =
             $"https://altinn-testtools-token-generator.azurewebsites.net/api/GetPersonalToken" +
             $"?env={EnvironmentHelper.Testenvironment}" +

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Clients/PlatformAuthenticationClient.cs
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Clients/PlatformAuthenticationClient.cs
@@ -229,7 +229,7 @@ public class PlatformAuthenticationClient
     /// <param name="user">User read from test config (testusers.at.json)</param>
     /// <param name="scopes">space separated list of scopes</param>
     /// <returns>The Altinn test token as a string</returns>
-    public async Task<string?> GetPersonalAltinnToken(Testuser? user, string scopes = "")
+    public async Task<string?> GetPersonalAltinnToken(Testuser user, string scopes = "")
     {
         ArgumentNullException.ThrowIfNull(user);
         var url =
@@ -334,7 +334,7 @@ public class PlatformAuthenticationClient
         return token;
     }
 
-    public async Task<HttpResponseMessage> DeleteRequest(string? endpoint, Testuser? testperson)
+    public async Task<HttpResponseMessage> DeleteRequest(string? endpoint, Testuser testperson)
     {
         // Get the Altinn token
         var altinnToken = await GetPersonalAltinnToken(testperson);

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Clients/SystemUserClient.cs
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Clients/SystemUserClient.cs
@@ -148,7 +148,7 @@ public class SystemUserClient
         return content;
     }
 
-    public async Task<HttpResponseMessage> ApproveRequest(string? endpoint, Testuser? testperson)
+    public async Task<HttpResponseMessage> ApproveRequest(string? endpoint, Testuser testperson)
     {
         // Get the Altinn token
         var altinnToken = await _platformClient.GetPersonalAltinnToken(testperson);
@@ -176,7 +176,7 @@ public class SystemUserClient
         Assert.Equal(HttpStatusCode.Accepted, putResponse.StatusCode);
     }
 
-    public async Task<ClientsForDelegationResponseDto> GetAvailableClientsForVendor(Testuser? facilitator, string? systemUserId, bool requireNonEmpty = true)
+    public async Task<ClientsForDelegationResponseDto> GetAvailableClientsForVendor(Testuser facilitator, string? systemUserId, bool requireNonEmpty = true)
     {
         var url = Endpoints.VendorGetAvailableClients.Url() + $"?agent={systemUserId}";
 
@@ -199,7 +199,7 @@ public class SystemUserClient
         return clients;
     }
 
-    public async Task<HttpResponseMessage> AddClient(Testuser? facilitator, string? systemUserId, string clientId)
+    public async Task<HttpResponseMessage> AddClient(Testuser facilitator, string? systemUserId, string clientId)
     {
         var urlPost = Endpoints.VendorAddClients.Url().Replace("{clientId}", clientId).Replace("{systemUserId}", systemUserId);
 
@@ -235,7 +235,7 @@ public class SystemUserClient
         return await _platformClient.Delete(urlDelete, token);
     }
 
-    public async Task<ClientsForDelegationResponseDto> GetDelegatedClientsFromVendorSystemUser(Testuser? facilitator, string? systemUserId)
+    public async Task<ClientsForDelegationResponseDto> GetDelegatedClientsFromVendorSystemUser(Testuser facilitator, string? systemUserId)
     {
         var urlGet = Endpoints.VendorGetDelegatedClients.Url().Replace("{systemUserId}", systemUserId);
 

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Domain/SystemRegister/SystemRegisterPostDto.cs
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Domain/SystemRegister/SystemRegisterPostDto.cs
@@ -25,4 +25,9 @@ public class AccessPackageDto
     {
         return obj is AccessPackageDto other && Urn == other.Urn;
     }
+
+    public override int GetHashCode()
+    {
+        return Urn?.GetHashCode() ?? 0;
+    }
 }

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Domain/SystemUserAgentDto.cs
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Domain/SystemUserAgentDto.cs
@@ -21,5 +21,5 @@ public class SystemUserAgentDto
 
 public class AccessPackage
 {
-    public string Urn { get; set; }
+    public string Urn { get; set; } = string.Empty;
 }

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Domain/SystemUserAgentDto.cs
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Domain/SystemUserAgentDto.cs
@@ -21,5 +21,5 @@ public class SystemUserAgentDto
 
 public class AccessPackage
 {
-    public string Urn { get; set; } = string.Empty;
+    public string? Urn { get; set; }
 }

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Tests/ClientDelegation/ClientDelegationVendorTests.cs
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Tests/ClientDelegation/ClientDelegationVendorTests.cs
@@ -67,7 +67,7 @@ public class ClientDelegationVendorTests : IClassFixture<ClientDelegationFixture
         Assert.Equal(expectedDecision, decision);
 
         //Remove clients so system user can be deleted later
-        await _fixture.Platform.SystemUserClient.DeleteAllClientsFromVendorSystemUser(_fixture.Facilitator, systemUser.Id, delegatedClients.Data);
+        await _fixture.Platform.SystemUserClient.DeleteAllClientsFromVendorSystemUser(_fixture.Facilitator, systemUser.Id, delegatedClients.Data ?? []);
     }
 
     [Fact]

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Tests/SystemUserTests.cs
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Tests/SystemUserTests.cs
@@ -41,10 +41,11 @@ public class SystemUserTests : IDisposable
     public async Task GetCreatedSystemUser()
     {
         var dagl = _platformClient.FindTestUserByRole("DAGL");
+        Assert.NotNull(dagl);
 
         var altinnToken = await _platformClient.GetPersonalAltinnToken(dagl);
 
-        var endpoint = Endpoints.GetSystemUsersByParty.Url().Replace("{party}", dagl!.AltinnPartyId);
+        var endpoint = Endpoints.GetSystemUsersByParty.Url().Replace("{party}", dagl.AltinnPartyId);
 
         var respons = await _platformClient.GetAsync(endpoint, altinnToken);
 
@@ -495,7 +496,7 @@ public class SystemUserTests : IDisposable
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
-    private async Task ApproveSystemUserRequest(Testuser? testuser, string requestId, HttpStatusCode expectedStatusCode = HttpStatusCode.OK)
+    private async Task ApproveSystemUserRequest(Testuser testuser, string requestId, HttpStatusCode expectedStatusCode = HttpStatusCode.OK)
     {
         ArgumentNullException.ThrowIfNull(testuser);
 

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Tests/SystemUserTests.cs
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Tests/SystemUserTests.cs
@@ -44,7 +44,7 @@ public class SystemUserTests : IDisposable
 
         var altinnToken = await _platformClient.GetPersonalAltinnToken(dagl);
 
-        var endpoint = Endpoints.GetSystemUsersByParty.Url().Replace("{party}", dagl.AltinnPartyId);
+        var endpoint = Endpoints.GetSystemUsersByParty.Url().Replace("{party}", dagl!.AltinnPartyId);
 
         var respons = await _platformClient.GetAsync(endpoint, altinnToken);
 
@@ -497,6 +497,8 @@ public class SystemUserTests : IDisposable
 
     private async Task ApproveSystemUserRequest(Testuser? testuser, string requestId, HttpStatusCode expectedStatusCode = HttpStatusCode.OK)
     {
+        ArgumentNullException.ThrowIfNull(testuser);
+
         var approveUrl = Endpoints.ApproveSystemUserRequest.Url()
             .Replace("{party}", testuser.AltinnPartyId)
             .Replace("{requestId}", requestId);

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Utils/ApiEndpoints/Endpoints.cs
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Utils/ApiEndpoints/Endpoints.cs
@@ -213,13 +213,13 @@ public class ApiEndpoint
     {
         if (obj is not ApiEndpoint other) return false;
 
-        return Url.Equals(other.Url, StringComparison.OrdinalIgnoreCase) &&
+        return string.Equals(Url, other.Url, StringComparison.OrdinalIgnoreCase) &&
                Method.Method.Equals(other.Method.Method, StringComparison.OrdinalIgnoreCase);
     }
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(Url.ToLowerInvariant(), Method.Method.ToLowerInvariant());
+        return HashCode.Combine(Url?.ToLowerInvariant(), Method.Method.ToLowerInvariant());
     }
 
     /// <summary>
@@ -227,6 +227,7 @@ public class ApiEndpoint
     /// </summary>
     public static string? NormalizeUrl(string? url)
     {
+        if (string.IsNullOrEmpty(url)) return url;
         if (!url.StartsWith("v1/")) url = "v1/" + url; // ✅ Ensure v1 prefix
         // ✅ Remove trailing slashes for consistency
         url = url.TrimEnd('/');

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Utils/ApiEndpoints/Endpoints.cs
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Utils/ApiEndpoints/Endpoints.cs
@@ -219,7 +219,9 @@ public class ApiEndpoint
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(Url?.ToLowerInvariant(), Method.Method.ToLowerInvariant());
+        int urlHash = Url is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(Url);
+        int methodHash = StringComparer.OrdinalIgnoreCase.GetHashCode(Method.Method);
+        return HashCode.Combine(urlHash, methodHash);
     }
 
     /// <summary>

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Utils/Common.cs
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Utils/Common.cs
@@ -94,6 +94,8 @@ public class Common
 
     public async Task<HttpResponseMessage> ApproveRequest(string? endpoint, Testuser? testperson)
     {
+        ArgumentNullException.ThrowIfNull(testperson);
+
         // Use the PostAsync method for the approval request
         var response = await _platformClient.PostAsync(endpoint, string.Empty, testperson.AltinnToken);
         return response;

--- a/test/Altinn.Platform.Authentication.SystemIntegrationTests/Utils/Common.cs
+++ b/test/Altinn.Platform.Authentication.SystemIntegrationTests/Utils/Common.cs
@@ -92,7 +92,7 @@ public class Common
         return resp.Content;
     }
 
-    public async Task<HttpResponseMessage> ApproveRequest(string? endpoint, Testuser? testperson)
+    public async Task<HttpResponseMessage> ApproveRequest(string? endpoint, Testuser testperson)
     {
         ArgumentNullException.ThrowIfNull(testperson);
 


### PR DESCRIPTION
Ratchets the **SystemIntegrationTests** project to **zero warnings + `TreatWarningsAsErrors`** (#488). Unlike Integration, this is a **clean full lock** — a leaf test project with no interface/contract ripple and no StyleCop violations.

Branched from `main` (independent of the still-in-review #2108).

## Fixes (16 warnings)

- **`GetPersonalAltinnToken`** — nullable param + `ArgumentNullException.ThrowIfNull` guard: clears all 6 `'user'` `CS8604` call sites at once and is semantically correct (the method requires a user).
- **Dead fields** `_cachedToken`/`_tokenExpiry` removed (`CS0169`, confirmed unused, no reflection).
- **`AccessPackageDto`** — add `GetHashCode` to match `Equals` (`CS0659`).
- **`AccessPackage.Urn`** — default to `string.Empty` (`CS8618`).
- **`ClientDelegationVendorTests`** — `delegatedClients.Data ?? []` (`CS8604`).
- **`Common`/`SystemUserTests`** — guard nullable `Testuser` params (`CS8602`).
- **`Endpoints`** — null-safe `string.Equals` / `Url?.ToLowerInvariant()` / `NormalizeUrl` guard.

## Verification

- **Debug** build (CI-equivalent, StyleCop on) passes with `TreatWarningsAsErrors` — **0 errors**.
- Build-only: this project runs against **TT02** (real environment) and its tests are environment-gated/skipped locally; nullable changes are compile-time only, so no runtime impact.

## #488 ratchet progress
Persistance ✅ + SystemIntegrationTests ✅ locked. Integration reduced 60→7 (#2108, lock pending #2109). Remaining: Core (410), host (532), Tests (978).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build checks now treat compiler warnings as errors, tightening quality gates.

* **Bug Fixes**
  * Improved endpoint comparison, hashing, and URL normalization (case-insensitive, null-safe).
  * Aligned access package hashing with existing equality logic.
  * System user agent access package now correctly supports missing `Urn` values.

* **Tests**
  * Updated test helpers and client methods to require non-null user inputs, with clearer early validation.
  * Safer handling of potentially missing delegated client data during cleanup flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->