### PR TITLE
chore(tests): clear nullable warnings + enable WarnAsError (#488, Tests iteration 4)

### DIFF
--- a/test/Altinn.Platform.Authentication.Tests/Altinn.Platform.Authentication.Tests.csproj
+++ b/test/Altinn.Platform.Authentication.Tests/Altinn.Platform.Authentication.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Altinn.Platform.Authentication.Tests/AuthenticationHelperTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/AuthenticationHelperTests.cs
@@ -323,7 +323,7 @@ namespace Altinn.Platform.Authentication.Tests
         public void ValidateRedirectUrl_NullAllowedRedirectUrls_ReturnsProblem()
         {
             // Arrange
-            List<Uri> allowedRedirectUrls = null;
+            List<Uri> allowedRedirectUrls = null!; // deliberately null: testing guard clause
             string redirectURL = "https://example.com/callback";
 
             // Act
@@ -367,7 +367,7 @@ namespace Altinn.Platform.Authentication.Tests
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        public void TryParseAcrValues_NoValueRequested_IsValidAndEmpty(string input)
+        public void TryParseAcrValues_NoValueRequested_IsValidAndEmpty(string? input)
         {
             bool ok = AuthenticationHelper.TryParseAcrValues(input, out string[] values);
 

--- a/test/Altinn.Platform.Authentication.Tests/Constants/XacmlResourceAttributes.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Constants/XacmlResourceAttributes.cs
@@ -8,40 +8,40 @@ public class XacmlResourceAttributes
     /// <summary>
     /// Gets or sets the value for org attribute
     /// </summary>
-    public string OrgValue { get; set; }
+    public string? OrgValue { get; set; }
 
     /// <summary>
     /// Gets or sets the value for app attribute
     /// </summary>
-    public string AppValue { get; set; }
+    public string? AppValue { get; set; }
 
     /// <summary>
     /// Gets or sets the value for instance attribute
     /// </summary>
-    public string InstanceValue { get; set; }
+    public string? InstanceValue { get; set; }
 
     /// <summary>
     /// Gets or sets the value for resourceparty attribute
     /// </summary>
-    public string ResourcePartyValue { get; set; }
+    public string? ResourcePartyValue { get; set; }
 
     /// <summary>
     /// Gets or sets the value for task attribute
     /// </summary>
-    public string TaskValue { get; set; }
+    public string? TaskValue { get; set; }
 
     /// <summary>
-    /// Gets or sets the value for app resource. 
+    /// Gets or sets the value for app resource.
     /// </summary>
-    public string AppResourceValue { get; set; }
-    
+    public string? AppResourceValue { get; set; }
+
     /// <summary>
     /// Gets or sets the resource registry Id
     /// </summary>
-    public string ResourceRegistryId { get; set; }
+    public string? ResourceRegistryId { get; set; }
 
     /// <summary>
     /// Gets or sets the OrganizationNumber for the org owning the resource
     /// </summary>
-    public string OrganizationNumber { get; set; }
+    public string? OrganizationNumber { get; set; }
 }

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerIdPortenRegisterTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerIdPortenRegisterTests.cs
@@ -57,7 +57,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             IConfiguration configuration = new ConfigurationBuilder()
                 .AddJsonFile(configPath)
                 .AddInMemoryCollection(
-                    new Dictionary<string, string>
+                    new Dictionary<string, string?>
                     {
                         { "GeneralSettings:DefaultOidcProvider", "altinn" }
                     })
@@ -111,7 +111,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
             // The mock returns a Register party (deserialized to exercise the real polymorphic contract)
             // whose User object carries the Altinn user id and username.
-            RegisterContracts.Party party = JsonSerializer.Deserialize<RegisterContracts.Party>(
+            RegisterContracts.Party? party = JsonSerializer.Deserialize<RegisterContracts.Party>(
                 """
                 {
                   "partyType": "person",
@@ -127,6 +127,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 }
                 """,
                 new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+            Assert.NotNull(party);
 
             _partiesClient
                 .Setup(p => p.GetPartyIdentifiersAndUsernameByPersonIdentifier(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -158,7 +160,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
         private static string GetConfigPath()
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(AuthenticationControllerIdPortenRegisterTests).Assembly.Location).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(AuthenticationControllerIdPortenRegisterTests).Assembly.Location).LocalPath)!; // assembly location always has a directory
             return Path.Combine(unitTestFolder, $"../../../appsettings.test.json");
         }
     }

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerTests.cs
@@ -51,7 +51,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         private readonly Mock<IGuidService> guidService = new();
         private readonly Mock<IEventsQueueClient> _eventQueue = new();
         private readonly Mock<IPartiesClient> _partiesClient = new();
-        private IConfiguration _configuration;
+        private IConfiguration _configuration = null!; // set in ConfigureServices
 
         protected override void ConfigureHost(IWebHostBuilder builder)
         {
@@ -69,7 +69,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             var configuration = new ConfigurationBuilder()
               .AddJsonFile(configPath)
               .AddInMemoryCollection(
-                new Dictionary<string, string>
+                new Dictionary<string, string?>
                 {
                     { "GeneralSettings:DefaultOidcProvider", "altinn" }
                 })
@@ -333,7 +333,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
             Assert.True(principal.HasClaim(c => c.Type == "urn:altinn:org"));
 
-            Assert.Equal("ttd", principal.FindFirst(c => c.Type == "urn:altinn:org").Value);
+            Assert.Equal("ttd", principal.FindFirst(c => c.Type == "urn:altinn:org")!.Value); // non-null: HasClaim asserted above
         }
 
         /// <summary>
@@ -434,7 +434,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             identity.AddClaims(claims);
             ClaimsPrincipal externalPrincipal = new ClaimsPrincipal(identity);
 
-            RegisterContracts.Party party = System.Text.Json.JsonSerializer.Deserialize<RegisterContracts.Party>(
+            RegisterContracts.Party? party = System.Text.Json.JsonSerializer.Deserialize<RegisterContracts.Party>(
                 """
                 {
                   "partyType": "person",
@@ -450,6 +450,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 }
                 """,
                 new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+
+            Assert.NotNull(party);
 
             _partiesClient
                 .Setup(p => p.GetPartyIdentifiersAndUsernameByPersonIdentifier(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -508,7 +510,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             identity.AddClaims(claims);
             ClaimsPrincipal externalPrincipal = new ClaimsPrincipal(identity);
 
-            RegisterContracts.Party party = System.Text.Json.JsonSerializer.Deserialize<RegisterContracts.Party>(
+            RegisterContracts.Party? party = System.Text.Json.JsonSerializer.Deserialize<RegisterContracts.Party>(
                 """
                 {
                   "partyType": "person",
@@ -524,6 +526,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 }
                 """,
                 new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+
+            Assert.NotNull(party);
 
             _partiesClient
                 .Setup(p => p.GetPartyIdentifiersAndUsernameByPersonIdentifier(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -610,7 +614,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             identity.AddClaims(claims);
             ClaimsPrincipal externalPrincipal = new ClaimsPrincipal(identity);
 
-            RegisterContracts.Party party = System.Text.Json.JsonSerializer.Deserialize<RegisterContracts.Party>(
+            RegisterContracts.Party? party = System.Text.Json.JsonSerializer.Deserialize<RegisterContracts.Party>(
                 """
                 {
                   "partyType": "person",
@@ -626,6 +630,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 }
                 """,
                 new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+
+            Assert.NotNull(party);
 
             _partiesClient
                 .Setup(p => p.GetPartyIdentifiersAndUsernameByPersonIdentifier(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -737,7 +743,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
             string externalToken = JwtTokenMock.GenerateEncryptedAndSignedToken(externalPrincipal, TimeSpan.FromMinutes(2), now: TimeProvider.GetUtcNow());
             ClaimsPrincipal claimsPrincipal = JwtTokenMock.ValidateEncryptedAndSignedToken(externalToken);
-            Assert.Equal(externalPrincipal.Identity.Name, claimsPrincipal.Identity.Name);
+            Assert.Equal(externalPrincipal.Identity!.Name, claimsPrincipal.Identity!.Name); // non-null: both principals are constructed with an identity
         }
 
         /// <summary>
@@ -812,7 +818,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             identity.AddClaims(claims);
             ClaimsPrincipal externalPrincipal = new ClaimsPrincipal(identity);
 
-            RegisterContracts.Party party = System.Text.Json.JsonSerializer.Deserialize<RegisterContracts.Party>(
+            RegisterContracts.Party? party = System.Text.Json.JsonSerializer.Deserialize<RegisterContracts.Party>(
                 """
                 {
                   "partyType": "person",
@@ -828,6 +834,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 }
                 """,
                 new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+
+            Assert.NotNull(party);
 
             _partiesClient
                 .Setup(p => p.GetPartyIdentifiersAndUsernameByPersonIdentifier(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -845,7 +853,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Get the altinn token
             string token = await response.Content.ReadAsStringAsync();
             ClaimsPrincipal altinnTokenPrincipal = JwtTokenMock.ValidateToken(token, TimeProvider.GetUtcNow());
-            string altinnSessionId = altinnTokenPrincipal.FindFirstValue("sid");
+            string? altinnSessionId = altinnTokenPrincipal.FindFirstValue("sid");
 
             url = "/authentication/api/v1/refresh";
 
@@ -909,11 +917,11 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
         private static string GetConfigPath()
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(AuthenticationControllerTests).Assembly.Location).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(AuthenticationControllerTests).Assembly.Location).LocalPath)!; // assembly location always has a directory
             return Path.Combine(unitTestFolder, $"../../../appsettings.test.json");
         }
 
-        private AuthenticationEvent GetAuthenticationEvent(AuthenticationMethod authMethod, SecurityLevel authLevel, int? orgNumber, AuthenticationEventType authEventType, int? userId = null, bool isAuthenticated = true, string externalSessionId = null)
+        private AuthenticationEvent GetAuthenticationEvent(AuthenticationMethod authMethod, SecurityLevel authLevel, int? orgNumber, AuthenticationEventType authEventType, int? userId = null, bool isAuthenticated = true, string? externalSessionId = null)
         {
             AuthenticationEvent authenticationEvent = new AuthenticationEvent();
             authenticationEvent.Created = TimeProvider.GetUtcNow();

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/IntrospectionControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/IntrospectionControllerTest.cs
@@ -79,10 +79,11 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Act
             HttpResponseMessage res = await client.SendAsync(requestMessage);
             string responseString = await res.Content.ReadAsStringAsync();
-            IntrospectionResponse actual = JsonSerializer.Deserialize<IntrospectionResponse>(responseString, _options);
+            IntrospectionResponse? actual = JsonSerializer.Deserialize<IntrospectionResponse>(responseString, _options);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+            Assert.NotNull(actual);
             AdvancedAsserts.Equal(expected, actual);
             _eformidlingValidatorService.Verify(efvs => efvs.ValidateToken(It.IsAny<string>()), Times.Once());
         }
@@ -119,10 +120,11 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Act
             HttpResponseMessage res = await client.SendAsync(requestMessage);
             string responseString = await res.Content.ReadAsStringAsync();
-            IntrospectionResponse actual = JsonSerializer.Deserialize<IntrospectionResponse>(responseString, _options);
+            IntrospectionResponse? actual = JsonSerializer.Deserialize<IntrospectionResponse>(responseString, _options);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+            Assert.NotNull(actual);
             Assert.False(actual.Active);
             _eformidlingValidatorService.Verify(efvs => efvs.ValidateToken(It.IsAny<string>()), Times.Once());
         }

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/LogoutControllerTests.cs
@@ -35,7 +35,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
     public class LogoutControllerTests(DbFixture dbFixture, WebApplicationFixture webApplicationFixture)
         : WebApplicationTests(dbFixture, webApplicationFixture)
     {
-        private IConfiguration _configuration;
+        private IConfiguration _configuration = null!; // set in ConfigureServices
   
         private readonly Mock<IUserProfileService> _userProfileService = new();
         private readonly Mock<IOrganisationsService> _organisationsService = new();
@@ -52,7 +52,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             var configuration = new ConfigurationBuilder()
              .AddJsonFile(configPath)
              .AddInMemoryCollection(
-               new Dictionary<string, string>
+               new Dictionary<string, string?>
                {
                     { "GeneralSettings:DefaultOidcProvider", "altinn" },
                     { "FeatureManagement:EnableAuditLog", "false" }
@@ -180,7 +180,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Assert
             Assert.Equal(System.Net.HttpStatusCode.Found, response.StatusCode);
 
-            IEnumerable<string> values;
+            IEnumerable<string>? values;
             if (response.Headers.TryGetValues("location", out values))
             {
                 Assert.Equal("http://localhost/", values.First());
@@ -213,7 +213,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Assert
             Assert.Equal(System.Net.HttpStatusCode.Found, response.StatusCode);
 
-            IEnumerable<string> values;
+            IEnumerable<string>? values;
             if (response.Headers.TryGetValues("location", out values))
             {
                 Assert.Equal("http://localhost/", values.First());
@@ -240,10 +240,10 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Assert
             Assert.Equal(System.Net.HttpStatusCode.Found, response.StatusCode);
 
-            response.Headers.TryGetValues("Set-Cookie", out IEnumerable<string> cookieValues);
+            response.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookieValues);
             Assert.Equal("AltinnLogoutInfo=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=localhost; path=/; secure; httponly", cookieValues?.First());
 
-            response.Headers.TryGetValues("location", out IEnumerable<string> locationValues);
+            response.Headers.TryGetValues("location", out IEnumerable<string>? locationValues);
             Assert.Equal("https://smartcloudaltinn.azurewebsites.net/request", locationValues?.First());
         }
 
@@ -262,10 +262,10 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Assert
             Assert.Equal(System.Net.HttpStatusCode.Found, response.StatusCode);
 
-            response.Headers.TryGetValues("Set-Cookie", out IEnumerable<string> cookieValues);
+            response.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookieValues);
             Assert.Equal("AltinnLogoutInfo=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=localhost; path=/; secure; httponly", cookieValues?.First());
 
-            response.Headers.TryGetValues("location", out IEnumerable<string> locationValues);
+            response.Headers.TryGetValues("location", out IEnumerable<string>? locationValues);
             Assert.Equal("https://smartcloudaltinn.azurewebsites.net/changerequest", locationValues?.First());
         }
 
@@ -284,10 +284,10 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Assert
             Assert.Equal(System.Net.HttpStatusCode.Found, response.StatusCode);
 
-            response.Headers.TryGetValues("Set-Cookie", out IEnumerable<string> cookieValues);
+            response.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookieValues);
             Assert.Equal("AltinnLogoutInfo=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=localhost; path=/; secure; httponly", cookieValues?.First());
 
-            response.Headers.TryGetValues("location", out IEnumerable<string> locationValues);
+            response.Headers.TryGetValues("location", out IEnumerable<string>? locationValues);
             Assert.Equal("https://smartcloudaltinn.azurewebsites.net/agentrequest", locationValues?.First());
         }
 
@@ -306,7 +306,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Assert
             Assert.Equal(System.Net.HttpStatusCode.Found, response.StatusCode);
 
-            response.Headers.TryGetValues("location", out IEnumerable<string> locationValues);
+            response.Headers.TryGetValues("location", out IEnumerable<string>? locationValues);
             Assert.Equal("https://am.ui.localhost/accessmanagement/api/v1/logoutredirect", locationValues?.First());
         }
 
@@ -324,10 +324,10 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Assert
             Assert.Equal(System.Net.HttpStatusCode.Found, response.StatusCode);
 
-            response.Headers.TryGetValues("Set-Cookie", out IEnumerable<string> cookieValues);
+            response.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookieValues);
             Assert.Equal("AltinnLogoutInfo=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=localhost; path=/; secure; httponly", cookieValues?.First());
 
-            response.Headers.TryGetValues("location", out IEnumerable<string> locationValues);
+            response.Headers.TryGetValues("location", out IEnumerable<string>? locationValues);
             Assert.Equal("http://localhost/", locationValues?.First());
         }
 
@@ -364,7 +364,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Assert
             Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
 
-            IEnumerable<string> values;
+            IEnumerable<string>? values;
 
             if (response.Headers.TryGetValues("Set-Cookie", out values))
             {
@@ -406,7 +406,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Assert
             Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
 
-            IEnumerable<string> values;
+            IEnumerable<string>? values;
 
             if (response.Headers.TryGetValues("Set-Cookie", out values))
             {
@@ -418,7 +418,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
        
         private static string GetConfigPath()
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(AuthenticationControllerTests).Assembly.Location).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(AuthenticationControllerTests).Assembly.Location).LocalPath)!; // assembly location always has a directory
             return Path.Combine(unitTestFolder, $"../../../appsettings.test.json");
         }
 

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEnd_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/EndToEnd_OidcFrontChannelControllerTest.cs
@@ -161,7 +161,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             _ = await Repository.InsertClientAsync(create);
 
             // Sanity: the test scenario seeds the client with a legacy PBKDF2 hash.
-            await TokenAssertsHelper.AssertClientSecretIsLegacyPbkdf2(Repository, testScenario.DownstreamClientId);
+            await TokenAssertsHelper.AssertClientSecretIsLegacyPbkdf2(Repository, testScenario.DownstreamClientId!); // always set by OidcScenarioHelper.GetScenario
 
             // 08:00:00 UTC — start of day: user signs in to Arbeidsflate (RP).
             // Arbeidsflate redirects the browser to the Altinn Authentication OIDC Provider’s /authorize endpoint.
@@ -202,11 +202,11 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             string tokenString = await tokenResp.Content.ReadAsStringAsync();
 
             // The first successful client_secret verify must have rehashed the stored hash to HMAC-SHA256.
-            await TokenAssertsHelper.AssertClientSecretMigratedToHmac(Repository, testScenario.DownstreamClientId);
+            await TokenAssertsHelper.AssertClientSecretMigratedToHmac(Repository, testScenario.DownstreamClientId!); // always set by OidcScenarioHelper.GetScenario
 
             // Asserts on token response structure
+            Assert.NotNull(tokenResult);
             string sid = TokenAssertsHelper.AssertTokenResponse(tokenResult, testScenario, _fakeTime.GetUtcNow());
-            Debug.Assert(tokenResult != null);
 
             OidcSession? originalSession = await OidcServerDatabaseUtil.GetOidcSessionAsync(sid, DataSource);
             OidcAssertHelper.AssertValidSession(originalSession, testScenario, _fakeTime.GetUtcNow());
@@ -263,7 +263,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
 
             // ===== Phase 7: Try to reuse old but still active refresh_token =====
             // User returns to arbeisflate and do a new refresh. Arbeidsflate has still active session and do a refresh.
-            Dictionary<string, string> refreshFormAfterAppVisit = OidcServerTestUtils.GetRefreshForm(testScenario, create, refreshed.refresh_token);
+            Dictionary<string, string> refreshFormAfterAppVisit = OidcServerTestUtils.GetRefreshForm(testScenario, create, refreshed.refresh_token!);
 
             using var refreshRespAfterAppVisit = await client.PostAsync(
                 "/authentication/api/v1/token",
@@ -297,7 +297,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             // ==== Phase 10: Returns to Arbeidsflate  =====
             // The refresh token should now be expired (max lifetime is 30 minutes and the token was issued at 08:01).
             // Arbeidsflate needs to redirect user to /authorize again to get a new code/refresh_token.
-            Dictionary<string, string> reuseForm = OidcServerTestUtils.GetRefreshForm(testScenario, create, refreshedAfterAppVisit.refresh_token);
+            Dictionary<string, string> reuseForm = OidcServerTestUtils.GetRefreshForm(testScenario, create, refreshedAfterAppVisit.refresh_token!);
 
             using var reuseResp = await client.PostAsync(
                 "/authentication/api/v1/token",
@@ -330,6 +330,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             TokenResponseDto? tokenResult2 = JsonSerializer.Deserialize<TokenResponseDto>(json2);
 
             // Asserts on token response structure
+            Assert.NotNull(tokenResult2);
             string sid2 = TokenAssertsHelper.AssertTokenResponse(tokenResult2, testScenario, _fakeTime.GetUtcNow());
 
             Assert.Equal(sid, sid2); // should be same session as before
@@ -422,8 +423,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             string tokenString = await tokenResp.Content.ReadAsStringAsync();
 
             // Asserts on token response structure
+            Assert.NotNull(tokenResult);
             string sid = TokenAssertsHelper.AssertTokenResponse(tokenResult, testScenario, _fakeTime.GetUtcNow());
-            Debug.Assert(tokenResult != null);
 
             OidcSession? originalSession = await OidcServerDatabaseUtil.GetOidcSessionAsync(sid, DataSource);
             OidcAssertHelper.AssertValidSession(originalSession, testScenario, _fakeTime.GetUtcNow());
@@ -480,7 +481,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
 
             // ===== Phase 7: Try to reuse old but still active refresh_token =====
             // User returns to arbeisflate and do a new refresh. Arbeidsflate has still active session and do a refresh.
-            Dictionary<string, string> refreshFormAfterAppVisit = OidcServerTestUtils.GetRefreshForm(testScenario, create, refreshed.refresh_token);
+            Dictionary<string, string> refreshFormAfterAppVisit = OidcServerTestUtils.GetRefreshForm(testScenario, create, refreshed.refresh_token!);
 
             using var refreshRespAfterAppVisit = await client.PostAsync(
                 "/authentication/api/v1/token",
@@ -514,7 +515,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             // ==== Phase 10: Returns to Arbeidsflate  =====
             // The refresh token should now be expired (max lifetime is 30 minutes and the token was issued at 08:01).
             // Arbeidsflate needs to redirect user to /authorize again to get a new code/refresh_token.
-            Dictionary<string, string> reuseForm = OidcServerTestUtils.GetRefreshForm(testScenario, create, refreshedAfterAppVisit.refresh_token);
+            Dictionary<string, string> reuseForm = OidcServerTestUtils.GetRefreshForm(testScenario, create, refreshedAfterAppVisit.refresh_token!);
 
             using var reuseResp = await client.PostAsync(
                 "/authentication/api/v1/token",
@@ -547,6 +548,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             TokenResponseDto? tokenResult2 = JsonSerializer.Deserialize<TokenResponseDto>(json2);
 
             // Asserts on token response structure
+            Assert.NotNull(tokenResult2);
             string sid2 = TokenAssertsHelper.AssertTokenResponse(tokenResult2, testScenario, _fakeTime.GetUtcNow());
 
             Assert.Equal(sid, sid2); // should be same session as before
@@ -648,8 +650,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             TokenResponseDto? tokenResult = await tokenResp.Content.ReadFromJsonAsync<TokenResponseDto>(jsonSerializerOptions);
 
             // Asserts on token response structure
+            Assert.NotNull(tokenResult);
             string sid = TokenAssertsHelper.AssertTokenResponse(tokenResult, testScenario, _fakeTime.GetUtcNow());
-            Debug.Assert(tokenResult != null);
 
             OidcSession? originalSession = await OidcServerDatabaseUtil.GetOidcSessionAsync(sid, DataSource);
             OidcAssertHelper.AssertValidSession(originalSession, testScenario, _fakeTime.GetUtcNow());
@@ -686,7 +688,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
 
             // ===== Phase 6: Try to reuse old but still active refresh_token =====
             // User returns to arbeisflate and do a new refresh. Arbeidsflate has still active session and do a refresh.
-            Dictionary<string, string> refreshFormAfterAppVisit = OidcServerTestUtils.GetRefreshForm(testScenario, create, tokenResult.refresh_token);
+            Dictionary<string, string> refreshFormAfterAppVisit = OidcServerTestUtils.GetRefreshForm(testScenario, create, tokenResult.refresh_token!);
 
             using var refreshRespAfterAppVisit = await client.PostAsync(
                 "/authentication/api/v1/token",
@@ -840,6 +842,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             TokenResponseDto? tokenResult = JsonSerializer.Deserialize<TokenResponseDto>(json);
 
             // Asserts on token response structure
+            Assert.NotNull(tokenResult);
             string sidFromCodeResponse = TokenAssertsHelper.AssertTokenResponse(tokenResult, testScenario, _fakeTime.GetUtcNow());
 
             // ===== Phase 5: User is done for the day. Press Logout in Arbeidsflate. This should log the user out both in Altinn and Idporten. =====
@@ -1111,6 +1114,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             TokenResponseDto? tokenResult = JsonSerializer.Deserialize<TokenResponseDto>(json);
 
             // Asserts on token response structure
+            Assert.NotNull(tokenResult);
             string sidFromCodeResponse = TokenAssertsHelper.AssertTokenResponse(tokenResult, testScenario, _fakeTime.GetUtcNow());
 
             // ===== Phase 5: User is done for the day. Press Logout in Arbeidsflate. This should log the user out both in Altinn and Idporten. =====
@@ -1205,8 +1209,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             string tokenString = await tokenResp.Content.ReadAsStringAsync();
 
             // Asserts on token response structure
+            Assert.NotNull(tokenResult);
             string sid = TokenAssertsHelper.AssertTokenResponse(tokenResult, testScenario, _fakeTime.GetUtcNow());
-            Debug.Assert(tokenResult != null);
 
             OidcSession? originalSession = await OidcServerDatabaseUtil.GetOidcSessionAsync(sid, DataSource);
             OidcAssertHelper.AssertValidSession(originalSession, testScenario, _fakeTime.GetUtcNow());
@@ -1631,8 +1635,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             string tokenString = await tokenResp.Content.ReadAsStringAsync();
 
             // Asserts on token response structure
+            Assert.NotNull(tokenResult);
             string sid = TokenAssertsHelper.AssertTokenResponse(tokenResult, testScenario, _fakeTime.GetUtcNow());
-            Debug.Assert(tokenResult != null);
 
             OidcSession? originalSession = await OidcServerDatabaseUtil.GetOidcSessionAsync(sid, DataSource);
             OidcAssertHelper.AssertValidSession(originalSession, testScenario, _fakeTime.GetUtcNow());
@@ -1719,8 +1723,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             string tokenString = await tokenResp.Content.ReadAsStringAsync();
 
             // Asserts on token response structure
+            Assert.NotNull(tokenResult);
             string sid = TokenAssertsHelper.AssertTokenResponse(tokenResult, testScenario, _fakeTime.GetUtcNow());
-            Debug.Assert(tokenResult != null);
 
             OidcSession? originalSession = await OidcServerDatabaseUtil.GetOidcSessionAsync(sid, DataSource);
             OidcAssertHelper.AssertValidSession(originalSession, testScenario, _fakeTime.GetUtcNow());
@@ -1777,7 +1781,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
 
             // ===== Phase 7: Try to reuse old but still active refresh_token =====
             // User returns to arbeisflate and do a new refresh. Arbeidsflate has still active session and do a refresh.
-            Dictionary<string, string> refreshFormAfterAppVisit = OidcServerTestUtils.GetRefreshForm(testScenario, create, refreshed.refresh_token);
+            Dictionary<string, string> refreshFormAfterAppVisit = OidcServerTestUtils.GetRefreshForm(testScenario, create, refreshed.refresh_token!);
 
             using var refreshRespAfterAppVisit = await client.PostAsync(
                 "/authentication/api/v1/token",
@@ -1811,7 +1815,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             // ==== Phase 10: Returns to Arbeidsflate  =====
             // The refresh token should now be expired (max lifetime is 30 minutes and the token was issued at 08:01).
             // Arbeidsflate needs to redirect user to /authorize again to get a new code/refresh_token.
-            Dictionary<string, string> reuseForm = OidcServerTestUtils.GetRefreshForm(testScenario, create, refreshedAfterAppVisit.refresh_token);
+            Dictionary<string, string> reuseForm = OidcServerTestUtils.GetRefreshForm(testScenario, create, refreshedAfterAppVisit.refresh_token!);
 
             using var reuseResp = await client.PostAsync(
                 "/authentication/api/v1/token",
@@ -1844,6 +1848,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             TokenResponseDto? tokenResult2 = JsonSerializer.Deserialize<TokenResponseDto>(json2);
 
             // Asserts on token response structure
+            Assert.NotNull(tokenResult2);
             string sid2 = TokenAssertsHelper.AssertTokenResponse(tokenResult2, testScenario, _fakeTime.GetUtcNow());
 
             Assert.Equal(sid, sid2); // should be same session as before
@@ -1933,8 +1938,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             string tokenString = await tokenResp.Content.ReadAsStringAsync();
 
             // Asserts on token response structure
+            Assert.NotNull(tokenResult);
             string sid = TokenAssertsHelper.AssertTokenResponse(tokenResult, testScenario, _fakeTime.GetUtcNow());
-            Debug.Assert(tokenResult != null);
 
             OidcSession? originalSession = await OidcServerDatabaseUtil.GetOidcSessionAsync(sid, DataSource);
             OidcAssertHelper.AssertValidSession(originalSession, testScenario, _fakeTime.GetUtcNow());
@@ -1991,7 +1996,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
 
             // ===== Phase 7: Try to reuse old but still active refresh_token =====
             // User returns to arbeisflate and do a new refresh. Arbeidsflate has still active session and do a refresh.
-            Dictionary<string, string> refreshFormAfterAppVisit = OidcServerTestUtils.GetRefreshForm(testScenario, create, refreshed.refresh_token);
+            Dictionary<string, string> refreshFormAfterAppVisit = OidcServerTestUtils.GetRefreshForm(testScenario, create, refreshed.refresh_token!);
 
             using var refreshRespAfterAppVisit = await client.PostAsync(
                 "/authentication/api/v1/token",
@@ -2025,7 +2030,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             // ==== Phase 10: Returns to Arbeidsflate  =====
             // The refresh token should now be expired (max lifetime is 30 minutes and the token was issued at 08:01).
             // Arbeidsflate needs to redirect user to /authorize again to get a new code/refresh_token.
-            Dictionary<string, string> reuseForm = OidcServerTestUtils.GetRefreshForm(testScenario, create, refreshedAfterAppVisit.refresh_token);
+            Dictionary<string, string> reuseForm = OidcServerTestUtils.GetRefreshForm(testScenario, create, refreshedAfterAppVisit.refresh_token!);
 
             using var reuseResp = await client.PostAsync(
                 "/authentication/api/v1/token",
@@ -2058,6 +2063,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             TokenResponseDto? tokenResult2 = JsonSerializer.Deserialize<TokenResponseDto>(json2);
 
             // Asserts on token response structure
+            Assert.NotNull(tokenResult2);
             string sid2 = TokenAssertsHelper.AssertTokenResponse(tokenResult2, testScenario, _fakeTime.GetUtcNow());
 
             Assert.Equal(sid, sid2); // should be same session as before
@@ -2103,10 +2109,11 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
             return Path.Combine(unitTestFolder, $"../../../appsettings.test.json");
         }
 
-        private async Task<(string? UpstreamState, UpstreamLoginTransaction? CreatedUpstreamLogingTransaction)> AssertAutorizeRequestResult(OidcTestScenario testScenario, HttpResponseMessage authorizationRequestResponse, DateTimeOffset now)
+        private async Task<(string UpstreamState, UpstreamLoginTransaction CreatedUpstreamLogingTransaction)> AssertAutorizeRequestResult(OidcTestScenario testScenario, HttpResponseMessage authorizationRequestResponse, DateTimeOffset now)
         {
             OidcAssertHelper.AssertAuthorizeResponse(authorizationRequestResponse);
             string? upstreamState = HttpUtility.ParseQueryString(authorizationRequestResponse.Headers.Location!.Query)["state"];
+            Assert.NotNull(upstreamState);
 
             UpstreamLoginTransaction? createdUpstreamLogingTransaction = await OidcServerDatabaseUtil.GetUpstreamTransaction(upstreamState, DataSource);
             Assert.NotNull(createdUpstreamLogingTransaction);
@@ -2117,6 +2124,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
                 // Asserting DB persistence after /authorize
                 Debug.Assert(testScenario?.DownstreamClientId != null);
                 LoginTransaction? loginTransaction = await OidcServerDatabaseUtil.GetDownstreamTransaction(testScenario.DownstreamClientId, testScenario.GetDownstreamState(), DataSource);
+                Assert.NotNull(loginTransaction);
                 OidcAssertHelper.AssertLoginTransaction(loginTransaction, testScenario, now);
             }
 
@@ -2127,12 +2135,12 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
         {
             Guid upstreamSID = Guid.NewGuid();
             OidcCodeResponse oidcCodeResponse = IDProviderTestTokenUtil.GetIdPortenTokenResponse(
-                testScenario.Ssn,
-                testScenario.Email,
+                testScenario.Ssn!, // deliberately null in e-mail user scenarios: token util omits the pid claim
+                testScenario.Email!, // deliberately null in scenarios without e-mail: token util omits the email claim
                 createdUpstreamLogingTransaction.Nonce, 
                 upstreamSID.ToString(),
                 testScenario.Acr.ToArray(), 
-                testScenario.Amr?.ToArray(),
+                testScenario.Amr?.ToArray()!, // deliberately null when scenario has no amr: token util guards against null
                 createdUpstreamLogingTransaction.UpstreamClientId, 
                 createdUpstreamLogingTransaction.Scopes,
                 authTime);

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/ErrorScenarios_OidcFrontChannelControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/Oidc/ErrorScenarios_OidcFrontChannelControllerTest.cs
@@ -354,14 +354,14 @@ namespace Altinn.Platform.Authentication.Tests.Controllers.Oidc
 
         private static string GetConfigPath()
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(AuthenticationControllerTests).Assembly.Location).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(AuthenticationControllerTests).Assembly.Location).LocalPath)!; // assembly location always has a directory
             return Path.Combine(unitTestFolder, $"../../../appsettings.test.json");
         }
 
         private static OidcClientCreate NewClientCreate(OidcTestScenario testScenario) =>
             new()
             {
-                ClientId = testScenario.DownstreamClientId,
+                ClientId = testScenario.DownstreamClientId!, // always set by OidcScenarioHelper.GetScenario
                 ClientName = "Test Client",
                 ClientType = ClientType.Confidential,
                 TokenEndpointAuthMethod = TokenEndpointAuthMethod.ClientSecretBasic,

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/OpenIdControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/OpenIdControllerTests.cs
@@ -44,7 +44,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Assert
             string json = await response.Content.ReadAsStringAsync();
 
-            DiscoveryDocument discoveryDocument = JsonSerializer.Deserialize<DiscoveryDocument>(json);
+            DiscoveryDocument? discoveryDocument = JsonSerializer.Deserialize<DiscoveryDocument>(json);
 
             Assert.NotNull(discoveryDocument);
             Assert.EndsWith("jwks", discoveryDocument.JwksUri);
@@ -67,7 +67,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Assert
             string json = await response.Content.ReadAsStringAsync();
 
-            JwksDocument jwksDocument = JsonSerializer.Deserialize<JwksDocument>(json);
+            JwksDocument? jwksDocument = JsonSerializer.Deserialize<JwksDocument>(json);
 
             Assert.NotNull(jwksDocument);
             Assert.Single(jwksDocument.Keys);

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/RequestControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/RequestControllerTests.cs
@@ -293,7 +293,7 @@ public class RequestControllerTests(
         HttpResponseMessage message = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
 
         Assert.Equal(HttpStatusCode.BadRequest, message.StatusCode);
-        ProblemDetails problemDetails = await message.Content.ReadFromJsonAsync<ProblemDetails>();
+        ProblemDetails? problemDetails = await message.Content.ReadFromJsonAsync<ProblemDetails>();
         Assert.NotNull(problemDetails);
         Assert.Equal(Problem.AccessPackage_NotDelegable_Standard.Title, problemDetails.Title);
         Assert.True(problemDetails.Extensions.ContainsKey("NotDelegablePackages"));
@@ -431,6 +431,7 @@ public class RequestControllerTests(
         };
         HttpResponseMessage message2 = await client.SendAsync(request2, HttpCompletionOption.ResponseHeadersRead);
         AgentRequestSystemResponse? createdResponse = await message2.Content.ReadFromJsonAsync<AgentRequestSystemResponse>();
+        Assert.NotNull(createdResponse);
         Assert.Contains("&DONTCHOOSEREPORTEE=true", createdResponse.ConfirmUrl);
         Assert.Equal(HttpStatusCode.OK, message2.StatusCode);
     }
@@ -569,7 +570,7 @@ public class RequestControllerTests(
         HttpResponseMessage message = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
 
         Assert.Equal(HttpStatusCode.BadRequest, message.StatusCode);
-        ProblemDetails problemDetails = await message.Content.ReadFromJsonAsync<ProblemDetails>();
+        ProblemDetails? problemDetails = await message.Content.ReadFromJsonAsync<ProblemDetails>();
         Assert.NotNull(problemDetails);
         Assert.Equal(Problem.AccessPackage_NotDelegable_Agent.Title, problemDetails.Title);
         Assert.True(problemDetails.Extensions.ContainsKey("NotDelegablePackages"));
@@ -751,8 +752,8 @@ public class RequestControllerTests(
         HttpResponseMessage message2 = await client2.GetAsync(endpoint2);
         Assert.Equal(HttpStatusCode.OK, message2.StatusCode);
         AgentRequestSystemResponse? res2 = await message2.Content.ReadFromJsonAsync<AgentRequestSystemResponse>();
+        Assert.NotNull(res2);
         Assert.Contains("&DONTCHOOSEREPORTEE=true", res2.ConfirmUrl);
-        Assert.True(res2 is not null);
         Assert.Equal(testId, res2.Id);
         Assert.NotEqual(default(DateTime), res2.Created);
     }
@@ -808,8 +809,8 @@ public class RequestControllerTests(
         HttpResponseMessage message2 = await client2.GetAsync(endpoint2);
         Assert.Equal(HttpStatusCode.OK, message2.StatusCode);
         AgentRequestSystemResponse? res2 = await message2.Content.ReadFromJsonAsync<AgentRequestSystemResponse>();
+        Assert.NotNull(res2);
         Assert.Contains("&DONTCHOOSEREPORTEE=true", res2.ConfirmUrl);
-        Assert.True(res2 is not null);
         Assert.Equal(testId, res2.Id);
         Assert.True(res2.TimedOut);
         timeProvider.AdjustTime(prev.UtcDateTime);

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemRegisterControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemRegisterControllerTests.cs
@@ -164,7 +164,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage response = await SystemRegisterTestHelper.CreateSystemRegister(client, dataFileName);
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
 
-            AltinnValidationProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             AltinnValidationError error = problemDetails.Errors.First(e => e.ErrorCode == ValidationErrors.SystemRegister_Invalid_SystemId_Spaces.ErrorCode);
             Assert.Equal("/registersystemrequest/systemid", error.Paths.First(p => p.Equals("/registersystemrequest/systemid")));
@@ -183,7 +183,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage existingSystemResponse = await SystemRegisterTestHelper.CreateSystemRegister(client2, dataFileName);
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, existingSystemResponse.StatusCode);
 
-            AltinnValidationProblemDetails problemDetails = await existingSystemResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await existingSystemResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             AltinnValidationError error = problemDetails.Errors.First(e => e.ErrorCode == ValidationErrors.SystemRegister_SystemId_Exists.ErrorCode);
             Assert.Equal("/registersystemrequest/systemid", error.Paths.First(p => p.Equals("/registersystemrequest/systemid")));
@@ -199,7 +199,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage response = await SystemRegisterTestHelper.CreateSystemRegister(client, dataFileName);
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
 
-            AltinnValidationProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.Single(problemDetails.Errors);
             AltinnValidationError error = problemDetails.Errors.Single(e => e.ErrorCode == ValidationErrors.SystemRegister_Invalid_SystemId_Format.ErrorCode);
@@ -215,7 +215,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpClient client = GetAuthenticatedClient(Admin, ValidOrg);
             HttpResponseMessage response = await SystemRegisterTestHelper.CreateSystemRegister(client, dataFileName);
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
-            AltinnValidationProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.Single(problemDetails.Errors);
             AltinnValidationError error = problemDetails.Errors.Single(e => e.ErrorCode == ValidationErrors.SystemRegister_ResourceId_InvalidFormat.ErrorCode);
@@ -231,7 +231,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpClient client = GetAuthenticatedClient(Admin, ValidOrg);
             HttpResponseMessage response = await SystemRegisterTestHelper.CreateSystemRegister(client, dataFileName);
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
-            AltinnValidationProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.Single(problemDetails.Errors);
             AltinnValidationError error = problemDetails.Errors.Single(e => e.ErrorCode == ValidationErrors.SystemRegister_ResourceId_DoesNotExist.ErrorCode);
@@ -247,19 +247,19 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpClient client = GetAuthenticatedClient(Admin, ValidOrg);
             HttpResponseMessage response = await SystemRegisterTestHelper.CreateSystemRegister(client, dataFileName);
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
-            AltinnValidationProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.Equal(2, problemDetails.Errors.Count);
             AltinnValidationError error = problemDetails.Errors.Single(e => e.ErrorCode == ValidationErrors.SystemRegister_ResourceId_NotDelegable.ErrorCode);
             Assert.Equal("/registersystemrequest/rights/resource", error.Paths.Single(p => p.Equals("/registersystemrequest/rights/resource")));
             Assert.Equal(ValidationErrors.SystemRegister_ResourceId_NotDelegable.Title, error.Title);
-            string notDelegableExtensionValue = error.Extensions["ResourceIds Not Delegable : "].ToString();
+            string? notDelegableExtensionValue = error.Extensions["ResourceIds Not Delegable : "]?.ToString();
             Assert.Equal("ttd-am-k6", notDelegableExtensionValue);
 
             AltinnValidationError invalidFormatError = problemDetails.Errors.Single(e => e.ErrorCode == ValidationErrors.SystemRegister_ResourceId_InvalidFormat.ErrorCode);
             Assert.Equal("/registersystemrequest/rights/resource", invalidFormatError.Paths.Single(p => p.Equals("/registersystemrequest/rights/resource")));
             Assert.Equal(ValidationErrors.SystemRegister_ResourceId_InvalidFormat.Title, invalidFormatError.Title);
-            string invalidFormatErrorExtensionValue = invalidFormatError.Extensions["Invalid Resource Id Details : "].ToString();
+            string? invalidFormatErrorExtensionValue = invalidFormatError.Extensions["Invalid Resource Id Details : "]?.ToString();
             Assert.Equal("ttd-am-invalidresformat", invalidFormatErrorExtensionValue);
         }
 
@@ -271,7 +271,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpClient client = GetAuthenticatedClient(Admin, ValidOrg);
             HttpResponseMessage response = await SystemRegisterTestHelper.CreateSystemRegister(client, dataFileName);
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
-            AltinnValidationProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.Single(problemDetails.Errors);
             AltinnValidationError error = problemDetails.Errors.Single(e => e.ErrorCode == ValidationErrors.SystemRegister_AccessPackage_NotValid.ErrorCode);
@@ -287,7 +287,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpClient client = GetAuthenticatedClient(Admin, ValidOrg);
             HttpResponseMessage response = await SystemRegisterTestHelper.CreateSystemRegister(client, dataFileName);
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
-            AltinnValidationProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.Single(problemDetails.Errors);
             AltinnValidationError error = problemDetails.Errors.Single(e => e.ErrorCode == ValidationErrors.SystemRegister_ResourceId_Duplicates.ErrorCode);
@@ -303,7 +303,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpClient client = GetAuthenticatedClient(Admin, ValidOrg);
             HttpResponseMessage response = await SystemRegisterTestHelper.CreateSystemRegister(client, dataFileName);
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
-            AltinnValidationProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.Single(problemDetails.Errors);
             AltinnValidationError error = problemDetails.Errors.Single(e => e.ErrorCode == ValidationErrors.SystemRegister_AccessPackage_Duplicates.ErrorCode);
@@ -319,7 +319,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpClient client = GetAuthenticatedClient(Admin, ValidOrg);
             HttpResponseMessage response = await SystemRegisterTestHelper.CreateSystemRegister(client, dataFileName);
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
-            AltinnValidationProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.Single(problemDetails.Errors);
             AltinnValidationError error = problemDetails.Errors.Single(e => e.ErrorCode == ValidationErrors.SystemRegister_InValid_RedirectUrlFormat.ErrorCode);
@@ -335,7 +335,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpClient client = GetAuthenticatedClient(Admin, ValidOrg);
             HttpResponseMessage response = await SystemRegisterTestHelper.CreateSystemRegister(client, dataFileName);
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
-            AltinnValidationProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             AltinnValidationError error = problemDetails.Errors.First(e => e.ErrorCode == ValidationErrors.SystemRegister_InValid_Org_Identifier.ErrorCode);
             Assert.Equal("/registersystemrequest/vendor/id", error.Paths.First(p => p.Equals("/registersystemrequest/vendor/id")));
@@ -608,7 +608,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 request.Content = content;
                 HttpResponseMessage updateResponse = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
                 Assert.Equal(System.Net.HttpStatusCode.BadRequest, updateResponse.StatusCode);
-                AltinnValidationProblemDetails problemDetails = await updateResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+                AltinnValidationProblemDetails? problemDetails = await updateResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
                 Assert.NotNull(problemDetails);
                 AltinnValidationError error = problemDetails.Errors.Single(e => e.ErrorCode == ValidationErrors.SystemRegister_ResourceId_Duplicates.ErrorCode);
                 Assert.Equal("/registersystemrequest/rights/resource", error.Paths.Single(p => p.Equals("/registersystemrequest/rights/resource")));
@@ -644,7 +644,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 request.Content = content;
                 HttpResponseMessage updateResponse = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
                 Assert.Equal(System.Net.HttpStatusCode.BadRequest, updateResponse.StatusCode);
-                AltinnValidationProblemDetails problemDetails = await updateResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+                AltinnValidationProblemDetails? problemDetails = await updateResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
                 Assert.NotNull(problemDetails);
                 AltinnValidationError error = problemDetails.Errors.Single(e => e.ErrorCode == ValidationErrors.SystemRegister_AccessPackage_Duplicates.ErrorCode);
                 Assert.Equal("/registersystemrequest/accesspackages", error.Paths.Single(p => p.Equals("/registersystemrequest/accesspackages")));
@@ -680,7 +680,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 request.Content = content;
                 HttpResponseMessage updateResponse = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
                 Assert.Equal(System.Net.HttpStatusCode.BadRequest, updateResponse.StatusCode);
-                AltinnValidationProblemDetails problemDetails = await updateResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+                AltinnValidationProblemDetails? problemDetails = await updateResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
                 Assert.NotNull(problemDetails);
                 Assert.Single(problemDetails.Errors);
                 AltinnValidationError error = problemDetails.Errors.Single(e => e.ErrorCode == ValidationErrors.SystemRegister_ResourceId_DoesNotExist.ErrorCode);
@@ -711,7 +711,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
                 HttpRequestMessage request = new(HttpMethod.Get, $"/authentication/api/v1/systemregister");
                 HttpResponseMessage getAllResponse = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
-                List<RegisteredSystemDTO> list = JsonSerializer.Deserialize<List<RegisteredSystemDTO>>(await getAllResponse.Content.ReadAsStringAsync(), _options);
+                List<RegisteredSystemDTO>? list = JsonSerializer.Deserialize<List<RegisteredSystemDTO>>(await getAllResponse.Content.ReadAsStringAsync(), _options);
+                Assert.NotNull(list);
                 Assert.Equal(3, list.Count);
             }
         }
@@ -724,7 +725,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
             HttpRequestMessage request = new(HttpMethod.Get, $"/authentication/api/v1/systemregister");
             HttpResponseMessage getAllResponse = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
-            List<RegisteredSystemResponse> list = JsonSerializer.Deserialize<List<RegisteredSystemResponse>>(await getAllResponse.Content.ReadAsStringAsync(), _options);
+            List<RegisteredSystemResponse>? list = JsonSerializer.Deserialize<List<RegisteredSystemResponse>>(await getAllResponse.Content.ReadAsStringAsync(), _options);
+            Assert.NotNull(list);
             Assert.True(list.Count == 0);
         }
 
@@ -755,8 +757,9 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 
             HttpRequestMessage request = new(HttpMethod.Get, $"/authentication/api/v1/systemregister/vendor");
             HttpResponseMessage getAllResponse = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
-            List<RegisteredSystemDTO> list = JsonSerializer.Deserialize<List<RegisteredSystemDTO>>(await getAllResponse.Content.ReadAsStringAsync(), _options);
-            Assert.Single(list);            
+            List<RegisteredSystemDTO>? list = JsonSerializer.Deserialize<List<RegisteredSystemDTO>>(await getAllResponse.Content.ReadAsStringAsync(), _options);
+            Assert.NotNull(list);
+            Assert.Single(list);
         }
 
         [Fact]
@@ -766,7 +769,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
             HttpRequestMessage request = new(HttpMethod.Get, $"/authentication/api/v1/systemregister/vendor");
             HttpResponseMessage getAllResponse = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
-            List<RegisteredSystemResponse> list = JsonSerializer.Deserialize<List<RegisteredSystemResponse>>(await getAllResponse.Content.ReadAsStringAsync(), _options);
+            List<RegisteredSystemResponse>? list = JsonSerializer.Deserialize<List<RegisteredSystemResponse>>(await getAllResponse.Content.ReadAsStringAsync(), _options);
+            Assert.NotNull(list);
             Assert.True(list.Count == 0);
         }
 
@@ -789,12 +793,14 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 };
 
                 string systemRegister = File.OpenText("Data/SystemRegister/Json/SystemRegisterResponse.json").ReadToEnd();
-                RegisteredSystemResponse expectedRegisteredSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(systemRegister, options);
+                RegisteredSystemResponse? expectedRegisteredSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(systemRegister, options);
 
                 string systemId = "991825827_the_matrix";
                 HttpRequestMessage request = new(HttpMethod.Get, $"/authentication/api/v1/systemregister/vendor/{systemId}");
                 HttpResponseMessage getResponse = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
-                RegisteredSystemResponse actualRegisteredSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(await getResponse.Content.ReadAsStringAsync(), _options);
+                RegisteredSystemResponse? actualRegisteredSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(await getResponse.Content.ReadAsStringAsync(), _options);
+                Assert.NotNull(expectedRegisteredSystem);
+                Assert.NotNull(actualRegisteredSystem);
                 AssertionUtil.AssertRegisteredSystem(expectedRegisteredSystem, actualRegisteredSystem);
             }
         }
@@ -818,7 +824,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 };
 
                 string systemRegister = File.OpenText("Data/SystemRegister/Json/SystemRegisterResponse.json").ReadToEnd();
-                RegisteredSystemResponse expectedRegisteredSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(systemRegister, options);
+                RegisteredSystemResponse? expectedRegisteredSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(systemRegister, options);
 
                 string systemId = "991825827_the_matrix";
                 HttpRequestMessage request = new(HttpMethod.Get, $"/authentication/api/v1/systemregister/vendor/{systemId}");
@@ -846,12 +852,14 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 };
 
                 string systemRegisterDTO = File.OpenText("Data/SystemRegister/Json/SystemRegisterDtoResponse.json").ReadToEnd();
-                RegisteredSystemDTO expectedRegisteredSystem = JsonSerializer.Deserialize<RegisteredSystemDTO>(systemRegisterDTO, options);
+                RegisteredSystemDTO? expectedRegisteredSystem = JsonSerializer.Deserialize<RegisteredSystemDTO>(systemRegisterDTO, options);
 
                 string systemId = "991825827_the_matrix";
                 HttpRequestMessage request = new(HttpMethod.Get, $"/authentication/api/v1/systemregister/{systemId}");
                 HttpResponseMessage getResponse = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
-                RegisteredSystemDTO actualRegisteredSystem = JsonSerializer.Deserialize<RegisteredSystemDTO>(await getResponse.Content.ReadAsStringAsync(), _options);
+                RegisteredSystemDTO? actualRegisteredSystem = JsonSerializer.Deserialize<RegisteredSystemDTO>(await getResponse.Content.ReadAsStringAsync(), _options);
+                Assert.NotNull(expectedRegisteredSystem);
+                Assert.NotNull(actualRegisteredSystem);
                 AssertionUtil.AssertRegisteredSystemDTO(expectedRegisteredSystem, actualRegisteredSystem);
             }
         }
