### PR TITLE
chore(tests): migrate deprecated APIs, await async, fix XML docs (#488, Tests iteration 3)

### DIFF
--- a/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerTests.cs
@@ -66,14 +66,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
             string configPath = GetConfigPath();
 
-            WebHostBuilder builder = new();
-
-            builder.ConfigureAppConfiguration((context, conf) =>
-            {
-                conf.AddJsonFile(configPath);
-            });
-
-            var configuration = new ConfigurationBuilder()            
+            var configuration = new ConfigurationBuilder()
               .AddJsonFile(configPath)
               .AddInMemoryCollection(
                 new Dictionary<string, string>

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/ChangeRequestControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/ChangeRequestControllerTest.cs
@@ -33,7 +33,6 @@ using Altinn.Platform.Authentication.Tests.Mocks;
 using Altinn.Platform.Authentication.Tests.RepositoryDataAccess;
 using Altinn.Platform.Authentication.Tests.Utils;
 using AltinnCore.Authentication.JwtCookie;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -71,13 +70,6 @@ public class ChangeRequestControllerTest(
         string defaultOidc = "altinn";
 
         string configPath = GetConfigPath();
-
-        WebHostBuilder builder = new();
-
-        builder.ConfigureAppConfiguration((context, conf) =>
-        {
-            conf.AddJsonFile(configPath);
-        });
 
         var configuration = new ConfigurationBuilder()
           .AddJsonFile(configPath)

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
@@ -18,7 +18,6 @@ using Altinn.Platform.Authentication.Tests.RepositoryDataAccess;
 using Altinn.Platform.Authentication.Tests.Utils;
 using AltinnCore.Authentication.JwtCookie;
 using App.IntegrationTests.Utils;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -49,12 +48,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             base.ConfigureServices(services);
 
             string configPath = GetConfigPath();
-            WebHostBuilder builder = new();
-
-            builder.ConfigureAppConfiguration((context, conf) =>
-            {
-                conf.AddJsonFile(configPath);
-            });
 
             var configuration = new ConfigurationBuilder()
              .AddJsonFile(configPath)
@@ -84,18 +77,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             services.AddSingleton(_organisationsService.Object);            
             _configuration = configuration;
         }
-
-        /// <summary>
-        /// Initialises a new instance of the <see cref="OpenIdControllerTests"/> class with the given WebApplicationFactory.
-        /// </summary>
-        /// <param name="factory">The WebApplicationFactory to use when creating a test server.</param>
-        // public LogoutControllerTests(WebApplicationFactory<LogoutController> factory)
-        // {
-        //    _factory = factory;
-        //    _userProfileService = new Mock<IUserProfileService>();
-        //    _organisationsService = new Mock<IOrganisationsService>();
-        //    SetupDateTimeMock();
-        // }
 
         /// <summary>
         /// Validates that an unauthenticated user is redirected to BaseUrl (no OIDC provider can be resolved).

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEnd_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEnd_OidcFrontChannelControllerTest.cs
@@ -28,7 +28,6 @@ using Altinn.Platform.Authentication.Tests.RepositoryDataAccess;
 using Altinn.Platform.Authentication.Tests.Utils;
 using Altinn.Register.Contracts.V1;
 using AltinnCore.Authentication.JwtCookie;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -77,9 +76,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             services.AddSingleton<TimeProvider>(_fakeTime);
 
             string configPath = GetConfigPath();
-
-            WebHostBuilder builder = new();
-            builder.ConfigureAppConfiguration((context, conf) => { conf.AddJsonFile(configPath); });
 
             var configuration = new ConfigurationBuilder()
                 .AddJsonFile(configPath)

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/ErrorScenarios_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/ErrorScenarios_OidcFrontChannelControllerTest.cs
@@ -10,7 +10,6 @@ using Altinn.Platform.Authentication.Tests.Fakes;
 using Altinn.Platform.Authentication.Tests.Models;
 using Altinn.Platform.Authentication.Tests.RepositoryDataAccess;
 using Altinn.Platform.Authentication.Tests.Utils;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
@@ -41,9 +40,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             services.AddSingleton<TimeProvider>(_fakeTime);
 
             string configPath = GetConfigPath();
-
-            WebHostBuilder builder = new();
-            builder.ConfigureAppConfiguration((context, conf) => { conf.AddJsonFile(configPath); });
 
             var configuration = new ConfigurationBuilder()
                 .AddJsonFile(configPath)

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/RequestControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/RequestControllerTests.cs
@@ -34,7 +34,6 @@ using Altinn.Platform.Authentication.Tests.Mocks;
 using Altinn.Platform.Authentication.Tests.RepositoryDataAccess;
 using Altinn.Platform.Authentication.Tests.Utils;
 using AltinnCore.Authentication.JwtCookie;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
@@ -71,13 +70,6 @@ public class RequestControllerTests(
         string defaultOidc = "altinn";
 
         string configPath = GetConfigPath();
-
-        WebHostBuilder builder = new();
-
-        builder.ConfigureAppConfiguration((context, conf) =>
-        {
-            conf.AddJsonFile(configPath);
-        });
 
         var configuration = new ConfigurationBuilder()
           .AddJsonFile(configPath)

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemRegisterControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemRegisterControllerTests.cs
@@ -29,7 +29,6 @@ using Altinn.Platform.Authentication.Tests.Mocks;
 using Altinn.Platform.Authentication.Tests.RepositoryDataAccess;
 using Altinn.Platform.Authentication.Tests.Utils;
 using AltinnCore.Authentication.JwtCookie;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -76,10 +75,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             string defaultOidc = "altinn";
 
             string configPath = GetConfigPath();
-
-            WebHostBuilder builder = new();
-
-            builder.ConfigureAppConfiguration((context, conf) => { conf.AddJsonFile(configPath); });
 
             var configuration = new ConfigurationBuilder()
                 .AddJsonFile(configPath)

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserClientDelegationControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserClientDelegationControllerTest.cs
@@ -37,7 +37,6 @@ using Altinn.Platform.Authentication.Tests.Utils;
 using AltinnCore.Authentication.JwtCookie;
 using App.IntegrationTests.Utils;
 using Azure;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -67,13 +66,6 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             base.ConfigureServices(services);
 
             string configPath = GetConfigPath();
-
-            WebHostBuilder builder = new();
-
-            builder.ConfigureAppConfiguration((context, conf) =>
-            {
-                conf.AddJsonFile(configPath);
-            });
 
             var configuration = new ConfigurationBuilder()
               .AddJsonFile(configPath)

--- a/test/Altinn.Platform.Authentication.Tests/Fakes/SigningKeyResolverStub.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Fakes/SigningKeyResolverStub.cs
@@ -10,16 +10,16 @@ using Microsoft.IdentityModel.Tokens;
 namespace Altinn.Platform.Authentication.Tests.Fakes
 {
     /// <summary>
-    /// Represents a stub for the <see cref="SigningKeysResolver"/> class to be used in integration tests.
+    /// Represents a stub for the <see cref="IPublicSigningKeyProvider"/> implementation to be used in integration tests.
     /// </summary>
     public class SigningKeyResolverStub : IPublicSigningKeyProvider
     {
-        /// <inheritdoc/>/>
+        /// <inheritdoc/>
         public Task<IEnumerable<SecurityKey>> GetSigningKeys(string issuer)
         {
             List<SecurityKey> signingKeys = new List<SecurityKey>();
 
-            X509Certificate2 cert = new X509Certificate2($"{issuer}-org.pem");
+            X509Certificate2 cert = X509CertificateLoader.LoadCertificateFromFile($"{issuer}-org.pem");
             SecurityKey key = new X509SecurityKey(cert);
 
             signingKeys.Add(key);

--- a/test/Altinn.Platform.Authentication.Tests/Fakes/SigningKeysRetrieverStub.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Fakes/SigningKeysRetrieverStub.cs
@@ -15,7 +15,7 @@ namespace Altinn.Platform.Authentication.Tests.Fakes
         {
             List<SecurityKey> signingKeys = new List<SecurityKey>();
 
-            X509Certificate2 cert = new X509Certificate2("JWTValidationCert.cer");
+            X509Certificate2 cert = X509CertificateLoader.LoadCertificateFromFile("JWTValidationCert.cer");
             SecurityKey key = new X509SecurityKey(cert);
 
             signingKeys.Add(key);

--- a/test/Altinn.Platform.Authentication.Tests/RepositoryDataAccess/DbFixture.cs
+++ b/test/Altinn.Platform.Authentication.Tests/RepositoryDataAccess/DbFixture.cs
@@ -42,8 +42,7 @@ public class DbFixture
     {
         private int _dbCounter = 0;
         private readonly AsyncLock _dbLock = new();
-        private readonly PostgreSqlContainer _dbContainer = new PostgreSqlBuilder()
-            .WithImage("ghcr.io/altinn/library/postgres:16.2-alpine") 
+        private readonly PostgreSqlContainer _dbContainer = new PostgreSqlBuilder("ghcr.io/altinn/library/postgres:16.2-alpine")
             .WithUsername("auth_authentication")
             .WithCleanUp(true)
             .Build();

--- a/test/Altinn.Platform.Authentication.Tests/Services/EventLogServiceTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Services/EventLogServiceTest.cs
@@ -45,7 +45,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
             Mock<HttpContext> context = new Mock<HttpContext>();
 
             // Act
-            service.CreateAuthenticationEventAsync(featureManageMock.Object, authenticatedUser, AuthenticationEventType.Authenticate, context.Object);
+            await service.CreateAuthenticationEventAsync(featureManageMock.Object, authenticatedUser, AuthenticationEventType.Authenticate, context.Object);
 
             queueMock.Verify(r => r.EnqueueAuthenticationEvent(It.IsAny<string>()), Times.Once);
         }
@@ -90,7 +90,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
             IPAddress address = IPAddress.Parse("255.1.3.12");
 
             // Act
-            service.CreateAuthenticationEventAsync(featureManageMock.Object, externalToken, AuthenticationEventType.Authenticate, address);
+            await service.CreateAuthenticationEventAsync(featureManageMock.Object, externalToken, AuthenticationEventType.Authenticate, address);
 
             queueMock.Verify(r => r.EnqueueAuthenticationEvent(It.IsAny<string>()), Times.Once);
         }
@@ -113,7 +113,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
             Mock<HttpContext> context = new Mock<HttpContext>();
 
             // Act
-            service.CreateAuthenticationEventAsync(featureManageMock.Object, authenticatedUser, AuthenticationEventType.Authenticate, context.Object);
+            await service.CreateAuthenticationEventAsync(featureManageMock.Object, authenticatedUser, AuthenticationEventType.Authenticate, context.Object);
 
             queueMock.Verify(r => r.EnqueueAuthenticationEvent(It.IsAny<string>()), Times.Never);
         }
@@ -138,7 +138,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
             IPAddress ipadress = IPAddress.Parse("244.233.12.2");
 
             // Act
-            service.CreateAuthenticationEventAsync(featureManageMock.Object, token, AuthenticationEventType.Authenticate, ipadress);
+            await service.CreateAuthenticationEventAsync(featureManageMock.Object, token, AuthenticationEventType.Authenticate, ipadress);
 
             queueMock.Verify(r => r.EnqueueAuthenticationEvent(It.IsAny<string>()), Times.Never);
         }

--- a/test/Altinn.Platform.Authentication.Tests/Services/UserProfileServiceLocalSiTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Services/UserProfileServiceLocalSiTests.cs
@@ -18,8 +18,8 @@ namespace Altinn.Platform.Authentication.Tests.Services;
 
 /// <summary>
 /// Unit tests for the local self-identified credential validation path in
-/// <see cref="UserProfileService"/> (feature flag
-/// <see cref="FeatureFlags.LocalSelfIdentifiedCredentialValidation"/> enabled). These tests do not
+/// <see cref="UserProfileService"/> (the local path is permanent since the
+/// LocalSelfIdentifiedCredentialValidation flag was removed, see ADR-0004). These tests do not
 /// require Docker - they exercise the service directly with mocks and a throwing HTTP handler that
 /// guarantees the SBL Bridge is never contacted on the local path.
 /// </summary>


### PR DESCRIPTION
## Summary

Tests iteration 3 of the #488 warning ratchet: clears the deprecated-API, not-awaited-async, and XML-doc warnings in `Altinn.Platform.Authentication.Tests`. After this, the Tests project only has nullable (`CS86xx`) warnings left (iteration 4+).

- **ASPDEPR004 (8)** — the deprecated `WebHostBuilder` in 8 test classes was dead code: constructed and given a `ConfigureAppConfiguration` callback, but never used (the actual configuration comes from a separate `ConfigurationBuilder`). Deleted the blocks and the now-unused `using Microsoft.AspNetCore.Hosting;` in 7 files (`AuthenticationControllerTests` still needs it for `ConfigureHost(IWebHostBuilder)`).
- **CS4014 (4)** — awaited `CreateAuthenticationEventAsync` in `EventLogServiceTest`; also makes the `Verify(...)` assertions deterministic instead of racing the fire-and-forget task.
- **SYSLIB0057 (2)** — `SigningKeyResolverStub`/`SigningKeysRetrieverStub` now use `X509CertificateLoader.LoadCertificateFromFile` (public certs only, no PKCS#12 variant needed).
- **CS0618 (1)** — `DbFixture` passes the image to the `PostgreSqlBuilder` constructor instead of the obsolete parameterless ctor + `WithImage`.
- **CS1574/CS1587 (3)** — cref fixed to `IPublicSigningKeyProvider`; `UserProfileServiceLocalSiTests` doc now references the removed `LocalSelfIdentifiedCredentialValidation` flag as plain text (removed per ADR-0004); deleted a doc comment on a commented-out constructor in `LogoutControllerTests`.

The same warning codes remaining in `src/Authentication` are deliberately left for the host ratchet iteration.

## Verification

- Debug build (matches CI, StyleCop active): 0 remaining ASPDEPR/SYSLIB/CS0618/CS4014/CS15xx warnings in the Tests project.
- Full test suite run locally against podman: **494 passed, 0 failed, 2 skipped** (pre-existing skips).

Part of #488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test configuration setup for more consistent and maintainable test execution.
  * Updated asynchronous event-log tests to correctly await operations.
  * Improved certificate loading in test doubles.
  * Streamlined test database container setup.

* **Documentation**
  * Updated test documentation to reflect the permanent local validation behavior.
  * Corrected XML documentation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->