### PR TITLE
chore(tests): remove dead code (#488, Tests iteration 2)

### DIFF
--- a/test/Altinn.Platform.Authentication.Tests/Controllers/ChangeRequestControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/ChangeRequestControllerTest.cs
@@ -220,9 +220,6 @@ public class ChangeRequestControllerTest(
         });
 
         Guid id = Guid.NewGuid();
-        string orgno = "910493353";
-        string ext = "external";
-        string sys = "991825827_the_matrix";
 
         // Change Request, create
         string createChangeRequestEndpoint = $"/authentication/api/v1/systemuser/changerequest/vendor?correlation-id={id}&system-user-id={systemuser.Id}";
@@ -348,9 +345,6 @@ public class ChangeRequestControllerTest(
         });
 
         Guid id = Guid.NewGuid();
-        string orgno = "910493353";
-        string ext = "external";
-        string sys = "991825827_the_matrix";
 
         // Change Request, create
         string createChangeRequestEndpoint = $"/authentication/api/v1/systemuser/changerequest/vendor?correlation-id={id}&system-user-id={systemuser.Id}";
@@ -738,9 +732,6 @@ public class ChangeRequestControllerTest(
         });
 
         Guid id = Guid.NewGuid();
-        string orgno = "910493353";
-        string ext = "external";
-        string sys = "991825827_the_matrix";
 
         // Change Request, create
         string createChangeRequestEndpoint = $"/authentication/api/v1/systemuser/changerequest/vendor?correlation-id={id}&system-user-id={systemuser.Id}";
@@ -877,9 +868,6 @@ public class ChangeRequestControllerTest(
         });
 
         Guid id = Guid.NewGuid();
-        string orgno = "910493353";
-        string ext = "external";
-        string sys = "991825827_the_matrix";
 
         // Change Request, create
         string createChangeRequestEndpoint = $"/authentication/api/v1/systemuser/changerequest/vendor?correlation-id={id}&system-user-id={systemuser.Id}";
@@ -1030,9 +1018,6 @@ public class ChangeRequestControllerTest(
         });
 
         Guid id = Guid.NewGuid();
-        string orgno = "910493353";
-        string ext = "external";
-        string sys = "991825827_the_matrix";
 
         // Change Request, create
         string createChangeRequestEndpoint = $"/authentication/api/v1/systemuser/changerequest/vendor?correlation-id={id}&system-user-id={systemuser.Id}";
@@ -1179,9 +1164,6 @@ public class ChangeRequestControllerTest(
         });
 
         Guid id = Guid.NewGuid();
-        string orgno = "910493353";
-        string ext = "external";
-        string sys = "991825827_the_matrix";
 
         // ChangeRequest create
         string createChangeRequestEndpoint = $"/authentication/api/v1/systemuser/changerequest/vendor?correlation-id={id}&system-user-id={systemuser.Id}";
@@ -1343,9 +1325,6 @@ public class ChangeRequestControllerTest(
         });
 
         Guid id = Guid.NewGuid();
-        string orgno = "910493353";
-        string ext = "external";
-        string sys = "991825827_the_matrix";
 
         // ChangeRequest create
         string createChangeRequestEndpoint = $"/authentication/api/v1/systemuser/changerequest/vendor?correlation-id={id}&system-user-id={systemuser.Id}";
@@ -1481,9 +1460,6 @@ public class ChangeRequestControllerTest(
         });
 
         Guid id = Guid.NewGuid();
-        string orgno = "910493353";
-        string ext = "external";
-        string sys = "991825827_the_matrix";
 
         // ChangeRequest create
         string createChangeRequestEndpoint = $"/authentication/api/v1/systemuser/changerequest/vendor?correlation-id={id}&system-user-id={systemuser.Id}";
@@ -1838,9 +1814,6 @@ public class ChangeRequestControllerTest(
         });
 
         Guid id = Guid.NewGuid();
-        string orgno = "910493353";
-        string ext = "external";
-        string sys = "991825827_the_matrix";
 
         // ChangeRequest create
         string createChangeRequestEndpoint = $"/authentication/api/v1/systemuser/changerequest/vendor?correlation-id={id}&system-user-id={systemuser.Id}";
@@ -2121,9 +2094,6 @@ public class ChangeRequestControllerTest(
         });
 
         Guid id = Guid.NewGuid();
-        string orgno = "910493353";
-        string ext = "external";
-        string sys = "991825827_the_matrix";
 
         // ChangeRequest create
         string createChangeRequestEndpoint = $"/authentication/api/v1/systemuser/changerequest/vendor?correlation-id={id}&system-user-id={systemuser.Id}";