@@ -869,7 +877,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             };
 
             string systemRegister = File.OpenText("Data/SystemRegister/Json/SystemRegister.json").ReadToEnd();
-            RegisteredSystemResponse expectedRegisteredSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(systemRegister, options);
+            RegisteredSystemResponse? expectedRegisteredSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(systemRegister, options);
 
             string systemId = "991825827_the_matrix";
             HttpRequestMessage request = new(HttpMethod.Get, $"/authentication/api/v1/systemregister/vendor/{systemId}");
@@ -892,7 +900,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
                 HttpRequestMessage request = new(HttpMethod.Get, $"/authentication/api/v1/systemregister/{name}/rights");
                 HttpResponseMessage rightsResponse = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
-                List<Right> list = JsonSerializer.Deserialize<List<Right>>(await rightsResponse.Content.ReadAsStringAsync(), _options);
+                List<Right>? list = JsonSerializer.Deserialize<List<Right>>(await rightsResponse.Content.ReadAsStringAsync(), _options);
+                Assert.NotNull(list);
                 Assert.Equal("ske-krav-og-betalinger", list[0].Resource[0].Value);
                 Assert.True(list.Count == 1);
             }
@@ -918,7 +927,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
                 HttpRequestMessage request = new(HttpMethod.Get, $"/authentication/api/v1/systemregister/{name}/rights");
                 HttpResponseMessage rightsResponse = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
