### PR TITLE
style(tests): fix all StyleCop violations (#488, Tests iteration 1)

### DIFF
--- a/test/Altinn.Platform.Authentication.Tests/AuthenticationHelperTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/AuthenticationHelperTests.cs
@@ -144,7 +144,6 @@ namespace Altinn.Platform.Authentication.Tests
         public void ValidateRedirectUrl_ValidUrlWithoutQuery_ReturnsTrue()
         {
             // Arrange
-
             List<Uri> allowedRedirectUrls = new List<Uri>
                     {
                         new Uri("https://example.com/callback")
@@ -273,7 +272,6 @@ namespace Altinn.Platform.Authentication.Tests
         public void ValidateRedirectUrl_ValidUrlWithFragment_ReturnsTrue()
         {
             // Arrange
-
             List<Uri> allowedRedirectUrls = new List<Uri>
                 {
                     new Uri("https://example.com/callback")

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/ChangeRequestControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/ChangeRequestControllerTest.cs
@@ -1165,7 +1165,7 @@ public class ChangeRequestControllerTest(
         HttpRequestMessage getRequestMessage = new(HttpMethod.Get, getEndpoint);
         HttpResponseMessage getResponseMessage = await client.SendAsync(getRequestMessage);
         ////string errorContent = await getResponseMessage.Content.ReadAsStringAsync();
-        //Console.WriteLine(errorContent);
+        // Console.WriteLine(errorContent);
         SystemUserDetailExternalDTO? systemuser = await getResponseMessage.Content.ReadFromJsonAsync<SystemUserDetailExternalDTO>();
 
         Assert.NotNull(systemuser);
@@ -1561,7 +1561,7 @@ public class ChangeRequestControllerTest(
         return false;
     }
 
-    [Fact (Skip = "deprecated")]
+    [Fact(Skip = "deprecated")]
     public async Task VerifyChangeRequest_AllRightsPermit_ReturnEmptySet()
     {
         List<XacmlJsonResult> xacmlJsonResults = GetDecisionResultSingle();
@@ -1651,7 +1651,7 @@ public class ChangeRequestControllerTest(
         Assert.Empty(verifyResponse.RequiredRights);
     }
 
-    [Fact (Skip = "deprecated")]
+    [Fact(Skip = "deprecated")]
     public async Task VerifyChangeRequest_NotAllRightsPermit_ReturnSet()
     {
         List<XacmlJsonResult> xacmlJsonResults = GetDecisionResultSingle();
@@ -2358,7 +2358,7 @@ public class ChangeRequestControllerTest(
 
     private async Task CreateSeveralChangeRequest(int paginationSize, string systemId)
     {
-        var tasks = Enumerable.Range(0, paginationSize +1)
+        var tasks = Enumerable.Range(0, paginationSize + 1)
                               .Select(i => CreateChangeRequest(i, systemId))
                               .ToList();
 

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
@@ -90,13 +90,13 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         /// Initialises a new instance of the <see cref="OpenIdControllerTests"/> class with the given WebApplicationFactory.
         /// </summary>
         /// <param name="factory">The WebApplicationFactory to use when creating a test server.</param>
-        //public LogoutControllerTests(WebApplicationFactory<LogoutController> factory)
-        //{
+        // public LogoutControllerTests(WebApplicationFactory<LogoutController> factory)
+        // {
         //    _factory = factory;
         //    _userProfileService = new Mock<IUserProfileService>();
         //    _organisationsService = new Mock<IOrganisationsService>();
         //    SetupDateTimeMock();
-        //}
+        // }
 
         /// <summary>
         /// Validates that an unauthenticated user is redirected to BaseUrl (no OIDC provider can be resolved).

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/ErrorScenarios_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/ErrorScenarios_OidcFrontChannelControllerTest.cs
@@ -87,7 +87,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             var url =
                 "/authentication/api/v1/authorize" +
                 "?redirect_uri=https%3A%2F%2Faf.altinn.no%2Fapi%2Fcb" +
-                "&scope=altinn%3Aportal%2Fenduser" +                // missing openid
+                "&scope=altinn%3Aportal%2Fenduser" + // missing openid
                 $"&client_id={testScenario.DownstreamClientId}" +
                 "&response_type=code" +
                 "&state=s123" +

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/RequestControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/RequestControllerTests.cs
@@ -750,7 +750,7 @@ public class RequestControllerTests(
         Assert.NotNull(res);
         Assert.Equal(req.ExternalRef, res.ExternalRef);
 
-        //Get by Guid
+        // Get by Guid
         HttpClient client2 = CreateClient();
         AddSystemUserRequesReadTestTokenToClient(client2);
         Guid testId = res.Id;
@@ -4073,11 +4073,10 @@ public class RequestControllerTests(
         Assert.Equal(req.ExternalRef, res.ExternalRef);
     }
 
-    //private void SetupDateTimeMock()
-    //{
+    // private void SetupDateTimeMock()
+    // {
     //    timeProviderMock.Setup(x => x.GetUtcNow()).Returns(TestTime);
-    //}
-
+    // }
     private void SetupGuidMock()
     {
         guidService.Setup(q => q.NewGuid()).Returns("eaec330c-1e2d-4acb-8975-5f3eba12b2fb");

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemRegisterControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemRegisterControllerTests.cs
@@ -430,7 +430,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 string systemID = "991825827_the_matrix";
                 HttpClient client = CreateClient();
                 string[] prefixes = { "altinn", "digdir" };
-                string token = PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:authentication/systemregister.admin", prefixes  , TestTime);
+                string token = PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:authentication/systemregister.admin", prefixes, TestTime);
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
                 JsonSerializerOptions options = new JsonSerializerOptions()
                 {

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserControllerTest.cs
@@ -1414,7 +1414,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             AccessPackage accessPackage = new()
             {
                 Urn = "urn:altinn:accesspackage:skatt-naering"
-
             };
 
             // Arrange
@@ -1481,7 +1480,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             AccessPackage accessPackage = new()
             {
                 Urn = "urn:altinn:accesspackage:skatt-naering"
-
             };
 
             // Arrange
@@ -1555,7 +1553,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             AccessPackage accessPackage = new()
             {
                 Urn = "urn:altinn:accesspackage:skattnaerin" // Missing g
-
             };
 
             // Arrange
@@ -3241,14 +3238,13 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         // =====================================================================
         // GET /byExternalId — missing required parameters → BadRequest
         // =====================================================================
-
         [Fact]
         public async Task SystemUser_Get_byExternalId_MissingClientId_ReturnsBadRequest()
         {
             HttpClient client = CreateClient();
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:maskinporten/systemuser.read", null, now: TestTime));
 
-            HttpRequestMessage request = new(HttpMethod.Get,"/authentication/api/v1/systemuser/byExternalId?systemProviderOrgNo=991825827&systemUserOwnerOrgNo=910493353");
+            HttpRequestMessage request = new(HttpMethod.Get, "/authentication/api/v1/systemuser/byExternalId?systemProviderOrgNo=991825827&systemUserOwnerOrgNo=910493353");
             HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -3260,7 +3256,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpClient client = CreateClient();
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:maskinporten/systemuser.read", null, now: TestTime));
 
-            HttpRequestMessage request = new(HttpMethod.Get,"/authentication/api/v1/systemuser/byExternalId?clientId=32ef65ac-6e62-498d-880f-76c85c2052ae&systemUserOwnerOrgNo=910493353");
+            HttpRequestMessage request = new(HttpMethod.Get, "/authentication/api/v1/systemuser/byExternalId?clientId=32ef65ac-6e62-498d-880f-76c85c2052ae&systemUserOwnerOrgNo=910493353");
             HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -3272,7 +3268,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpClient client = CreateClient();
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:maskinporten/systemuser.read", null, now: TestTime));
 
-            HttpRequestMessage request = new(HttpMethod.Get,"/authentication/api/v1/systemuser/byExternalId?clientId=32ef65ac-6e62-498d-880f-76c85c2052ae&systemProviderOrgNo=991825827");
+            HttpRequestMessage request = new(HttpMethod.Get, "/authentication/api/v1/systemuser/byExternalId?clientId=32ef65ac-6e62-498d-880f-76c85c2052ae&systemProviderOrgNo=991825827");
             HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -3281,7 +3277,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         // =====================================================================
         // GET /vendor/byquery — Unauthorized and NotFound (wrong vendor)
         // =====================================================================
-
         [Fact]
         public async Task SystemUser_Vendors_Byquery_ReturnsForbidden_WhenNoConsumerClaim()
         {
@@ -3290,7 +3285,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Regular user token has no "consumer" claim → RetrieveOrgNoFromToken returns null
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1337, null, 3, now: TestTime));
 
-            HttpRequestMessage request = new(HttpMethod.Get,"/authentication/api/v1/systemuser/vendor/byquery?system-id=991825827_the_matrix&orgno=910493353");
+            HttpRequestMessage request = new(HttpMethod.Get, "/authentication/api/v1/systemuser/vendor/byquery?system-id=991825827_the_matrix&orgno=910493353");
             HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -3313,7 +3308,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             string differentVendorToken = PrincipalUtil.GetOrgToken("digdir", "999999999", "altinn:authentication/systemuser.request.write", prefixes, now: TestTime);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", differentVendorToken);
 
-            HttpRequestMessage request = new(HttpMethod.Get,"/authentication/api/v1/systemuser/vendor/byquery?system-id=991825827_the_matrix&orgno=910493353&external-ref=99");
+            HttpRequestMessage request = new(HttpMethod.Get, "/authentication/api/v1/systemuser/vendor/byquery?system-id=991825827_the_matrix&orgno=910493353&external-ref=99");
             HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -3322,7 +3317,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         // =====================================================================
         // GET /vendor/bysystem/{systemId} — Forbidden (no consumer claim)
         // =====================================================================
-
         [Fact]
         public async Task SystemUser_ListByVendorsSystem_ReturnsForbidden_WhenNoConsumerClaim()
         {
@@ -3331,7 +3325,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Regular user token — no "consumer" claim
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1337, null, 3, now: TestTime));
 
-            HttpRequestMessage request = new(HttpMethod.Get,"/authentication/api/v1/systemuser/vendor/bysystem/991825827_the_matrix");
+            HttpRequestMessage request = new(HttpMethod.Get, "/authentication/api/v1/systemuser/vendor/bysystem/991825827_the_matrix");
             HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -3340,7 +3334,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         // =====================================================================
         // POST /agent/{party}/{systemUserId}/ — Forbid (party mismatch)
         // =====================================================================
-
         [Fact]
         public async Task AgentSystemUser_Delegate_Post_ReturnsForbidden_WhenPartyMismatch()
         {

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/AccessManagementClientMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/AccessManagementClientMock.cs
@@ -162,7 +162,7 @@ public class AccessManagementClientMock: IAccessManagementClient
             {
                 Id = delegationId,
                 FacilitatorId = facilitator,
-                FromId = new Guid("fd9d93c7-1dd7-45bc-9772-6ba977b3cd36"),// value not from our input
+                FromId = new Guid("fd9d93c7-1dd7-45bc-9772-6ba977b3cd36"), // value not from our input
                 ToId = Guid.NewGuid() // the Assignment Id
             }
         });
@@ -229,8 +229,7 @@ public class AccessManagementClientMock: IAccessManagementClient
         string content = File.ReadAllText(dataFileName);
         PaginatedInput<AccessPackageDto.Check> paginatedAccessPackages = JsonSerializer.Deserialize<PaginatedInput<AccessPackageDto.Check>>(content, _serializerOptions)!;
 
-        //List<AccessPackageDto.Check> accessPackages = JsonSerializer.Deserialize<List<AccessPackageDto.Check>>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
-
+        // List<AccessPackageDto.Check> accessPackages = JsonSerializer.Deserialize<List<AccessPackageDto.Check>>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
         foreach (AccessPackageDto.Check accessPackageCheck in paginatedAccessPackages.Items)
         {
             yield return accessPackageCheck;

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/PDPPermitMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/PDPPermitMock.cs
@@ -12,13 +12,12 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
         /// <inheritdoc/>
         public Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest)
         {
-            //var response = new XacmlJsonResponse
-            //{
+            // var response = new XacmlJsonResponse
+            // {
             //    Response = new List<XacmlJsonResult>(new[] { new XacmlJsonResult { Decision = "Permit" } })
-            //};
+            // };
 
-            //return Task.FromResult(response);
-
+            // return Task.FromResult(response);
             string decision = "Permit";
 
             // Check for claim "userid" with value "2234" in all AccessSubjects

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/ResourceRegistryClientMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/ResourceRegistryClientMock.cs
@@ -64,7 +64,7 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
                 try
                 {
                     content = File.ReadAllText(dataFileName);
-                    res = (List<PolicyRightsDTO>) JsonSerializer.Deserialize(content, typeof(List<PolicyRightsDTO>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                    res = (List<PolicyRightsDTO>)JsonSerializer.Deserialize(content, typeof(List<PolicyRightsDTO>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                 }
                 catch (Exception ex)
                 {

--- a/test/Altinn.Platform.Authentication.Tests/RepositoryDataAccess/AsyncConcurrencyLimiter.cs
+++ b/test/Altinn.Platform.Authentication.Tests/RepositoryDataAccess/AsyncConcurrencyLimiter.cs
@@ -12,7 +12,7 @@ internal class AsyncConcurrencyLimiter
 
     public AsyncConcurrencyLimiter(int maxConcurrency)
     {
-        //Guard.IsGreaterThanOrEqualTo(maxConcurrency, 1);
+        // Guard.IsGreaterThanOrEqualTo(maxConcurrency, 1);
         Assert.True(maxConcurrency > 0);
 
         _semaphoreSlim = new SemaphoreSlim(maxConcurrency, maxConcurrency);
@@ -53,7 +53,7 @@ internal class AsyncConcurrencyLimiter
         {
             if (_semaphoreSlim != null)
             {
-                //ThrowHelper.ThrowInvalidOperationException("Lock not released.");
+                // ThrowHelper.ThrowInvalidOperationException("Lock not released.");
                 throw new InvalidOperationException("Lock not released.");
             }
         }

--- a/test/Altinn.Platform.Authentication.Tests/RepositoryDataAccess/DbFixture.cs
+++ b/test/Altinn.Platform.Authentication.Tests/RepositoryDataAccess/DbFixture.cs
@@ -17,7 +17,7 @@ public class DbFixture
 {
     private const int MAX_CONCURRENCY = 20;
 
-    Singleton.Ref<Inner>? _inner;
+    private Singleton.Ref<Inner>? _inner;
 
     public async Task InitializeAsync()
     {
@@ -50,8 +50,8 @@ public class DbFixture
 
         private readonly AsyncConcurrencyLimiter _throtler = new(MAX_CONCURRENCY);
 
-        string? _connectionString;
-        NpgsqlDataSource? _db;
+        private string? _connectionString;
+        private NpgsqlDataSource? _db;
 
         public async Task InitializeAsync()
         {
@@ -109,10 +109,10 @@ public class DbFixture
 
     public sealed class OwnedDb : IAsyncDisposable
     {
-        readonly string _connectionString;
-        readonly string _dbName;
-        readonly DbFixture _db;
-        readonly IDisposable _ticket;
+        private readonly string _connectionString;
+        private readonly string _dbName;
+        private readonly DbFixture _db;
+        private readonly IDisposable _ticket;
 
         public OwnedDb(string connectionString, string dbName, DbFixture db, IDisposable ticket)
         {
@@ -156,7 +156,7 @@ public class DbFixture
         }
     }
 
-    class TraceService : Yuniql.Extensibility.ITraceService
+    private class TraceService : Yuniql.Extensibility.ITraceService
     {
         public static Yuniql.Extensibility.ITraceService Instance { get; } = new TraceService();
 

--- a/test/Altinn.Platform.Authentication.Tests/RepositoryDataAccess/Singleton.cs
+++ b/test/Altinn.Platform.Authentication.Tests/RepositoryDataAccess/Singleton.cs
@@ -32,7 +32,7 @@ internal static class Singleton
         {
             if (Interlocked.Exchange(ref _disposed, 1) == 0)
             {
-                //ThrowHelper.ThrowInvalidOperationException($"Singleton.Ref<{typeof(T).Name}> was not disposed");
+                // ThrowHelper.ThrowInvalidOperationException($"Singleton.Ref<{typeof(T).Name}> was not disposed");
                 throw new InvalidOperationException($"Singleton.Ref<{typeof(T).Name}> was not disposed");
             }
         }

--- a/test/Altinn.Platform.Authentication.Tests/RepositoryDataAccess/SystemUserRepositoryDbTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/RepositoryDataAccess/SystemUserRepositoryDbTests.cs
@@ -24,23 +24,23 @@ public class SystemUserRepositoryDbTests(DbFixture dbFixture, WebApplicationFixt
 
     protected NpgsqlDataSource DataSource => Services.GetRequiredService<NpgsqlDataSource>();
 
-    ///*****************************comment for testing*********************************/
+    // *****************************comment for testing*********************************/
     ///// <summary>
     ///// Inserts a new SystemUser, using the same input expected from GUI or API
     ///// </summary>
     ///// <returns></returns>
-    //[Fact]
-    //public async Task InsertSystemUser()
-    //{
+    // [Fact]
+    // public async Task InsertSystemUser()
+    // {
     //    Guid guid = Guid.NewGuid();
     //    List<string> clientId = new List<string>();
     //    clientId.Add(guid.ToString());
 
-    //    RegisterSystemRequest registeredSystem = new() { SystemId = "Awesome_System", SystemVendorOrgNumber = "991825827", SystemName = "Awesome System", ClientId = clientId, SoftDeleted = false };
+    // RegisterSystemRequest registeredSystem = new() { SystemId = "Awesome_System", SystemVendorOrgNumber = "991825827", SystemName = "Awesome System", ClientId = clientId, SoftDeleted = false };
 
-    //    Guid? createdSystemInternalId = await RegisterRepository.CreateRegisteredSystem(registeredSystem);
+    // Guid? createdSystemInternalId = await RegisterRepository.CreateRegisteredSystem(registeredSystem);
 
-    //    Guid? systemUserId = await Repository.InsertSystemUser(new Core.Models.SystemUser 
+    // Guid? systemUserId = await Repository.InsertSystemUser(new Core.Models.SystemUser 
     //    {
     //        SystemInternalId = createdSystemInternalId,
     //        IntegrationTitle = "InsertSystemUserTitle",
@@ -50,19 +50,19 @@ public class SystemUserRepositoryDbTests(DbFixture dbFixture, WebApplicationFixt
     //        SupplierOrgNo = "123456789 MVA"
     //    });
 
-    //    Assert.True(systemUserId is not null);
-    //}
+    // Assert.True(systemUserId is not null);
+    // }
 
     ///// <summary>
     ///// Used to populate the Overview page for a specific user
     ///// </summary>
     ///// <returns></returns>
-    //[Fact]
-    //public async Task GetAllActiveSystemUsersForParty()
-    //{
+    // [Fact]
+    // public async Task GetAllActiveSystemUsersForParty()
+    // {
     //    Guid guid = Guid.NewGuid();
 
-    //    List<string> clientId = new List<string>();
+    // List<string> clientId = new List<string>();
     //    clientId.Add(guid.ToString());
     //    List<Right> rights = new List<Right>()
     //            {
@@ -79,11 +79,11 @@ public class SystemUserRepositoryDbTests(DbFixture dbFixture, WebApplicationFixt
     //                }
     //            };
 
-    //    RegisterSystemRequest registeredSystem = new() { SystemId = "Awesome_System", SystemVendorOrgNumber="991825827", SystemName="Awesome System", ClientId = clientId, SoftDeleted = false };
+    // RegisterSystemRequest registeredSystem = new() { SystemId = "Awesome_System", SystemVendorOrgNumber="991825827", SystemName="Awesome System", ClientId = clientId, SoftDeleted = false };
 
-    //    Guid? createdSystemInternalId = await RegisterRepository.CreateRegisteredSystem(registeredSystem);
+    // Guid? createdSystemInternalId = await RegisterRepository.CreateRegisteredSystem(registeredSystem);
 
-    //    Guid? systemUserId = await Repository.InsertSystemUser(new Core.Models.SystemUser
+    // Guid? systemUserId = await Repository.InsertSystemUser(new Core.Models.SystemUser
     //    {
     //        SystemInternalId = createdSystemInternalId,
     //        IntegrationTitle = "GetAllActiveSystemUsersForPartyTitle",
@@ -93,27 +93,27 @@ public class SystemUserRepositoryDbTests(DbFixture dbFixture, WebApplicationFixt
     //        SupplierOrgNo = "123456789 MVA"
     //    });
 
-    //    var res = await Repository.GetAllActiveSystemUsersForParty(1);
+    // var res = await Repository.GetAllActiveSystemUsersForParty(1);
 
-    //    Assert.True(res is not null && res.Count > 0 && res.Find((SystemUser usr) => usr.Id == systemUserId.ToString()) is not null);
-    //}
+    // Assert.True(res is not null && res.Count > 0 && res.Find((SystemUser usr) => usr.Id == systemUserId.ToString()) is not null);
+    // }
 
     ///// <summary>
     ///// Retrieves a specific SystemUserIntegration
     ///// </summary>
     ///// <returns></returns>
-    //[Fact]
-    //public async Task GetSystemUserById()
-    //{
+    // [Fact]
+    // public async Task GetSystemUserById()
+    // {
     //    Guid guid = Guid.NewGuid();
 
-    //    List<string> clientId = [guid.ToString()];
+    // List<string> clientId = [guid.ToString()];
 
-    //    RegisterSystemRequest registeredSystem = new() { SystemId = "Awesome_System", SystemVendorOrgNumber = "991825827", SystemName = "Awesome System", ClientId = clientId, SoftDeleted = false };
+    // RegisterSystemRequest registeredSystem = new() { SystemId = "Awesome_System", SystemVendorOrgNumber = "991825827", SystemName = "Awesome System", ClientId = clientId, SoftDeleted = false };
 
-    //    Guid? createdSystemInternalId = await RegisterRepository.CreateRegisteredSystem(registeredSystem);
+    // Guid? createdSystemInternalId = await RegisterRepository.CreateRegisteredSystem(registeredSystem);
 
-    //    Guid? systemUserId = await Repository.InsertSystemUser(new Core.Models.SystemUser
+    // Guid? systemUserId = await Repository.InsertSystemUser(new Core.Models.SystemUser
     //    {
     //        SystemInternalId = createdSystemInternalId,
     //        IntegrationTitle = "GetSystemUserByIdTitle",
@@ -122,28 +122,28 @@ public class SystemUserRepositoryDbTests(DbFixture dbFixture, WebApplicationFixt
     //        SupplierOrgNo = "1234567890"
     //    });
 
-    //    SystemUser? systemUser = await Repository.GetSystemUserById((Guid)systemUserId);
+    // SystemUser? systemUser = await Repository.GetSystemUserById((Guid)systemUserId);
 
-    //    Assert.True(systemUser is not null && systemUser.Id == systemUserId.ToString());
-    //}
+    // Assert.True(systemUser is not null && systemUser.Id == systemUserId.ToString());
+    // }
 
     ///// <summary>
     ///// Sets the SystemUserIntegration to be in a "deleted" state.
     ///// </summary>
     ///// <returns></returns>
-    //[Fact]
-    //public async Task SoftDeleteSystemUserById()
-    //{
+    // [Fact]
+    // public async Task SoftDeleteSystemUserById()
+    // {
     //    Guid guid = Guid.NewGuid();
 
-    //    List<string> clientId = new List<string>();
+    // List<string> clientId = new List<string>();
     //    clientId.Add(guid.ToString());
 
-    //    RegisterSystemRequest registeredSystem = new() { SystemId = "Awesome_System", SystemVendorOrgNumber = "991825827", SystemName = "Awesome System", ClientId = clientId, SoftDeleted = false };
+    // RegisterSystemRequest registeredSystem = new() { SystemId = "Awesome_System", SystemVendorOrgNumber = "991825827", SystemName = "Awesome System", ClientId = clientId, SoftDeleted = false };
 
-    //    Guid? createdSystemInternalId = await RegisterRepository.CreateRegisteredSystem(registeredSystem);
+    // Guid? createdSystemInternalId = await RegisterRepository.CreateRegisteredSystem(registeredSystem);
 
-    //    Guid? systemUserId = await Repository.InsertSystemUser(new Core.Models.SystemUser
+    // Guid? systemUserId = await Repository.InsertSystemUser(new Core.Models.SystemUser
     //    {
     //        SystemInternalId = createdSystemInternalId,
     //        IntegrationTitle = "GetSystemUserByIdTitle",
@@ -153,11 +153,11 @@ public class SystemUserRepositoryDbTests(DbFixture dbFixture, WebApplicationFixt
     //        SupplierOrgNo = "123456789 MVA"
     //    });
 
-    //    await Repository.SetDeleteSystemUserById((Guid)systemUserId);
+    // await Repository.SetDeleteSystemUserById((Guid)systemUserId);
 
-    //    var res = await Repository.GetAllActiveSystemUsersForParty(1);
+    // var res = await Repository.GetAllActiveSystemUsersForParty(1);
 
-    //    Assert.True(res.Find((SystemUser usr) => usr.Id == systemUserId.ToString()) is null);
-    //}
-    ///*****************************comment for testing*********************************/
+    // Assert.True(res.Find((SystemUser usr) => usr.Id == systemUserId.ToString()) is null);
+    // }
+    // *****************************comment for testing*********************************/
 }

--- a/test/Altinn.Platform.Authentication.Tests/WebApplicationFixture.cs
+++ b/test/Altinn.Platform.Authentication.Tests/WebApplicationFixture.cs
@@ -74,7 +74,6 @@ public class WebApplicationFixture
                 services.AddSingleton<TimeProvider>(timeProvider);
 
                 // services.AddSingleton<AdvanceableTimeProvider>(timeProvider);
-
                 services.AddSingleton<IPublicSigningKeyProvider, SigningKeyResolverStub>();
             });
 


### PR DESCRIPTION
**Iteration 1 of several** on the Tests project (#488): clear all **190 StyleCop (`SA*`) warnings**. Formatting-only — no behaviour change.

Branched from `main` (independent of the other in-review #488 PRs).

## How

- **186 auto-fixed** via `dotnet format analyzers` scoped to the Tests project, for exactly these StyleCop diagnostics: `SA1005` (comment must start with a space, ×110), `SA1512`/`SA1508` (blank lines), `SA1001` (comma spacing), `SA1400` (explicit access modifier), `SA1003`/`SA1004`/`SA1008`/`SA1009`/`SA1025` (misc spacing).
- **4 `SA1626`** (documentation-style `///` on plain comments) fixed by hand — the auto-fixer bailed on overlapping edits.

Diff is 15 files, all cosmetic (comment spacing, `[Fact(Skip=…)]`, operator/comma spacing, blank-line trims).

## Not in this PR

`TreatWarningsAsErrors` is **not** enabled — the Tests project still has ~788 `CS`/nullable warnings to clear across later iterations before it can be locked. Planned order: StyleCop (this) → dead code → deprecated APIs → nullable (by folder) → lock.

## Verification
- Release build: **0 errors**; sample suites (Introspection, Logout) pass.
- StyleCop count in Tests (Debug): **190 → 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