@@ -2261,9 +2231,6 @@ public class ChangeRequestControllerTest(
         });
 
         Guid id = Guid.NewGuid();
-        string orgno = "910493353";
-        string ext = "external";
-        string sys = "991825827_the_matrix";
 
         // ChangeRequest create
         string createChangeRequestEndpoint = $"/authentication/api/v1/systemuser/changerequest/vendor?correlation-id={id}&system-user-id={systemuser.Id}";
@@ -2462,8 +2429,6 @@ public class ChangeRequestControllerTest(
         });
 
         Guid id = Guid.NewGuid();
-        string orgno = "910493353";
-        string sys = "991825827_the_matrix";
 
         // ChangeRequest create
         string createChangeRequestEndpoint = $"/authentication/api/v1/systemuser/changerequest/vendor?correlation-id={id}&system-user-id={systemuser.Id}";

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
@@ -36,7 +36,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
     public class LogoutControllerTests(DbFixture dbFixture, WebApplicationFixture webApplicationFixture)
         : WebApplicationTests(dbFixture, webApplicationFixture)
     {
-        private readonly WebApplicationFactory<LogoutController> _factory;
         private IConfiguration _configuration;
   
         private readonly Mock<IUserProfileService> _userProfileService = new();

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/OpenIdControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/OpenIdControllerTests.cs
@@ -20,8 +20,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
     public class OpenIdControllerTests(DbFixture dbFixture, WebApplicationFixture webApplicationFixture)
         : WebApplicationTests(dbFixture, webApplicationFixture)
     {
-        private readonly WebApplicationFactory<OpenIdController> _factory;
-
         protected override void ConfigureServices(IServiceCollection services)
         {
             base.ConfigureServices(services);

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/RequestControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/RequestControllerTests.cs
@@ -757,7 +757,6 @@ public class RequestControllerTests(
         string endpoint2 = $"/authentication/api/v1/systemuser/request/vendor/agent/{testId}";
 
         HttpResponseMessage message2 = await client2.GetAsync(endpoint2);
-        string debug = "pause_here";
         Assert.Equal(HttpStatusCode.OK, message2.StatusCode);
         AgentRequestSystemResponse? res2 = await message2.Content.ReadFromJsonAsync<AgentRequestSystemResponse>();
         Assert.Contains("&DONTCHOOSEREPORTEE=true", res2.ConfirmUrl);
@@ -815,7 +814,6 @@ public class RequestControllerTests(
         string endpoint2 = $"/authentication/api/v1/systemuser/request/vendor/agent/{testId}";
 
         HttpResponseMessage message2 = await client2.GetAsync(endpoint2);
-        string debug = "pause_here";
         Assert.Equal(HttpStatusCode.OK, message2.StatusCode);
         AgentRequestSystemResponse? res2 = await message2.Content.ReadFromJsonAsync<AgentRequestSystemResponse>();
         Assert.Contains("&DONTCHOOSEREPORTEE=true", res2.ConfirmUrl);
@@ -941,7 +939,6 @@ public class RequestControllerTests(
         string endpoint2 = $"/authentication/api/v1/systemuser/request/vendor/agent/{testId}";
 
         HttpResponseMessage message2 = await client2.GetAsync(endpoint2);
-        string debug = "pause_here";
         Assert.Equal(HttpStatusCode.NotFound, message2.StatusCode);
         ProblemDetails? problem = await message2.Content.ReadFromJsonAsync<ProblemDetails>();
         Assert.Equal("The Id does not refer to a Request in our system.", problem!.Title);
@@ -1256,7 +1253,6 @@ public class RequestControllerTests(
         HttpClient client2 = CreateClient();
         client2.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1338, null, 3, addPortalScope: true, now: TestTime));
 
-        int partyId = 500000;
         Guid resId = Guid.NewGuid();
 
         string partyEndpoint = $"/authentication/api/v1/systemuser/request/{resId}";
@@ -1315,8 +1311,6 @@ public class RequestControllerTests(
         // Party Get Request
         HttpClient client2 = CreateClient();
         client2.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1338, null, 3, addPortalScope: false, now: TestTime));
-
-        int partyId = 500000;
 
         string partyEndpoint = $"/authentication/api/v1/systemuser/request/{res.Id}";
 
@@ -1726,8 +1720,6 @@ public class RequestControllerTests(
         // Party Get Request
         HttpClient client2 = CreateClient();
         client2.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1338, null, 3, addPortalScope: false, now: TestTime));
-
-        int partyId = 500000;
 
         string partyEndpoint = $"/authentication/api/v1/systemuser/request/agent/{res.Id}";
 

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemRegisterControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemRegisterControllerTests.cs
@@ -1808,7 +1808,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         public async Task GetSystemChangeLog_InvalidSystemId_ReturnsNotFound()
         {
             // Post original System
-            const string dataFileName = "Data/SystemRegister/Json/SystemRegister.json";
             HttpClient createClient = GetAuthenticatedClient(Write, ValidOrg);
 
             string systemId = "991825827_the_matrix";

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserControllerTest.cs
@@ -896,7 +896,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpClient client = CreateClient();
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1337, null, 3, now: TestTime));
 
-            int partyId = 500000;
             string partyOrgno = "910493353"; 
 
             SystemUserRequestDto newSystemUser = new()

--- a/test/Altinn.Platform.Authentication.Tests/Health/HealthCheckTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Health/HealthCheckTests.cs
@@ -17,8 +17,6 @@ namespace Altinn.Platform.Authentication.UnitTest
     public class HealthCheckTests(DbFixture dbFixture, WebApplicationFixture webApplicationFixture)
         : WebApplicationTests(dbFixture, webApplicationFixture)
     {
-        private readonly WebApplicationFactory<HealthCheck> _factory;
-
         /// <summary>
         /// Verify that component responds on health check
         /// </summary>

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/ResourceRegistryClientMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/ResourceRegistryClientMock.cs
@@ -66,9 +66,8 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
                     content = File.ReadAllText(dataFileName);
                     res = (List<PolicyRightsDTO>)JsonSerializer.Deserialize(content, typeof(List<PolicyRightsDTO>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
-                    string message = $"Error reading file {dataFileName}";
                     throw;
                 }                
                                 
@@ -85,9 +84,8 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
                     content = File.ReadAllText(dataFileName);
                     res = (List<PolicyRightsDTO>)JsonSerializer.Deserialize(content, typeof(List<PolicyRightsDTO>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
-                    string message = $"Error reading file {dataFileName}";
                     throw;
                 }
 

--- a/test/Altinn.Platform.Authentication.Tests/Utils/IDProviderTestTokenUtil.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Utils/IDProviderTestTokenUtil.cs
@@ -108,8 +108,6 @@ namespace Altinn.Platform.Authentication.Tests.Utils
         public static OidcCodeResponse GetUidpTokenResponse(OidcTestScenario scenario, UpstreamLoginTransaction createdUpstreamLogingTransaction, DateTimeOffset authTime)
         {
             string sub = Guid.NewGuid().ToString();
-            string locale = "nb";
-            string digDirOrgNo = "991825827";
 
             OidcCodeResponse response = new()
             {


### PR DESCRIPTION
Part of #488. Second Tests-project iteration: remove compiler-flagged dead code.

## What

Removed unused locals/fields flagged by the compiler in the **Tests** project:

- **CS0219** (assigned, value never used): `orgno`/`ext`/`sys`, `partyId`, `debug`, `dataFileName`, `locale`, `digDirOrgNo` across `ChangeRequestControllerTest`, `RequestControllerTests`, `SystemRegisterControllerTests`, `SystemUserControllerTest` and `IDProviderTestTokenUtil`.
- **CS0169** (unused field): `_factory` in `LogoutControllerTests`, `OpenIdControllerTests`, `HealthCheckTests`.
- **CS0168** (unused variable): unused `ex` in the two `ResourceRegistryClientMock` catch blocks (also dropped the dead `message` local sitting next to it).

Tidied the resulting blank lines so StyleCop stays green.

## Scope notes

- **No test logic changed** — only unused declarations removed.
- The three dead-code warnings in `src/Authentication` (`LogoutController`, `SystemUserClientDelegationController`, `ChangeRequestSystemUserService`) are intentionally **left for the host-project iteration**, to keep this PR scoped to the Tests project.
- `TreatWarningsAsErrors` is **not** enabled here yet — the Tests ratchet is applied after the remaining iterations (deprecated APIs + async, then nullable).

## Verification

`dotnet build` of the Tests project is green with **0** remaining `CS0219`/`CS0169`/`CS0168`/`CS9113` warnings in Tests-project files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up several authentication test files by removing unused variables and obsolete debug placeholders.
  * Simplified test setup in a few areas by dropping unused factory fields and redundant local values.
  * Streamlined a mock helper’s error handling without changing behavior.
  * No functional changes or user-facing behavior updates were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->