-                List<Right> list = JsonSerializer.Deserialize<List<Right>>(await rightsResponse.Content.ReadAsStringAsync(), _options);
+                List<Right>? list = JsonSerializer.Deserialize<List<Right>>(await rightsResponse.Content.ReadAsStringAsync(), _options);
+                Assert.NotNull(list);
 
                 // Assert
                 Assert.True(list.Count == 1);
@@ -952,7 +962,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
                 HttpRequestMessage request = new(HttpMethod.Get, $"/authentication/api/v1/systemregister/{name}/rights?useoldformatforapp=true");
                 HttpResponseMessage rightsResponse = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
-                List<Right> list = JsonSerializer.Deserialize<List<Right>>(await rightsResponse.Content.ReadAsStringAsync(), _options);
+                List<Right>? list = JsonSerializer.Deserialize<List<Right>>(await rightsResponse.Content.ReadAsStringAsync(), _options);
+                Assert.NotNull(list);
 
                 // Assert
                 Assert.True(list.Count == 1);
@@ -990,7 +1001,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
                 HttpRequestMessage request = new(HttpMethod.Get, $"/authentication/api/v1/systemregister/{name}/rights");
                 HttpResponseMessage rightsResponse = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
-                List<Right> list = JsonSerializer.Deserialize<List<Right>>(await rightsResponse.Content.ReadAsStringAsync(), _options);
+                List<Right>? list = JsonSerializer.Deserialize<List<Right>>(await rightsResponse.Content.ReadAsStringAsync(), _options);
+                Assert.NotNull(list);
 
                 // Assert
                 Assert.True(list.Count == 2);
@@ -1036,7 +1048,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
                 HttpRequestMessage request = new(HttpMethod.Get, $"/authentication/api/v1/systemregister/{name}/rights?useoldformatforapp=true");
                 HttpResponseMessage rightsResponse = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
-                List<Right> list = JsonSerializer.Deserialize<List<Right>>(await rightsResponse.Content.ReadAsStringAsync(), _options);
+                List<Right>? list = JsonSerializer.Deserialize<List<Right>>(await rightsResponse.Content.ReadAsStringAsync(), _options);
+                Assert.NotNull(list);
 
                 // Assert
                 Assert.True(list.Count == 2);
@@ -1091,7 +1104,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
                 HttpRequestMessage request = new(HttpMethod.Get, $"/authentication/api/v1/systemregister/{name}/accesspackages");
                 HttpResponseMessage responseMessage = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
-                List<AccessPackage> list = JsonSerializer.Deserialize<List<AccessPackage>>(await responseMessage.Content.ReadAsStringAsync(), _options);
+                List<AccessPackage>? list = JsonSerializer.Deserialize<List<AccessPackage>>(await responseMessage.Content.ReadAsStringAsync(), _options);
+                Assert.NotNull(list);
                 Assert.Equal("urn:altinn:accesspackage:skatt-naering", list[0].Urn);
                 Assert.True(list.Count == 3);
             }
@@ -1252,11 +1266,13 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage getSystemResponse = await GetSystemRegister(systemId);
             Assert.Equal(HttpStatusCode.OK, getSystemResponse.StatusCode);
 
-            RegisteredSystemResponse actualUpdatedSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(await getSystemResponse.Content.ReadAsStringAsync(), _options);
+            RegisteredSystemResponse? actualUpdatedSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(await getSystemResponse.Content.ReadAsStringAsync(), _options);
             string systemRegister = await File.OpenText("Data/SystemRegister/Json/SystemRegisterUpdateResponse.json").ReadToEndAsync();
-            RegisteredSystemResponse expectedRegisteredSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(systemRegister, options);
+            RegisteredSystemResponse? expectedRegisteredSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(systemRegister, options);
 
             // Assert updates were made
+            Assert.NotNull(expectedRegisteredSystem);
+            Assert.NotNull(actualUpdatedSystem);
             AssertionUtil.AssertRegisteredSystem(expectedRegisteredSystem, actualUpdatedSystem);
            
             HttpClient getClient = GetAuthenticatedClient(Write, ValidOrg);
@@ -1298,7 +1314,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                 request.Content = content;
                 HttpResponseMessage updateResponse = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
                 Assert.Equal(System.Net.HttpStatusCode.BadRequest, updateResponse.StatusCode);
-                AltinnValidationProblemDetails problemDetails = await updateResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+                AltinnValidationProblemDetails? problemDetails = await updateResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
                 Assert.NotNull(problemDetails);
                 Assert.Equal(2, problemDetails.Errors.Count);
                 AltinnValidationError error = problemDetails.Errors.Single(e => e.ErrorCode == ValidationErrors.SystemRegister_ResourceId_DoesNotExist.ErrorCode);
@@ -1481,7 +1497,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             request.Content = content;
             HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
-            AltinnValidationProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.Single(problemDetails.Errors);
             AltinnValidationError error = problemDetails.Errors.Single(e => e.ErrorCode == ValidationErrors.SystemRegister_AccessPackage_NotValid.ErrorCode);
@@ -1506,9 +1522,9 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
 
-            AltinnValidationProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
-            AltinnValidationError error = problemDetails.Errors.FirstOrDefault(e => e.ErrorCode == ValidationErrors.SystemRegister_IsVisible_With_NonAssignable_AccessPackage.ErrorCode);
+            AltinnValidationError? error = problemDetails.Errors.FirstOrDefault(e => e.ErrorCode == ValidationErrors.SystemRegister_IsVisible_With_NonAssignable_AccessPackage.ErrorCode);
             Assert.NotNull(error);
             Assert.Equal("/registersystemrequest/accesspackages", error.Paths.First(p => p.Equals("/registersystemrequest/accesspackages")));
             Assert.Equal(ValidationErrors.SystemRegister_IsVisible_With_NonAssignable_AccessPackage.Title, error.Title);
@@ -1533,7 +1549,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             Assert.Equal(HttpStatusCode.OK, getSystemResponse.StatusCode);
 
             // Assert new system contains the same clientId
-            RegisteredSystemResponse actualUpdatedSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(await getSystemResponse.Content.ReadAsStringAsync(), _options);
+            RegisteredSystemResponse? actualUpdatedSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(await getSystemResponse.Content.ReadAsStringAsync(), _options);
+            Assert.NotNull(actualUpdatedSystem);
             Assert.True(actualUpdatedSystem.ClientId.Count == clientIdsInFirstSystem.Count);
             Assert.Contains(clientIdsInFirstSystem[0], actualUpdatedSystem.ClientId[0]);
             Assert.True(actualUpdatedSystem.IsVisible);
@@ -1565,7 +1582,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             Assert.Equal(HttpStatusCode.OK, getSystemResponse.StatusCode);
 
             // verify the second one failed and did not update isVisible = true
-            RegisteredSystemResponse noneUpdatedSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(await getSystemResponse.Content.ReadAsStringAsync(), _options);
+            RegisteredSystemResponse? noneUpdatedSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(await getSystemResponse.Content.ReadAsStringAsync(), _options);
+            Assert.NotNull(noneUpdatedSystem);
             Assert.False(noneUpdatedSystem.IsVisible);
             Assert.Equal(noneUpdatedSystem.ClientId, clientIdsInFirstSystem);
         }
@@ -1592,7 +1610,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             Assert.Equal(HttpStatusCode.OK, getSystemResponse.StatusCode);
 
             // Assert all client ids were removed
-            RegisteredSystemResponse actualUpdatedSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(await getSystemResponse.Content.ReadAsStringAsync(), _options);
+            RegisteredSystemResponse? actualUpdatedSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(await getSystemResponse.Content.ReadAsStringAsync(), _options);
+            Assert.NotNull(actualUpdatedSystem);
             Assert.Empty(actualUpdatedSystem.ClientId);
         }
 
@@ -1612,7 +1631,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             var resp = await PutSystemRegisterAsync(updatedSystem, systemId);
             Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
 
-            AltinnValidationProblemDetails problemDetails = await resp.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await resp.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.Contains(problemDetails.Errors, e => e.ErrorCode == ValidationErrors.SystemRegister_Duplicate_ClientIds.ErrorCode);
         }
@@ -1638,7 +1657,8 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage responseGet = await GetSystemRegister(systemId);
             Assert.Equal(HttpStatusCode.OK, responseGet.StatusCode);
 
-            RegisteredSystemResponse actualUpdatedSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(await responseGet.Content.ReadAsStringAsync(), _options);
+            RegisteredSystemResponse? actualUpdatedSystem = JsonSerializer.Deserialize<RegisteredSystemResponse>(await responseGet.Content.ReadAsStringAsync(), _options);
+            Assert.NotNull(actualUpdatedSystem);
             Assert.True(actualUpdatedSystem.ClientId.Count == proposedUpdate.ClientId.Count);
             Assert.Equal(proposedUpdate.ClientId, actualUpdatedSystem.ClientId);
         }
@@ -1711,7 +1731,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             // Expecting bad request here
             HttpResponseMessage resp = await PutSystemRegisterAsync(updatedSystem, systemId);
             Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
-            AltinnValidationProblemDetails problemDetails = await resp.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await resp.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.Contains(problemDetails.Errors, e => e.ErrorCode == ValidationErrors.SystemRegister_ClientID_Exists.ErrorCode);
         }
@@ -1957,7 +1977,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
         private static string GetConfigPath()
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(AuthenticationControllerTests).Assembly.Location).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(AuthenticationControllerTests).Assembly.Location).LocalPath)!; // assembly location always has a directory
             return Path.Combine(unitTestFolder, $"../../../appsettings.test.json");
         }
 

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserClientDelegationControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserClientDelegationControllerTest.cs
@@ -191,10 +191,10 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpRequestMessage clientListRequest = new(HttpMethod.Get, $"/authentication/api/v1/enduser/systemuser/clients/available?agent=b8d4d4d9-680b-4905-90c1-47ac5ff0c0a4");
             clientListRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetClientDelegationToken(1337, null, "altinn:clientdelegations.read", 3, TestTime));
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
-            ClientInfoPaginated<ClientInfo> result = JsonSerializer.Deserialize<ClientInfoPaginated<ClientInfo>>(await clientListResponse.Content.ReadAsStringAsync(), _options);
+            ClientInfoPaginated<ClientInfo>? result = JsonSerializer.Deserialize<ClientInfoPaginated<ClientInfo>>(await clientListResponse.Content.ReadAsStringAsync(), _options);
 
             Assert.Equal(HttpStatusCode.OK, clientListResponse.StatusCode);
-            Assert.True(result is not null);
+            Assert.NotNull(result);
             Assert.True(result.Items.Count() > 0);
             Assert.True(result.Links.Next is null);
         }
@@ -235,7 +235,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.BadRequest, clientListResponse.StatusCode);
-            AltinnValidationProblemDetails problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.True(problemDetails.Errors.Count > 0);
             AltinnValidationError error1 = problemDetails.Errors.First(e => e.ErrorCode == ValidationErrors.SystemUser_SystemUserId_NotFound.ErrorCode);
@@ -253,7 +253,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.BadRequest, clientListResponse.StatusCode);
-            AltinnValidationProblemDetails problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.True(problemDetails.Errors.Count > 0);
             AltinnValidationError error1 = problemDetails.Errors.First(e => e.ErrorCode == ValidationErrors.SystemUser_Missing_SystemUserId.ErrorCode);
@@ -271,7 +271,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.BadRequest, clientListResponse.StatusCode);
-            AltinnValidationProblemDetails problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.True(problemDetails.Errors.Count > 0);
             AltinnValidationError error1 = problemDetails.Errors.First(e => e.ErrorCode == ValidationErrors.SystemUser_Invalid_SystemUserId.ErrorCode);
@@ -289,10 +289,10 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
                                                         "Bearer", 
                                                         PrincipalUtil.GetClientDelegationToken(1337, null, "altinn:clientdelegations.read", 3, TestTime));
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
-            ClientInfoPaginated<ClientInfo> result = JsonSerializer.Deserialize<ClientInfoPaginated<ClientInfo>>(await clientListResponse.Content.ReadAsStringAsync(), _options);
+            ClientInfoPaginated<ClientInfo>? result = JsonSerializer.Deserialize<ClientInfoPaginated<ClientInfo>>(await clientListResponse.Content.ReadAsStringAsync(), _options);
 
             Assert.Equal(HttpStatusCode.OK, clientListResponse.StatusCode);
-            Assert.True(result is not null);
+            Assert.NotNull(result);
             Assert.True(result.Items.Count() == 0);
             Assert.True(result.Links.Next is null);
         }
@@ -320,7 +320,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.NotFound, clientListResponse.StatusCode);
-            AltinnProblemDetails problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnProblemDetails? problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);            
             Assert.Equal("System Owner not Found", problemDetails.Title);
             Assert.Equal("No associated party information found for systemuser owner 123447789", problemDetails.Detail);
@@ -335,10 +335,10 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpRequestMessage clientListRequest = new(HttpMethod.Get, $"/authentication/api/v1/enduser/systemuser/clients/?agent=b8d4d4d9-680b-4905-90c1-47ac5ff0c0a4");
             clientListRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetClientDelegationToken(1337, null, "altinn:clientdelegations.read", 3, TestTime));
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
-            ClientInfoPaginated<ClientInfo> result = JsonSerializer.Deserialize<ClientInfoPaginated<ClientInfo>>(await clientListResponse.Content.ReadAsStringAsync(), _options);
+            ClientInfoPaginated<ClientInfo>? result = JsonSerializer.Deserialize<ClientInfoPaginated<ClientInfo>>(await clientListResponse.Content.ReadAsStringAsync(), _options);
 
             Assert.Equal(HttpStatusCode.OK, clientListResponse.StatusCode);
-            Assert.True(result is not null);
+            Assert.NotNull(result);
             Assert.True(result.Items.Count() > 0);
             Assert.Contains(result.Items, c => c.ClientId == new Guid("fd9d93c7-1dd7-45bc-9772-6ba977b3cd36"));
             Assert.Contains(result.Items, c => c.ClientOrganizationNumber == "313872076");
@@ -355,10 +355,10 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpRequestMessage clientListRequest = new(HttpMethod.Get, $"/authentication/api/v1/enduser/systemuser/clients/?agent=fd9d93c7-1dd7-45bc-9772-6ba977b3cd36");
             clientListRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetClientDelegationToken(1337, null, "altinn:clientdelegations.read", 3, TestTime));
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
-            ClientInfoPaginated<ClientInfo> result = JsonSerializer.Deserialize<ClientInfoPaginated<ClientInfo>>(await clientListResponse.Content.ReadAsStringAsync(), _options);
+            ClientInfoPaginated<ClientInfo>? result = JsonSerializer.Deserialize<ClientInfoPaginated<ClientInfo>>(await clientListResponse.Content.ReadAsStringAsync(), _options);
 
             Assert.Equal(HttpStatusCode.OK, clientListResponse.StatusCode);
-            Assert.True(result is not null);
+            Assert.NotNull(result);
             Assert.True(result.Items.Count() == 0);
         }
 
@@ -398,7 +398,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.BadRequest, clientListResponse.StatusCode);
-            AltinnValidationProblemDetails problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.True(problemDetails.Errors.Count > 0);
             AltinnValidationError error1 = problemDetails.Errors.First(e => e.ErrorCode == ValidationErrors.SystemUser_SystemUserId_NotFound.ErrorCode);
@@ -416,7 +416,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.BadRequest, clientListResponse.StatusCode);
-            AltinnValidationProblemDetails problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.True(problemDetails.Errors.Count > 0);
             AltinnValidationError error1 = problemDetails.Errors.First(e => e.ErrorCode == ValidationErrors.SystemUser_Missing_SystemUserId.ErrorCode);
@@ -434,7 +434,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.BadRequest, clientListResponse.StatusCode);
-            AltinnValidationProblemDetails problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.True(problemDetails.Errors.Count > 0);
             AltinnValidationError error1 = problemDetails.Errors.First(e => e.ErrorCode == ValidationErrors.SystemUser_Invalid_SystemUserId.ErrorCode);
@@ -452,7 +452,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.NotFound, clientListResponse.StatusCode);
-            AltinnProblemDetails problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnProblemDetails? problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.Equal("System Owner not Found", problemDetails.Title);
             Assert.Equal("No associated party information found for systemuser owner 123447789", problemDetails.Detail);
@@ -470,10 +470,10 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpRequestMessage clientListRequest = new(HttpMethod.Post, $"/authentication/api/v1/enduser/systemuser/clients/?agent={systemUserId}&client={clientId}");
             clientListRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetClientDelegationToken(1337, null, "altinn:clientdelegations.write", 3, TestTime));
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
-            ClientDelegationResponse clientDelegationResponse = JsonSerializer.Deserialize<ClientDelegationResponse>(await clientListResponse.Content.ReadAsStringAsync(), _options);
+            ClientDelegationResponse? clientDelegationResponse = JsonSerializer.Deserialize<ClientDelegationResponse>(await clientListResponse.Content.ReadAsStringAsync(), _options);
 
             Assert.Equal(HttpStatusCode.OK, clientListResponse.StatusCode);
-            Assert.True(clientDelegationResponse is not null);
+            Assert.NotNull(clientDelegationResponse);
             Assert.Equal(clientId, clientDelegationResponse.Client);
             Assert.Equal(systemUserId, clientDelegationResponse.Agent);
         }
@@ -491,7 +491,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
             Assert.Equal(HttpStatusCode.BadRequest, removeClientResponse.StatusCode);
 
-            AltinnValidationProblemDetails problemDetails = await removeClientResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await removeClientResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.True(problemDetails.Errors.Count > 1);
             AltinnValidationError error1 = problemDetails.Errors.First(e => e.ErrorCode == ValidationErrors.SystemUser_Missing_SystemUserId.ErrorCode);
@@ -533,7 +533,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
             Assert.Equal(HttpStatusCode.BadRequest, removeClientResponse.StatusCode);
 
-            AltinnValidationProblemDetails problemDetails = await removeClientResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await removeClientResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             AltinnValidationError error = problemDetails.Errors.First(e => e.ErrorCode == ValidationErrors.SystemUser_Invalid_SystemUserId.ErrorCode);
             Assert.Equal("?agent", error.Paths.First(p => p.Equals("?agent")));
@@ -571,7 +571,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
             Assert.Equal(HttpStatusCode.BadRequest, removeClientResponse.StatusCode);
 
-            AltinnValidationProblemDetails problemDetails = await removeClientResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await removeClientResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             AltinnValidationError error = problemDetails.Errors.First(e => e.ErrorCode == ValidationErrors.SystemUser_SystemUserId_NotFound.ErrorCode);
             Assert.Equal("?agent", error.Paths.First(p => p.Equals("?agent")));
@@ -605,7 +605,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.NotFound, clientListResponse.StatusCode);
-            AltinnProblemDetails problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnProblemDetails? problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.Equal("System Owner not Found", problemDetails.Title);
             Assert.Equal("No associated party information found for systemuser owner 123447789", problemDetails.Detail);
@@ -625,7 +625,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.Forbidden, clientListResponse.StatusCode);
-            AltinnProblemDetails problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnProblemDetails? problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.Equal("Forbidden", problemDetails.Title);
         }
@@ -644,7 +644,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.BadRequest, clientListResponse.StatusCode);
-            AltinnProblemDetails problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnProblemDetails? problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.Equal("Client not found.", problemDetails.Title);            
         }
@@ -661,10 +661,10 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpRequestMessage clientListRequest = new(HttpMethod.Delete, $"/authentication/api/v1/enduser/systemuser/clients/?agent={systemUserId}&client={clientId}");
             clientListRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetClientDelegationToken(1337, null, "altinn:clientdelegations.write", 3, TestTime));
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
-            ClientDelegationResponse clientDelegationResponse = JsonSerializer.Deserialize<ClientDelegationResponse>(await clientListResponse.Content.ReadAsStringAsync(), _options);
+            ClientDelegationResponse? clientDelegationResponse = JsonSerializer.Deserialize<ClientDelegationResponse>(await clientListResponse.Content.ReadAsStringAsync(), _options);
 
             Assert.Equal(HttpStatusCode.OK, clientListResponse.StatusCode);
-            Assert.True(clientDelegationResponse is not null);
+            Assert.NotNull(clientDelegationResponse);
             Assert.Equal(clientId, clientDelegationResponse.Client);
             Assert.Equal(systemUserId, clientDelegationResponse.Agent);
         }
@@ -681,7 +681,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
             Assert.Equal(HttpStatusCode.BadRequest, removeClientResponse.StatusCode);
 
-            AltinnValidationProblemDetails problemDetails = await removeClientResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await removeClientResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.True(problemDetails.Errors.Count > 1);
             AltinnValidationError error1 = problemDetails.Errors.First(e => e.ErrorCode == ValidationErrors.SystemUser_Missing_SystemUserId.ErrorCode);
@@ -706,7 +706,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
             Assert.Equal(HttpStatusCode.BadRequest, removeClientResponse.StatusCode);
 
-            AltinnValidationProblemDetails problemDetails = await removeClientResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await removeClientResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             AltinnValidationError error = problemDetails.Errors.First(e => e.ErrorCode == ValidationErrors.SystemUser_Invalid_SystemUserId.ErrorCode);
             Assert.Equal("?agent", error.Paths.First(p => p.Equals("?agent")));
@@ -727,7 +727,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
             Assert.Equal(HttpStatusCode.BadRequest, removeClientResponse.StatusCode);
 
-            AltinnValidationProblemDetails problemDetails = await removeClientResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnValidationProblemDetails? problemDetails = await removeClientResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             AltinnValidationError error = problemDetails.Errors.First(e => e.ErrorCode == ValidationErrors.SystemUser_SystemUserId_NotFound.ErrorCode);
             Assert.Equal("?agent", error.Paths.First(p => p.Equals("?agent")));
@@ -761,7 +761,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
 
             Assert.Equal(HttpStatusCode.NotFound, clientListResponse.StatusCode);
-            AltinnProblemDetails problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            AltinnProblemDetails? problemDetails = await clientListResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
             Assert.NotNull(problemDetails);
             Assert.Equal("System Owner not Found", problemDetails.Title);
             Assert.Equal("No associated party information found for systemuser owner 123447789", problemDetails.Detail);
@@ -776,10 +776,10 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             HttpRequestMessage clientListRequest = new(HttpMethod.Get, $"/authentication/api/v1/enduser/systemuser/agents?party={orgnummer}");
             clientListRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetClientDelegationToken(1337, null, "altinn:clientdelegations.read", 3, TestTime));
             HttpResponseMessage systemUsersResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
-            List<SystemUserInternalDTO> result = JsonSerializer.Deserialize<List<SystemUserInternalDTO>>(await systemUsersResponse.Content.ReadAsStringAsync(), _options);
+            List<SystemUserInternalDTO>? result = JsonSerializer.Deserialize<List<SystemUserInternalDTO>>(await systemUsersResponse.Content.ReadAsStringAsync(), _options);
 
             Assert.Equal(HttpStatusCode.OK, systemUsersResponse.StatusCode);
-            Assert.True(result is not null);
+            Assert.NotNull(result);
             Assert.True(result.Count() > 0);
         }
 

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserControllerTest.cs
@@ -2047,11 +2047,11 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, clientListResponse.StatusCode);
-            StandardSystemUserDelegations standardSystemUserDelegations = JsonSerializer.Deserialize<StandardSystemUserDelegations>(await clientListResponse.Content.ReadAsStringAsync(), _options);
+            StandardSystemUserDelegations? standardSystemUserDelegations = JsonSerializer.Deserialize<StandardSystemUserDelegations>(await clientListResponse.Content.ReadAsStringAsync(), _options);
             Assert.NotNull(standardSystemUserDelegations);
             Assert.True(standardSystemUserDelegations.AccessPackages.Count == 1);
             Assert.True(standardSystemUserDelegations.Rights.Count == 3);
-            Assert.True(standardSystemUserDelegations.Rights.Any(r => r.Resource != null && r.Resource.Any(a => a.Value == "app_ttd_endring-av-navn-v2")));
+            Assert.Contains(standardSystemUserDelegations.Rights, r => r.Resource != null && r.Resource.Any(a => a.Value == "app_ttd_endring-av-navn-v2"));
         }
 
         /// <summary>

--- a/test/Altinn.Platform.Authentication.Tests/Fakes/JwtCookiePostConfigureOptionsStub.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Fakes/JwtCookiePostConfigureOptionsStub.cs
@@ -13,7 +13,7 @@ namespace Altinn.Platform.Authentication.Tests.Fakes
     public class JwtCookiePostConfigureOptionsStub : IPostConfigureOptions<JwtCookieOptions>
     {
         /// <inheritdoc />
-        public void PostConfigure(string name, JwtCookieOptions options)
+        public void PostConfigure(string? name, JwtCookieOptions options)
         {
             if (string.IsNullOrEmpty(options.JwtCookieName))
             {

--- a/test/Altinn.Platform.Authentication.Tests/Filters/TrimStringActionFilterTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Filters/TrimStringActionFilterTests.cs
@@ -38,7 +38,7 @@ namespace Altinn.Platform.Authentication.Tests.Filters
                 ExternalRef = "  ext  ",
                 SystemId = "  sys  ",
                 PartyOrgNo = "\t123456789\t",
-                Rights = new List<string> { "Read", "Write" },
+                Rights = new List<string?> { "Read", "Write" },
                 RedirectUrl = "  https://example.com/  ",
                 FreeText = "  do not trim  "
             };
@@ -66,7 +66,7 @@ namespace Altinn.Platform.Authentication.Tests.Filters
                 ExternalRef = null,
                 SystemId = null,
                 PartyOrgNo = null,
-                Rights = new List<string>(),
+                Rights = new List<string?>(),
                 RedirectUrl = null,
                 FreeText = null
             };
@@ -110,7 +110,7 @@ namespace Altinn.Platform.Authentication.Tests.Filters
             // Arrange
             var model = new CreateRequestSystemUser
             {
-                Rights = new List<string> { "  Read  ", " Write ", null, "  " }
+                Rights = new List<string?> { "  Read  ", " Write ", null, "  " }
             };
 
             var context = CreateContext(model);
@@ -120,7 +120,7 @@ namespace Altinn.Platform.Authentication.Tests.Filters
             filter.OnActionExecuting(context);
 
             // Assert
-            Assert.Equal(new List<string> { "  Read  ", " Write ", null, "  " }, model.Rights);
+            Assert.Equal(new List<string?> { "  Read  ", " Write ", null, "  " }, model.Rights);
         }
 
         [Fact]
@@ -150,15 +150,15 @@ namespace Altinn.Platform.Authentication.Tests.Filters
 
         [Required]
         [JsonPropertyName("systemId")]
-        public string SystemId { get; set; }
+        public string? SystemId { get; set; }
 
         [Required]
         [JsonPropertyName("partyOrgNo")]
-        public string PartyOrgNo { get; set; }
+        public string? PartyOrgNo { get; set; }
 
         [Required]
         [JsonPropertyName("rights")]
-        public List<string> Rights { get; set; }
+        public List<string?>? Rights { get; set; }
 
         [JsonPropertyName("redirectUrl")]
         public string? RedirectUrl { get; set; }
@@ -169,6 +169,6 @@ namespace Altinn.Platform.Authentication.Tests.Filters
 
     public class ModelWithArray
     {
-        public string[] Tags { get; set; }
+        public string?[]? Tags { get; set; }
     }
 }

--- a/test/Altinn.Platform.Authentication.Tests/Helpers/DelegationHelperTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Helpers/DelegationHelperTests.cs
@@ -252,6 +252,7 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
             var result = await helper.ValidateDelegationRightsForAccessPackages(Guid.NewGuid(), "sys", requested, false, CancellationToken.None);
 
             // Assert
+            Assert.NotNull(result.Value);
             Assert.True(result.Value.CanDelegate);
             Assert.NotNull(result.Value.AccessPackages);
             Assert.Single(result.Value.AccessPackages);
@@ -354,7 +355,9 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
             var result = await helper.ValidateDelegationRightsForAccessPackages(Guid.NewGuid(), "sys", requested, false, CancellationToken.None);
 
             // Assert
+            Assert.NotNull(result.Value);
             Assert.True(result.Value.CanDelegate);
+            Assert.NotNull(result.Value.AccessPackages);
             Assert.Empty(result.Value.AccessPackages);
         }
 
@@ -382,7 +385,9 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
             var result = await helper.ValidateDelegationRightsForAccessPackages(Guid.NewGuid(), "sys", requested, false, CancellationToken.None);
 
             // Assert
+            Assert.NotNull(result.Value);
             Assert.True(result.Value.CanDelegate);
+            Assert.NotNull(result.Value.AccessPackages);
             Assert.Empty(result.Value.AccessPackages);
             accessManagementClient.Verify(
                 a => a.CheckDelegationAccessForAccessPackage(It.IsAny<Guid>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()),
@@ -412,7 +417,9 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
             var result = await helper.ValidateDelegationRightsForAccessPackages(Guid.NewGuid(), "sys", requested, false, CancellationToken.None);
 
             // Assert
+            Assert.NotNull(result.Value);
             Assert.True(result.Value.CanDelegate);
+            Assert.NotNull(result.Value.AccessPackages);
             Assert.All(result.Value.AccessPackages, p => Assert.Null(p.Urn));
         }
 
@@ -478,6 +485,7 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
             // Assert
             Assert.True(result.CanDelegate);
             Assert.NotNull(result.RightResponses);
+            Assert.NotNull(result.errors);
             Assert.Empty(result.errors);
             Assert.Single(result.RightResponses);
         }
@@ -504,6 +512,7 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
             // Assert
             Assert.False(result.CanDelegate);
             Assert.Null(result.RightResponses);
+            Assert.NotNull(result.errors);
             Assert.NotEmpty(result.errors);
             Assert.Contains(result.errors, e => e.Description == "Unknown Right");
         }
@@ -558,7 +567,9 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
 
             // Assert
             Assert.False(result.CanDelegate);
+            Assert.NotNull(result.RightResponses);
             Assert.Empty(result.RightResponses);
+            Assert.NotNull(result.errors);
             Assert.Empty(result.errors);
         }
 
@@ -622,6 +633,7 @@ namespace Altinn.Platform.Authentication.Helpers.Tests
             // Assert
             Assert.False(result.CanDelegate);
             Assert.NotNull(result.RightResponses);
+            Assert.NotNull(result.errors);
             Assert.NotEmpty(result.errors);
             Assert.Contains(result.errors, e => e.Description == "Delegation denied");
 

--- a/test/Altinn.Platform.Authentication.Tests/Helpers/OidcServerTestUtils.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Helpers/OidcServerTestUtils.cs
@@ -13,7 +13,7 @@ namespace Altinn.Platform.Authentication.Tests.Helpers
                 ["grant_type"] = "refresh_token",
                 ["refresh_token"] = refreshToken,
                 ["client_id"] = create.ClientId,
-                ["client_secret"] = testScenario.ClientSecret // assuming your test client has this
+                ["client_secret"] = testScenario.ClientSecret! // always set by OidcScenarioHelper.GetScenario
             };
             return refreshForm;
         }
@@ -21,7 +21,7 @@ namespace Altinn.Platform.Authentication.Tests.Helpers
         public static OidcClientCreate NewClientCreate(OidcTestScenario testScenario) =>
             new()
             {
-                ClientId = testScenario.DownstreamClientId,
+                ClientId = testScenario.DownstreamClientId!, // always set by OidcScenarioHelper.GetScenario
                 ClientName = "Test Client",
                 ClientType = ClientType.Confidential,
                 TokenEndpointAuthMethod = TokenEndpointAuthMethod.ClientSecretBasic,
@@ -43,7 +43,7 @@ namespace Altinn.Platform.Authentication.Tests.Helpers
                 ["grant_type"] = "authorization_code",
                 ["code"] = code,
                 ["redirect_uri"] = testScenario.DownstreamClientCallbackUrl,
-                ["client_id"] = testScenario.DownstreamClientId,
+                ["client_id"] = testScenario.DownstreamClientId!, // always set by OidcScenarioHelper.GetScenario
                 ["client_secret"] = testScenario.ClientSecret!,
                 ["code_verifier"] = testScenario.GetDownstreamCodeVerifier(),
             };

--- a/test/Altinn.Platform.Authentication.Tests/Helpers/SystemRegisterTestHelper.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Helpers/SystemRegisterTestHelper.cs
@@ -29,21 +29,22 @@ namespace Altinn.Platform.Authentication.Tests.Helpers
             return response;
         }
 
-        private static async Task<List<SystemChangeLog>> GetSystemChangeLog(HttpClient client, string systemId)
+        private static async Task<List<SystemChangeLog>?> GetSystemChangeLog(HttpClient client, string systemId)
         {
             HttpRequestMessage request = new(HttpMethod.Get, $"/authentication/api/v1/systemregister/vendor/{systemId}/changelog");
             HttpResponseMessage getResponse = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
 
-            List<SystemChangeLog> actualSystemChangeLog = JsonSerializer.Deserialize<List<SystemChangeLog>>(await getResponse.Content.ReadAsStringAsync(), _options);
+            List<SystemChangeLog>? actualSystemChangeLog = JsonSerializer.Deserialize<List<SystemChangeLog>>(await getResponse.Content.ReadAsStringAsync(), _options);
             return actualSystemChangeLog;
         }
 
         public static async Task GetAndAssertSystemChangeLog(HttpClient client, string systemId, string fileName)
         {
             string systemChangeLog = File.OpenText($"Data/SystemChangeLog/{fileName}.json").ReadToEnd();
-            List<SystemChangeLog> expectedSystemChangeLog = JsonSerializer.Deserialize<List<SystemChangeLog>>(systemChangeLog, _options);
+            List<SystemChangeLog>? expectedSystemChangeLog = JsonSerializer.Deserialize<List<SystemChangeLog>>(systemChangeLog, _options);
+            Assert.NotNull(expectedSystemChangeLog);
 
-            List<SystemChangeLog> actualSystemChangeLog = await GetSystemChangeLog(client, systemId);
+            List<SystemChangeLog>? actualSystemChangeLog = await GetSystemChangeLog(client, systemId);
             Assert.NotNull(actualSystemChangeLog);
             Assert.Equal(expectedSystemChangeLog.Count, actualSystemChangeLog.Count);
 

--- a/test/Altinn.Platform.Authentication.Tests/Helpers/TokenAssertsHelper.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Helpers/TokenAssertsHelper.cs
@@ -29,6 +29,7 @@ namespace Altinn.Platform.Authentication.Tests.Helpers
             Assert.True(IsBase64Url(tokenResponseDto.refresh_token!), "refresh_token must be base64url");
             Assert.True(tokenResponseDto.refresh_token_expires_in == 1800);
 
+            Assert.NotNull(tokenResponseDto.scope);
             Assert.Contains("openid", tokenResponseDto.scope.Split(' '));
             Assert.Contains("altinn:portal/enduser", tokenResponseDto.scope.Split(' '));
             AssertAccessToken(tokenResponseDto.access_token, testScenario, now);
@@ -43,6 +44,7 @@ namespace Altinn.Platform.Authentication.Tests.Helpers
             Assert.Equal("Bearer", tokenResponseDto.token_type);
             Assert.True(tokenResponseDto.expires_in > 0);
             Assert.NotNull(tokenResponseDto.id_token); // since openid scope was requested
+            Assert.NotNull(tokenResponseDto.scope);
             Assert.Contains("openid", tokenResponseDto.scope.Split(' '));
             Assert.Contains("altinn:portal/enduser", tokenResponseDto.scope.Split(' '));
             AssertAccessToken(tokenResponseDto.access_token, testScenario, now);

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/AccessManagementClientMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/AccessManagementClientMock.cs
@@ -87,10 +87,10 @@ public class AccessManagementClientMock: IAccessManagementClient
         string packagesData = File.OpenText("Data/Packages/packages.json").ReadToEnd();
         List<Package>? packages = JsonSerializer.Deserialize<List<Package>>(packagesData, options);
         package = packages?.FirstOrDefault(p => p.Urn.Contains(urnValue, StringComparison.OrdinalIgnoreCase));
-        return Task.FromResult(package);
+        return Task.FromResult(package!); // null when urn is not in test data; IAccessManagementClient declares non-nullable
     }
 
-    public Task<Package> GetPackage(string packageId)
+    public Task<Package?> GetPackage(string packageId)
     {
         Package? package = null;
         JsonSerializerOptions options = new JsonSerializerOptions
@@ -114,7 +114,7 @@ public class AccessManagementClientMock: IAccessManagementClient
         return Task.FromResult(true);
     }
 
-    public async Task<AuthorizedPartyExternal> GetPartyFromReporteeListIfExists(int partyId, string token)
+    public async Task<AuthorizedPartyExternal?> GetPartyFromReporteeListIfExists(int partyId, string token)
     {
         return new AuthorizedPartyExternal();
     }
@@ -205,7 +205,7 @@ public class AccessManagementClientMock: IAccessManagementClient
         return true;
     }
 
-    public async IAsyncEnumerable<Result<PackagePermission>> GetAccessPackagesForSystemUser(Guid partyUuId, Guid systemUserId, CancellationToken cancellationToken)
+    public async IAsyncEnumerable<Result<PackagePermission>> GetAccessPackagesForSystemUser(Guid partyUuId, Guid systemUserId, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         string dataFileName = string.Empty;
         if (partyUuId == new Guid("39c4f60a-d432-4672-820d-2825c4a0d881"))

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/AccessManagementClientMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/AccessManagementClientMock.cs
@@ -84,7 +84,7 @@ public class AccessManagementClientMock: IAccessManagementClient
             PropertyNameCaseInsensitive = true,
         };
 
-        string packagesData = File.OpenText("Data/Packages/packages.json").ReadToEnd();
+        string packagesData = File.ReadAllText("Data/Packages/packages.json");
         List<Package>? packages = JsonSerializer.Deserialize<List<Package>>(packagesData, options);
         package = packages?.FirstOrDefault(p => p.Urn.Contains(urnValue, StringComparison.OrdinalIgnoreCase));
         return Task.FromResult(package!); // null when urn is not in test data; IAccessManagementClient declares non-nullable
@@ -98,7 +98,7 @@ public class AccessManagementClientMock: IAccessManagementClient
             PropertyNameCaseInsensitive = true,
         };
 
-        string packagesData = File.OpenText("Data/Packages/packages.json").ReadToEnd();
+        string packagesData = File.ReadAllText("Data/Packages/packages.json");
         List<Package>? packages = JsonSerializer.Deserialize<List<Package>>(packagesData, options);
         package = packages?.FirstOrDefault(p => p.Urn.Contains(packageId, StringComparison.OrdinalIgnoreCase));
         return Task.FromResult(package);
@@ -328,7 +328,7 @@ public class AccessManagementClientMock: IAccessManagementClient
 
         // The data file mirrors the paginated response from Access Management's GetClients
         // endpoint ({ "links": {...}, "data": [ ... ] }), so deserialize the wrapper and take Data.
-        string clientData = File.OpenText("Data/Customers/systemusercustomerlist.json").ReadToEnd();
+        string clientData = File.ReadAllText("Data/Customers/systemusercustomerlist.json");
         PaginatedResult<List<ClientDelegationDto>>? paginated = JsonSerializer.Deserialize<PaginatedResult<List<ClientDelegationDto>>>(clientData, options);
         List<ClientDelegationDto> clients = paginated?.Data ?? [];
 

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/OidcProviderAdvancedMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/OidcProviderAdvancedMock.cs
@@ -34,7 +34,7 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
                 ClientId: clientId,
                 RedirectUri: redirectUri,
                 CodeVerifier: codeVerifier,
-                Handler: (_, _, _, _, _) => Task.FromResult(response),
+                Handler: (_, _, _, _, _) => Task.FromResult<OidcCodeResponse?>(response),
                 Name: "success"));
         }
 
@@ -61,7 +61,7 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
         /// <summary>
         /// The method under test: returns a configured response or throws if no matching rule exists.
         /// </summary>
-        public async Task<OidcCodeResponse?> GetTokens(
+        public async Task<OidcCodeResponse> GetTokens(
             string authorizationCode,
             OidcProvider provider,
             string redirect_uri,
@@ -81,7 +81,7 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
                     $"FakeOidcProvider: no rule matched (code='{authorizationCode}', clientId='{provider?.ClientId}', redirect_uri='{redirect_uri}', verifier='{codeVerifier ?? "<null>"}').");
             }
 
-            return await match.Handler(authorizationCode, provider, redirect_uri, codeVerifier, cancellationToken);
+            return (await match.Handler(authorizationCode, provider, redirect_uri, codeVerifier, cancellationToken))!; // failure rules deliberately return null to exercise caller null-handling
         }
 
         private sealed record Rule(

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/OrganisationsServiceMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/OrganisationsServiceMock.cs
@@ -18,7 +18,7 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
                     return "dibk";
                 default:
                     await Task.CompletedTask;
-                    return null;
+                    return null!; // interface is declared non-nullable but production service also returns null for unknown orgs
             }
         }
     }

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/PartiesClientMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/PartiesClientMock.cs
@@ -20,7 +20,7 @@ public class PartiesClientMock : IPartiesClient
     /// <inheritdoc/>
     public Task<Party> GetPartyAsync(int partyId, CancellationToken cancellationToken = default)
     {
-        return Task.FromResult(GetTestDataParties(GetPartiesPath()).Find(p => p.PartyId == partyId));
+        return Task.FromResult(GetTestDataParties(GetPartiesPath()).Find(p => p.PartyId == partyId)!); // null when partyId is not in test data; IPartiesClient declares non-nullable
     }
 
     private static List<Party> GetTestDataParties(string partiesPath)
@@ -30,7 +30,7 @@ public class PartiesClientMock : IPartiesClient
         if (File.Exists(partiesPath))
         {
             string content = File.ReadAllText(partiesPath);
-            partyList = JsonSerializer.Deserialize<List<Party>>(content);
+            partyList = JsonSerializer.Deserialize<List<Party>>(content) ?? [];
         }
 
         return partyList;
@@ -38,36 +38,36 @@ public class PartiesClientMock : IPartiesClient
 
     private static string GetPartiesPath()
     {
-        string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PartiesClientMock).Assembly.Location).LocalPath);
-        return Path.Combine(unitTestFolder, "Data", "Parties", "parties.json");
+        string? unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PartiesClientMock).Assembly.Location).LocalPath);
+        return Path.Combine(unitTestFolder!, "Data", "Parties", "parties.json"); // assembly location always has a directory
     }
 
     private static string GetCustomerPartiesPath()
     {
-        string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PartiesClientMock).Assembly.Location).LocalPath);
-        return Path.Combine(unitTestFolder, "Data", "Parties", "customerparties.json");
+        string? unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PartiesClientMock).Assembly.Location).LocalPath);
+        return Path.Combine(unitTestFolder!, "Data", "Parties", "customerparties.json"); // assembly location always has a directory
     }
 
     private static string GetMainUnitsPath(int subunitPartyId)
     {
-        string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PartiesClientMock).Assembly.Location).LocalPath);
-        return Path.Combine(unitTestFolder, "Data", "MainUnits", $"{subunitPartyId}", "mainunits.json");
+        string? unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PartiesClientMock).Assembly.Location).LocalPath);
+        return Path.Combine(unitTestFolder!, "Data", "MainUnits", $"{subunitPartyId}", "mainunits.json"); // assembly location always has a directory
     }
 
     private static string GetKeyRoleUnitsPaths(int userId)
     {
-        string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PartiesClientMock).Assembly.Location).LocalPath);
-        return Path.Combine(unitTestFolder, "Data", "KeyRoleUnits", $"{userId}", "keyroleunits.json");
+        string? unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PartiesClientMock).Assembly.Location).LocalPath);
+        return Path.Combine(unitTestFolder!, "Data", "KeyRoleUnits", $"{userId}", "keyroleunits.json"); // assembly location always has a directory
     }
 
-    public Task<Organization> GetOrganizationAsync(string partyOrgNo, CancellationToken cancellationToken = default)
+    public Task<Organization?> GetOrganizationAsync(string partyOrgNo, CancellationToken cancellationToken = default)
     {
         Organization organization = new()
         {
             OrgNumber = partyOrgNo,
         };
 
-        return Task.FromResult<Organization>(organization);
+        return Task.FromResult<Organization?>(organization);
     }
 
     public Task<Party> GetPartyByOrgNo(string orgNo, CancellationToken cancellationToken = default)
@@ -90,7 +90,7 @@ public class PartiesClientMock : IPartiesClient
 
         if (!string.IsNullOrEmpty(orgNo) && orgNo == "123447789")
         {
-            party = null;
+            party = null!; // deliberately null: tests use orgNo 123447789 to trigger "System Owner not Found"
         }
 
         return Task.FromResult<Party>(party);
@@ -109,7 +109,7 @@ public class PartiesClientMock : IPartiesClient
 
     public Task<Party> GetPartyByUuId(Guid partyUuId, CancellationToken cancellationToken = default)
     {
-        return Task.FromResult(GetTestDataParties(GetCustomerPartiesPath()).Find(p => p.PartyUuid == partyUuId));
+        return Task.FromResult(GetTestDataParties(GetCustomerPartiesPath()).Find(p => p.PartyUuid == partyUuId)!); // null when partyUuId is not in test data; IPartiesClient declares non-nullable
     }
 
     public async Task<Result<bool>> CheckIfUserHasRelationToPartyUuid()

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/PepWithPDPAuthorizationMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/PepWithPDPAuthorizationMock.cs
@@ -427,7 +427,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
             if (File.Exists(rolesPath))
             {
                 string content = File.ReadAllText(rolesPath);
-                roles = (List<Role>?)JsonConvert.DeserializeObject(content, typeof(List<Role>)) ?? new List<Role>();
+                roles = JsonConvert.DeserializeObject<List<Role>>(content) ?? new List<Role>();
             }
 
             return Task.FromResult(roles);
@@ -504,7 +504,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
             string instancePart = instanceId.Split('/')[1];
 
             string content = File.ReadAllText(Path.Combine(GetInstancePath(), $"{partyPart}/{instancePart}.json"));
-            Instance instance = (Instance)JsonConvert.DeserializeObject(content, typeof(Instance))!; // test data instance files always deserialize
+            Instance instance = JsonConvert.DeserializeObject<Instance>(content)!; // test data instance files always deserialize
             return instance;
         }
     }

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/PepWithPDPAuthorizationMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/PepWithPDPAuthorizationMock.cs
@@ -207,7 +207,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
 
             if (!resourceAttributeComplete)
             {
-                Instance instanceData = GetTestInstance(resourceAttributes.InstanceValue);
+                Instance instanceData = GetTestInstance(resourceAttributes.InstanceValue!); // incomplete resource requests in test data always include the instance id
 
                 if (string.IsNullOrEmpty(resourceAttributes.OrgValue))
                 {
@@ -338,7 +338,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
             return false;
         }
 
-        private async Task EnrichSubjectAttributes(XacmlContextRequest request, string resourceParty)
+        private async Task EnrichSubjectAttributes(XacmlContextRequest request, string? resourceParty)
         {
             // If there is no resource party then it is impossible to enrich roles
             if (string.IsNullOrEmpty(resourceParty))
@@ -427,7 +427,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
             if (File.Exists(rolesPath))
             {
                 string content = File.ReadAllText(rolesPath);
-                roles = (List<Role>)JsonConvert.DeserializeObject(content, typeof(List<Role>));
+                roles = (List<Role>?)JsonConvert.DeserializeObject(content, typeof(List<Role>)) ?? new List<Role>();
             }
 
             return Task.FromResult(roles);
@@ -435,7 +435,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
 
         private static string GetRolesPath(int userId, int resourcePartyId)
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PepWithPDPAuthorizationMock).Assembly.Location).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PepWithPDPAuthorizationMock).Assembly.Location).LocalPath)!; // assembly location always has a directory
             var fullRolePath = Path.Combine(unitTestFolder, "..", "..", "..", "Data", "Roles", "user_" + userId, "party_" + resourcePartyId, "roles.json");
             return fullRolePath;
         }
@@ -488,13 +488,13 @@ namespace Altinn.AccessManagement.Tests.Mocks
 
         private static string GetResourceAccessPolicyPath(string ressursid)
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PepWithPDPAuthorizationMock).Assembly.Location).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PepWithPDPAuthorizationMock).Assembly.Location).LocalPath)!; // assembly location always has a directory
             return Path.Combine(unitTestFolder, "..", "..", "..", "Data", "Xacml", "3.0", "ResourceRegistry", $"{ressursid}");
         }
 
         private static string GetInstancePath()
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PepWithPDPAuthorizationMock).Assembly.Location).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PepWithPDPAuthorizationMock).Assembly.Location).LocalPath)!; // assembly location always has a directory
             return Path.Combine(unitTestFolder, "..", "..", "..", "Data", "Instances");
         }
 
@@ -504,7 +504,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
             string instancePart = instanceId.Split('/')[1];
 
             string content = File.ReadAllText(Path.Combine(GetInstancePath(), $"{partyPart}/{instancePart}.json"));
-            Instance instance = (Instance)JsonConvert.DeserializeObject(content, typeof(Instance));
+            Instance instance = (Instance)JsonConvert.DeserializeObject(content, typeof(Instance))!; // test data instance files always deserialize
             return instance;
         }
     }

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/ProfileFileMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/ProfileFileMock.cs
@@ -26,7 +26,7 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
 
             if (profileLookup.Ssn != null)
             {
-                userProfile = profileList.Find(p => p.Party.SSN == profileLookup.Ssn) ?? new UserProfile
+                userProfile = profileList.Find(p => p.Party?.SSN == profileLookup.Ssn) ?? new UserProfile
                 {
                     Party = new Party() { SSN = profileLookup.Ssn },
                     UserId = profileLookup.UserId,

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/ProfileFileMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/ProfileFileMock.cs
@@ -26,28 +26,23 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
 
             if (profileLookup.Ssn != null)
             {
-                userProfile = profileList.Find(p => p.Party.SSN == profileLookup.Ssn);
-                if (userProfile == null)
+                userProfile = profileList.Find(p => p.Party.SSN == profileLookup.Ssn) ?? new UserProfile
                 {
-                    userProfile.Party = new Party() { SSN = profileLookup.Ssn };    
-                    userProfile.UserId = profileLookup.UserId;
-                    userProfile.UserUuid = Guid.NewGuid();
-                }
+                    Party = new Party() { SSN = profileLookup.Ssn },
+                    UserId = profileLookup.UserId,
+                    UserUuid = Guid.NewGuid()
+                };
 
                 return Task.FromResult(userProfile);
             }
             else if (profileLookup.UserId != 0)
             {
-                userProfile = profileList.Find(p => p.UserId == profileLookup.UserId);
-                if (userProfile == null)
+                userProfile = profileList.Find(p => p.UserId == profileLookup.UserId) ?? new UserProfile
                 {
-                    userProfile = new UserProfile
-                    {
-                        Party = new Party() { PartyId = profileLookup.UserId },
-                        UserId = profileLookup.UserId,
-                        UserUuid = Guid.NewGuid()
-                    };
-                }
+                    Party = new Party() { PartyId = profileLookup.UserId },
+                    UserId = profileLookup.UserId,
+                    UserUuid = Guid.NewGuid()
+                };
 
                 return Task.FromResult(userProfile);
             }
@@ -57,7 +52,7 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
 
         private static string GetUserProfilePath()
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PartiesClientMock).Assembly.Location).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PartiesClientMock).Assembly.Location).LocalPath)!; // assembly location always has a directory
             return Path.Combine(unitTestFolder, "Data", "UserProfile", "UserProfiles.json");
         }
     }

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/ResourceRegistryClientMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/ResourceRegistryClientMock.cs
@@ -55,41 +55,16 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
 
         public async Task<List<PolicyRightsDTO>> GetRights(string resourceId)
         {
-            string dataFileName = string.Empty;
             if (resourceId == "ske-krav-og-betalinger")
             {
-                List<PolicyRightsDTO> res = [];
-                dataFileName = "Data/ResourceRegistry/policyrightDTO-kravogbetaling.json";
-                string content = string.Empty;
-                try
-                {
-                    content = File.ReadAllText(dataFileName);
-                    res = (List<PolicyRightsDTO>?)JsonSerializer.Deserialize(content, typeof(List<PolicyRightsDTO>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
-                }
-                catch (Exception)
-                {
-                    throw;
-                }
-
-                return res;
+                string content = File.ReadAllText("Data/ResourceRegistry/policyrightDTO-kravogbetaling.json");
+                return JsonSerializer.Deserialize<List<PolicyRightsDTO>>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
             }
 
             if (resourceId == "ske-krav-og-betalinger-2")
             {
-                List<PolicyRightsDTO> res = [];
-                dataFileName = "Data/ResourceRegistry/policyrightDTO-kravogbetaling2.json";
-                string content = string.Empty;
-                try
-                {
-                    content = File.ReadAllText(dataFileName);
-                    res = (List<PolicyRightsDTO>?)JsonSerializer.Deserialize(content, typeof(List<PolicyRightsDTO>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
-                }
-                catch (Exception)
-                {
-                    throw;
-                }
-
-                return res;
+                string content = File.ReadAllText("Data/ResourceRegistry/policyrightDTO-kravogbetaling2.json");
+                return JsonSerializer.Deserialize<List<PolicyRightsDTO>>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
             }
 
             return null!; // interface declares a non-nullable list, but the mock mirrors the null returned for unknown resources

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/ResourceRegistryClientMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/ResourceRegistryClientMock.cs
@@ -64,13 +64,13 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
                 try
                 {
                     content = File.ReadAllText(dataFileName);
-                    res = (List<PolicyRightsDTO>)JsonSerializer.Deserialize(content, typeof(List<PolicyRightsDTO>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                    res = (List<PolicyRightsDTO>?)JsonSerializer.Deserialize(content, typeof(List<PolicyRightsDTO>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
                 }
                 catch (Exception)
                 {
                     throw;
-                }                
-                                
+                }
+
                 return res;
             }
 
@@ -82,7 +82,7 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
                 try
                 {
                     content = File.ReadAllText(dataFileName);
-                    res = (List<PolicyRightsDTO>)JsonSerializer.Deserialize(content, typeof(List<PolicyRightsDTO>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                    res = (List<PolicyRightsDTO>?)JsonSerializer.Deserialize(content, typeof(List<PolicyRightsDTO>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
                 }
                 catch (Exception)
                 {
@@ -92,7 +92,7 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
                 return res;
             }
 
-            return null;
+            return null!; // interface declares a non-nullable list, but the mock mirrors the null returned for unknown resources
         }
     }
 }

--- a/test/Altinn.Platform.Authentication.Tests/Models/Role.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Models/Role.cs
@@ -13,11 +13,11 @@ public class Role
     /// Gets or sets the role type
     /// </summary>
     [JsonProperty]
-    public string Type { get; set; }
+    public string Type { get; set; } = null!; // always populated by JSON deserialization of test data
 
     /// <summary>
     /// Gets or sets the role
     /// </summary>
     [JsonProperty]
-    public string Value { get; set; }
+    public string Value { get; set; } = null!; // always populated by JSON deserialization of test data
 }

--- a/test/Altinn.Platform.Authentication.Tests/Services/EFormidlingAccessValidatorTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Services/EFormidlingAccessValidatorTest.cs
@@ -95,7 +95,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
                It.IsAny<EventId>(),
                It.IsAny<It.IsAnyType>(),
                It.IsAny<Exception>(),
-               (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+               (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()),
               Times.Once);
 
             Assert.False(actual.Active);

--- a/test/Altinn.Platform.Authentication.Tests/Services/EventLogServiceTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Services/EventLogServiceTest.cs
@@ -99,7 +99,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
         public async Task QueueAuthenticationEvent_Error()
         {
             // Arrange
-            UserAuthenticationModel authenticatedUser = null;
+            UserAuthenticationModel authenticatedUser = null!; // deliberately null: testing guard clause
 
             Mock<IEventsQueueClient> queueMock = new();
             queueMock
@@ -122,7 +122,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
         public async Task QueueAuthenticationEvent_Token_Error()
         {
             // Arrange
-            string token = null;
+            string token = null!; // deliberately null: testing guard clause
 
             Mock<IEventsQueueClient> queueMock = new();
             queueMock
@@ -143,14 +143,14 @@ namespace Altinn.Platform.Authentication.Tests.Services
             queueMock.Verify(r => r.EnqueueAuthenticationEvent(It.IsAny<string>()), Times.Never);
         }
 
-        private static IEventLog GetEventLogService(IEventsQueueClient queueMock = null, TimeProvider timeProviderMock = null)
+        private static IEventLog GetEventLogService(IEventsQueueClient? queueMock = null, TimeProvider? timeProviderMock = null)
         {
             if (queueMock == null)
             {
                 queueMock = new EventsQueueClientMock();
             }
 
-            var service = new EventLogService(queueMock, timeProviderMock);
+            var service = new EventLogService(queueMock, timeProviderMock!); // every call site passes a time provider
             return service;
         }
 

--- a/test/Altinn.Platform.Authentication.Tests/Services/EventLogServiceTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Services/EventLogServiceTest.cs
@@ -143,14 +143,9 @@ namespace Altinn.Platform.Authentication.Tests.Services
             queueMock.Verify(r => r.EnqueueAuthenticationEvent(It.IsAny<string>()), Times.Never);
         }
 
-        private static IEventLog GetEventLogService(IEventsQueueClient? queueMock = null, TimeProvider? timeProviderMock = null)
+        private static IEventLog GetEventLogService(IEventsQueueClient queueMock, TimeProvider timeProviderMock)
         {
-            if (queueMock == null)
-            {
-                queueMock = new EventsQueueClientMock();
-            }
-
-            var service = new EventLogService(queueMock, timeProviderMock!); // every call site passes a time provider
+            var service = new EventLogService(queueMock, timeProviderMock);
             return service;
         }
 

--- a/test/Altinn.Platform.Authentication.Tests/Services/OrganisationServiceTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Services/OrganisationServiceTest.cs
@@ -52,7 +52,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
 
             // Act 
             string org = await orgService.LookupOrg("974760223");
-            _memoryCache.TryGetValue("organisationDictionary", out Dictionary<string, Organisation> actualCachedDictionary);
+            _memoryCache.TryGetValue("organisationDictionary", out Dictionary<string, Organisation>? actualCachedDictionary);
 
             // Assert
             Assert.Equal("dibk", org);
@@ -82,7 +82,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
             _memoryCache.Set(cacheKey, organisationDictionary);
             _generalSettingsMock.Setup(o => o.Value).Returns(new GeneralSettings { OrganisationRepositoryLocation = "https://mock.com/altinn-orgs.json", OidcRefreshTokenPepper = "YWRzZmFzZmRhc2ZzYWVmZWY=" });
 
-            OrganisationsService orgService = new OrganisationsService(null, _memoryCache, _loggerMock.Object, _generalSettingsMock.Object);
+            OrganisationsService orgService = new OrganisationsService(null!, _memoryCache, _loggerMock.Object, _generalSettingsMock.Object); // deliberately null: the org is served from cache, so no HTTP client is needed
 
             // Act
             string orgName = await orgService.LookupOrg("976029100");
@@ -120,7 +120,7 @@ namespace Altinn.Platform.Authentication.Tests.Services
             handlerMock.Protected()
                 .Setup<Task<HttpResponseMessage>>(
                     "SendAsync",
-                    ItExpr.Is<HttpRequestMessage>(p => p.RequestUri.ToString().Contains("altinn-orgs")),
+                    ItExpr.Is<HttpRequestMessage>(p => p.RequestUri!.ToString().Contains("altinn-orgs")),
                     ItExpr.IsAny<CancellationToken>())
                 .ReturnsAsync(orgsResponseMessage)
                 .Verifiable();

--- a/test/Altinn.Platform.Authentication.Tests/SyntheticPersonIdentifierTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/SyntheticPersonIdentifierTests.cs
@@ -44,7 +44,7 @@ namespace Altinn.Platform.Authentication.Tests
             Assert.False(SyntheticPersonIdentifier.IsSyntheticTenor(null));
         }
 
-        private static JwtSecurityToken TokenWithPid(string pid)
+        private static JwtSecurityToken TokenWithPid(string? pid)
         {
             var claims = new List<Claim>();
             if (pid != null)

--- a/test/Altinn.Platform.Authentication.Tests/Utils/AssertionUtil.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Utils/AssertionUtil.cs
@@ -33,6 +33,8 @@ namespace Altinn.Platform.Authentication.Tests.Utils
             Assert.Equal(expected.ClientId, actual.ClientId);
             Assert.Equal(expected.IsVisible, actual.IsVisible);
             Assert.Equal(expected.IsDeleted, actual.IsDeleted);
+            Assert.NotNull(expected.Rights);
+            Assert.NotNull(actual.Rights);
             Assert.Equal(expected.Rights.Count, actual.Rights.Count);
             Assert.Equal(expected.AllowedRedirectUrls, actual.AllowedRedirectUrls);
         }

--- a/test/Altinn.Platform.Authentication.Tests/Utils/IDProviderTestTokenUtil.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Utils/IDProviderTestTokenUtil.cs
@@ -128,7 +128,7 @@ namespace Altinn.Platform.Authentication.Tests.Utils
             List<Claim> claims = [];
             string issuer = "uidp.udir.no";
             claims.Add(new Claim("iss", issuer, ClaimValueTypes.String, issuer));
-            claims.Add(new Claim("sub", scenario.ExternalIdentity, ClaimValueTypes.String, issuer));
+            claims.Add(new Claim("sub", scenario.ExternalIdentity!, ClaimValueTypes.String, issuer)); // scenario test data always sets ExternalIdentity
             claims.Add(new Claim("scope", string.Join(' ', createdUpstreamLogingTransaction.Scopes), ClaimValueTypes.String, issuer));
             claims.Add(new Claim("nonce", createdUpstreamLogingTransaction.Nonce, ClaimValueTypes.String, issuer));
 
@@ -155,7 +155,7 @@ namespace Altinn.Platform.Authentication.Tests.Utils
             List<Claim> claims = [];
             string issuer = "uidp.udir.no";
             claims.Add(new Claim("iss", issuer, ClaimValueTypes.String, issuer));
-            claims.Add(new Claim("sub", scenario.ExternalIdentity, ClaimValueTypes.String, issuer));
+            claims.Add(new Claim("sub", scenario.ExternalIdentity!, ClaimValueTypes.String, issuer)); // scenario test data always sets ExternalIdentity
             claims.Add(new Claim("scope", string.Join(' ', createdUpstreamLogingTransaction.Scopes), ClaimValueTypes.String, issuer));
 
             if (scenario.ProviderClaims != null)

--- a/test/Altinn.Platform.Authentication.Tests/Utils/OidcScenarioHelper.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Utils/OidcScenarioHelper.cs
@@ -16,7 +16,8 @@ namespace Altinn.Platform.Authentication.Tests.Utils
             if (File.Exists(path))
             {
                 string content = File.ReadAllText(path);
-                scenario = System.Text.Json.JsonSerializer.Deserialize<OidcTestScenario>(content);
+                scenario = System.Text.Json.JsonSerializer.Deserialize<OidcTestScenario>(content)
+                    ?? throw new InvalidOperationException($"Failed to deserialize scenario file: {path}");
             }
             else
             {
@@ -55,7 +56,7 @@ namespace Altinn.Platform.Authentication.Tests.Utils
 
         private static string GetOidcScenarioPath(string scenario)
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PartiesClientMock).Assembly.Location).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PartiesClientMock).Assembly.Location).LocalPath)!; // assembly location always has a directory
             return Path.Combine(unitTestFolder, "Data", "OidcScenarios", $"{scenario.ToLower()}.json");
         }
     }

--- a/test/Altinn.Platform.Authentication.Tests/Utils/PrincipalUtil.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Utils/PrincipalUtil.cs
@@ -149,7 +149,7 @@ namespace Altinn.Platform.Authentication.Tests.Utils
             return new ClaimsPrincipal(identity);
         }
 
-        public static string GetClientDelegationToken(int userId, List<Claim> claims, string scopes, int authenticationLevel = 2, DateTimeOffset? now = null)
+        public static string GetClientDelegationToken(int userId, List<Claim>? claims, string scopes, int authenticationLevel = 2, DateTimeOffset? now = null)
         {
             if (now == null)
             {

--- a/test/Altinn.Platform.Authentication.Tests/WebApplicationTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/WebApplicationTests.cs
@@ -29,8 +29,8 @@ public abstract class WebApplicationTests
         _webApplicationFixture = webApplicationFixture;
     }
 
-    private WebApplicationFactory<Program> _webApp;
-    private IServiceProvider _services;
+    private WebApplicationFactory<Program> _webApp = null!; // set in IAsyncLifetime.InitializeAsync
+    private IServiceProvider _services = null!; // set in IAsyncLifetime.InitializeAsync
     private AsyncServiceScope _scope;
     private DbFixture.OwnedDb? _db;
 


### PR DESCRIPTION
## Summary

Tests iteration 4 of the #488 warning ratchet — the final iteration for the Tests project. Fixes all **323** remaining warnings (nullable `CS86xx` + `xUnit1012`/`xUnit2012`) and **locks the project with `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`** (same pattern as Persistance #2106 and SystemIntegrationTests #2110).

### Fix conventions (per the review guidance on #488)

- Possibly-null deserialize/response results → nullable locals + `Assert.NotNull(x)` before first dereference (xUnit's `[NotNull]` annotation narrows flow analysis).
- `= null!` only for members always set by test lifecycle (`ConfigureServices`/`InitializeAsync`), each with a trailing justification comment.
- Deliberate-null guard-clause tests keep their semantics via `null!; // deliberately null: testing guard clause`.
- Mocks keep production interface signatures untouched; where returning null is load-bearing test behavior against a non-nullable signature, `!` with an explanatory trailing comment.
- `PrincipalUtil.GetClientDelegationToken(claims)` made nullable (test utility; mirrors the existing `GetToken` overload) instead of 31 `null!` call sites.

### Behavior-adjacent changes reviewers should eyeball

- **`ProfileFileMock` SSN branch**: the old lookup-miss path was a guaranteed `NullReferenceException` (assigned into the null it had just detected); it now constructs a fallback `UserProfile`, mirroring the UserId branch. No passing test could have relied on the old path.
- Two asserts got slightly **stronger**: a `Debug.Assert(tokenResult != null)` became a real `Assert.NotNull` (runs in Release too), and `AssertAutorizeRequestResult` now asserts `upstreamState` is non-null instead of letting null flow onward.
- `AccessManagementClientMock.GetAccessPackagesForSystemUser` gained `[EnumeratorCancellation]` (CS8425), matching its sibling method.

## Verification

- Debug build (matches CI, StyleCop active) with WarnAsError enabled: **Build succeeded, 0 errors** — the Tests project is at zero warnings and can no longer regress.
- Full test suite run locally against podman: **494 passed, 0 failed, 2 skipped** (pre-existing skips).

With this merged, three of six projects are locked (Persistance, SystemIntegrationTests, Tests). Remaining: Integration (#2109), Core (~410), host (~532), then root `Directory.Build.props` + CI `-warnaserror`.

Part of #488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded nullable reference handling across authentication, authorization, OIDC, system registration, delegation, and controller integration/unit tests.
  * Added/strengthened null checks and assertions for deserialized payloads, collections, token scopes, and returned result containers.
  * Improved robustness of test helpers and mocks when test data is missing or optional.

* **Chores**
  * Enabled stricter test build behavior by treating compiler warnings as errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->