### PR TITLE
chore(integration): clear warnings + enable WarnAsError (#488)

### DIFF
--- a/src/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/Controllers/AuthenticationController.cs
@@ -260,7 +260,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 Guid partyUuid = AuthenticationHelper.GetPartyUuId(HttpContext);
                 if (partyUuid != Guid.Empty)
                 {
-                    Party party = await _partiesClient.GetPartyByUuId(partyUuid, cancellationToken);
+                    Party? party = await _partiesClient.GetPartyByUuId(partyUuid, cancellationToken);
                     if (party != null && !string.IsNullOrWhiteSpace(party.SSN))
                     {
                         ClaimsIdentity? identity = principal.Identity as ClaimsIdentity;

--- a/src/Authentication/Controllers/SystemUserClientDelegationController.cs
+++ b/src/Authentication/Controllers/SystemUserClientDelegationController.cs
@@ -55,7 +55,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 return errorResult;
             }
 
-            Party party = await PartiesClient.GetPartyByOrgNo(systemUser.ReporteeOrgNo);
+            Party? party = await PartiesClient.GetPartyByOrgNo(systemUser.ReporteeOrgNo);
 
             if (party is null)
             {
@@ -114,7 +114,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 return errorResult;
             }
 
-            Party party = await PartiesClient.GetPartyByOrgNo(systemUser.ReporteeOrgNo);
+            Party? party = await PartiesClient.GetPartyByOrgNo(systemUser.ReporteeOrgNo);
             if (party is null)
             {
                 return NotFound(new ProblemDetails
@@ -177,7 +177,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 return errorResult;
             }
 
-            Party party = await PartiesClient.GetPartyByOrgNo(systemUser.ReporteeOrgNo);
+            Party? party = await PartiesClient.GetPartyByOrgNo(systemUser.ReporteeOrgNo);
             if (party is null)
             {
                 return NotFound(new ProblemDetails
@@ -240,7 +240,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 return errorResult;
             }
 
-            Party party = await PartiesClient.GetPartyByOrgNo(systemUser.ReporteeOrgNo);
+            Party? party = await PartiesClient.GetPartyByOrgNo(systemUser.ReporteeOrgNo);
             if (party is null)
             {
                 return NotFound(new ProblemDetails
@@ -288,7 +288,7 @@ namespace Altinn.Platform.Authentication.Controllers
         [Authorize(Policy = AuthzConstants.POLICY_CLIENTDELEGATION_READ)]
         public async Task<ActionResult<List<SystemUserInternalDTO>>> GetAllAgentSystemUsersForParty([FromQuery] string party)
         {
-            Party partyInfo = await PartiesClient.GetPartyByOrgNo(party);
+            Party? partyInfo = await PartiesClient.GetPartyByOrgNo(party);
             if (partyInfo is null)
             {
                 return NotFound(new ProblemDetails

--- a/src/Authentication/Services/ChangeRequestSystemUserService.cs
+++ b/src/Authentication/Services/ChangeRequestSystemUserService.cs
@@ -271,7 +271,7 @@ public class ChangeRequestSystemUserService(
     /// <inheritdoc/>
     public async Task<Result<ChangeRequestResponse>> GetChangeRequestByPartyAndRequestId(int partyId, Guid requestId)
     {
-        Party party = await partiesClient.GetPartyAsync(partyId);
+        Party? party = await partiesClient.GetPartyAsync(partyId);
         if (party is null)
         {
             return Problem.Reportee_Orgno_NotFound;
@@ -335,7 +335,7 @@ public class ChangeRequestSystemUserService(
             return Problem.SystemUserNotFound;
         }
 
-        Party party = await partiesClient.GetPartyAsync(partyId, cancellationToken);
+        Party? party = await partiesClient.GetPartyAsync(partyId, cancellationToken);
 
         if (party is null || string.IsNullOrEmpty(party.OrgNumber))
         {
@@ -579,7 +579,7 @@ public class ChangeRequestSystemUserService(
 
         ChangeRequestStatus changeRequestStatus = ChangeRequestStatus.NoChangeNeeded;
 
-        Party party = await partiesClient.GetPartyByOrgNo(systemUser.ReporteeOrgNo);
+        Party? party = await partiesClient.GetPartyByOrgNo(systemUser.ReporteeOrgNo);
 
         if (party is null || party.PartyUuid is null)
         {
@@ -903,9 +903,9 @@ public class ChangeRequestSystemUserService(
 
         IEnumerable<Claim> claims = context.User.Claims;
 
-        Party party = await partiesClient.GetPartyByOrgNo(req.PartyOrgNo);
+        Party? party = await partiesClient.GetPartyByOrgNo(req.PartyOrgNo);
 
-        if (!party.PartyUuid.HasValue)
+        if (party?.PartyUuid is null)
         {
             return Problem.Reportee_Orgno_NotFound;
         }

--- a/src/Authentication/Services/RequestSystemUserService.cs
+++ b/src/Authentication/Services/RequestSystemUserService.cs
@@ -450,7 +450,7 @@ public class RequestSystemUserService(
     /// <inheritdoc/>
     public async Task<Result<RequestSystemResponse>> GetRequestByPartyAndRequestId(int partyId, Guid requestId)
     {
-        Party party = await partiesClient.GetPartyAsync(partyId);
+        Party? party = await partiesClient.GetPartyAsync(partyId);
         if (party is null)
         {
             return Problem.Reportee_Orgno_NotFound;
@@ -487,7 +487,7 @@ public class RequestSystemUserService(
     /// <inheritdoc/>
     public async Task<Result<AgentRequestSystemResponse>> GetAgentRequestByPartyAndRequestId(int partyId, Guid requestId)
     {
-        Party party = await partiesClient.GetPartyAsync(partyId);
+        Party? party = await partiesClient.GetPartyAsync(partyId);
         if (party is null)
         {
             return Problem.Reportee_Orgno_NotFound;
@@ -914,9 +914,9 @@ public class RequestSystemUserService(
 
         IEnumerable<Claim> claims = context.User.Claims;
 
-        Party party = await partiesClient.GetPartyByOrgNo(orgNo);
+        Party? party = await partiesClient.GetPartyByOrgNo(orgNo);
 
-        if (!party.PartyUuid.HasValue)
+        if (party?.PartyUuid is null)
         {
             return Problem.Reportee_Orgno_NotFound;
         }
@@ -988,7 +988,7 @@ public class RequestSystemUserService(
 
     private async Task<Result<bool>> ValidatePartyRequest(int partyId, Guid requestId, SystemUserType userType, CancellationToken cancellationToken)
     {
-        Party party = await partiesClient.GetPartyAsync(partyId, cancellationToken);
+        Party? party = await partiesClient.GetPartyAsync(partyId, cancellationToken);
         if (party is null)
         {
             return Problem.Reportee_Orgno_NotFound;

--- a/src/Authentication/Services/SystemUserService.cs
+++ b/src/Authentication/Services/SystemUserService.cs
@@ -76,7 +76,7 @@ namespace Altinn.Platform.Authentication.Services
                 return Problem.SystemIdNotFound;
             }
 
-            Party party = await _partiesClient.GetPartyAsync(int.Parse(partyId));
+            Party? party = await _partiesClient.GetPartyAsync(int.Parse(partyId));
 
             if (party is null || string.IsNullOrEmpty(party.OrgNumber))
             {
@@ -164,7 +164,7 @@ namespace Altinn.Platform.Authentication.Services
         /// <returns>Boolean True if row affected</returns>
         public async Task<Result<bool>> SetDeleteFlagOnSystemUser(string partyId, Guid systemUserId, CancellationToken cancellationToken = default)
         {
-            Party party = await _partiesClient.GetPartyAsync(int.Parse(partyId), cancellationToken);
+            Party? party = await _partiesClient.GetPartyAsync(int.Parse(partyId), cancellationToken);
 
             if (party is null || string.IsNullOrEmpty(party.OrgNumber))
             {
@@ -325,7 +325,7 @@ namespace Altinn.Platform.Authentication.Services
                 return Problem.SystemIdNotFound;
             }
 
-            Party party = await _partiesClient.GetPartyAsync(int.Parse(partyId), cancellationToken);
+            Party? party = await _partiesClient.GetPartyAsync(int.Parse(partyId), cancellationToken);
 
             if (party is null || string.IsNullOrEmpty(party.OrgNumber))
             {
@@ -423,7 +423,7 @@ namespace Altinn.Platform.Authentication.Services
                 return Problem.SystemIdNotFound;
             }
 
-            Party party = await _partiesClient.GetPartyAsync(int.Parse(partyId), cancellationToken);
+            Party? party = await _partiesClient.GetPartyAsync(int.Parse(partyId), cancellationToken);
 
             if (party is null || string.IsNullOrEmpty(party.OrgNumber))
             {
@@ -713,17 +713,17 @@ namespace Altinn.Platform.Authentication.Services
                 if (found)
                 {
                     string urnValue = accessPackage.Urn!;
-                    Package package = await _accessManagementClient.GetAccessPackage(urnValue);
+                    Package? package = await _accessManagementClient.GetAccessPackage(urnValue);
                     if (isAgentRequest)
                     {
-                        if (!package.IsDelegable)
+                        if (package is null || !package.IsDelegable)
                         {
                             notDelegablePackages.Add(accessPackage.Urn!);
                         }
                     }
                     else
                     {
-                        if (!package.IsAssignable)
+                        if (package is null || !package.IsAssignable)
                         {
                             notDelegablePackages.Add(accessPackage.Urn!);
                         }
@@ -1036,10 +1036,10 @@ namespace Altinn.Platform.Authentication.Services
         /// <inheritdoc/>
         public async Task<Result<List<DelegationResponse>>> GetListOfDelegationsForAgentSystemUser(int partyId, Guid facilitator, Guid systemUserId, Guid? client = null)
         {
-            Party party = await _partiesClient.GetPartyAsync(partyId);
+            Party? party = await _partiesClient.GetPartyAsync(partyId);
             List<DelegationResponse> found = [];
 
-            if (party.PartyUuid != facilitator)
+            if (party?.PartyUuid != facilitator)
             {
                 return Problem.AgentSystemUser_DelegationNotFound;
             }
@@ -1153,7 +1153,7 @@ namespace Altinn.Platform.Authentication.Services
                 return Problem.SystemUserNotFound;
             }
 
-            Party party = await _partiesClient.GetPartyAsync(partyId, cancellationToken);
+            Party? party = await _partiesClient.GetPartyAsync(partyId, cancellationToken);
 
             if (party is null || string.IsNullOrEmpty(party.OrgNumber))
             {
@@ -1316,7 +1316,7 @@ namespace Altinn.Platform.Authentication.Services
 
         private async Task<Result<Guid>> GetPartyUuId(int partyId, CancellationToken cancellationToken)
         {
-            Party party = await _partiesClient.GetPartyAsync(partyId, cancellationToken);
+            Party? party = await _partiesClient.GetPartyAsync(partyId, cancellationToken);
 
             if (party is null || string.IsNullOrEmpty(party.OrgNumber))
             {

--- a/src/Core/Clients/Interfaces/IPartiesClient.cs
+++ b/src/Core/Clients/Interfaces/IPartiesClient.cs
@@ -23,24 +23,24 @@ public interface IPartiesClient
     /// </summary>
     /// <param name="partyId">The party ID to lookup</param>
     /// <param name="cancellationToken">The cancellation token<see cref="CancellationToken"/></param>
-    /// <returns>party information</returns>
-    Task<Party> GetPartyAsync(int partyId, CancellationToken cancellationToken = default);
+    /// <returns>party information, or <see langword="null"/> if Register did not return the party</returns>
+    Task<Party?> GetPartyAsync(int partyId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns partyInfo
     /// </summary>
     /// <param name="orgNo">The OrgNo to lookup</param>
     /// <param name="cancellationToken">The cancellation token<see cref="CancellationToken"/></param>
-    /// <returns>party information</returns>
-    Task<Party> GetPartyByOrgNo(string orgNo, CancellationToken cancellationToken = default);
+    /// <returns>party information, or <see langword="null"/> if Register did not return the party</returns>
+    Task<Party?> GetPartyByOrgNo(string orgNo, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns partyInfo
     /// </summary>
     /// <param name="partyUuId">The party uuid to lookup</param>
     /// <param name="cancellationToken">The cancellation token<see cref="CancellationToken"/></param>
-    /// <returns>party information</returns>
-    Task<Party> GetPartyByUuId(Guid partyUuId, CancellationToken cancellationToken = default);
+    /// <returns>party information, or <see langword="null"/> if Register did not return the party</returns>
+    Task<Party?> GetPartyByUuId(Guid partyUuId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Looks up a person party in Register by national identity number (SSN), returning a minimal

--- a/src/Integration/AccessManagement/IAccessManagementClient.cs
+++ b/src/Integration/AccessManagement/IAccessManagementClient.cs
@@ -67,8 +67,8 @@ public interface IAccessManagementClient
     /// Retrieves the access package for the given urn value
     /// </summary>
     /// <param name="urnValue">the urn for the package</param>
-    /// <returns>package</returns>
-    Task<Package> GetAccessPackage(string urnValue);
+    /// <returns>the package, or <see langword="null"/> if no package matches the urn</returns>
+    Task<Package?> GetAccessPackage(string urnValue);
 
     /// <summary>
     /// Revokes the assignment of

--- a/src/Integration/Altinn.Platform.Authentication.Integration.csproj
+++ b/src/Integration/Altinn.Platform.Authentication.Integration.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Integration/Clients/PartiesClient.cs
+++ b/src/Integration/Clients/PartiesClient.cs
@@ -65,7 +65,7 @@ public class PartiesClient : IPartiesClient
     }
 
     /// <inheritdoc/>
-    public async Task<Party> GetPartyAsync(int partyId, CancellationToken cancellationToken = default)
+    public async Task<Party?> GetPartyAsync(int partyId, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -93,7 +93,7 @@ public class PartiesClient : IPartiesClient
     }
 
     /// <inheritdoc/>
-    public async Task<Party> GetPartyByUuId(Guid partyUuId, CancellationToken cancellationToken = default)
+    public async Task<Party?> GetPartyByUuId(Guid partyUuId, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -121,7 +121,7 @@ public class PartiesClient : IPartiesClient
     }
 
     /// <inheritdoc/>
-    public async Task<Party> GetPartyByOrgNo(string orgNo, CancellationToken cancellationToken = default)
+    public async Task<Party?> GetPartyByOrgNo(string orgNo, CancellationToken cancellationToken = default)
     {
         try
         {

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/AccessManagementClientMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/AccessManagementClientMock.cs
@@ -76,7 +76,7 @@ public class AccessManagementClientMock: IAccessManagementClient
         }
     }
 
-    public Task<Package> GetAccessPackage(string urnValue)
+    public Task<Package?> GetAccessPackage(string urnValue)
     {
         Package? package = null;
         JsonSerializerOptions options = new JsonSerializerOptions
@@ -87,7 +87,7 @@ public class AccessManagementClientMock: IAccessManagementClient
         string packagesData = File.ReadAllText("Data/Packages/packages.json");
         List<Package>? packages = JsonSerializer.Deserialize<List<Package>>(packagesData, options);
         package = packages?.FirstOrDefault(p => p.Urn.Contains(urnValue, StringComparison.OrdinalIgnoreCase));
-        return Task.FromResult(package!); // null when urn is not in test data; IAccessManagementClient declares non-nullable
+        return Task.FromResult(package);
     }
 
     public Task<Package?> GetPackage(string packageId)

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/PartiesClientMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/PartiesClientMock.cs
@@ -18,9 +18,9 @@ namespace Altinn.Authentication.Tests.Mocks;
 public class PartiesClientMock : IPartiesClient
 {
     /// <inheritdoc/>
-    public Task<Party> GetPartyAsync(int partyId, CancellationToken cancellationToken = default)
+    public Task<Party?> GetPartyAsync(int partyId, CancellationToken cancellationToken = default)
     {
-        return Task.FromResult(GetTestDataParties(GetPartiesPath()).Find(p => p.PartyId == partyId)!); // null when partyId is not in test data; IPartiesClient declares non-nullable
+        return Task.FromResult(GetTestDataParties(GetPartiesPath()).Find(p => p.PartyId == partyId));
     }
 
     private static List<Party> GetTestDataParties(string partiesPath)
@@ -70,9 +70,9 @@ public class PartiesClientMock : IPartiesClient
         return Task.FromResult<Organization?>(organization);
     }
 
-    public Task<Party> GetPartyByOrgNo(string orgNo, CancellationToken cancellationToken = default)
+    public Task<Party?> GetPartyByOrgNo(string orgNo, CancellationToken cancellationToken = default)
     {
-        Party party = new Party();
+        Party? party = new Party();
         party.PartyId = 500000;
         party.PartyUuid = new Guid("00000000-0000-0000-0005-000000000000");
 
@@ -90,10 +90,10 @@ public class PartiesClientMock : IPartiesClient
 
         if (!string.IsNullOrEmpty(orgNo) && orgNo == "123447789")
         {
-            party = null!; // deliberately null: tests use orgNo 123447789 to trigger "System Owner not Found"
+            party = null; // deliberately null: tests use orgNo 123447789 to trigger "System Owner not Found"
         }
 
-        return Task.FromResult<Party>(party);
+        return Task.FromResult(party);
     }
     
     public Task<Result<CustomerList>> GetPartyCustomers(Guid partyUuid, string accessPackage, CancellationToken cancellationToken)
@@ -107,9 +107,9 @@ public class PartiesClientMock : IPartiesClient
         return Task.FromResult<RegisterContracts.Party?>(null);
     }
 
-    public Task<Party> GetPartyByUuId(Guid partyUuId, CancellationToken cancellationToken = default)
+    public Task<Party?> GetPartyByUuId(Guid partyUuId, CancellationToken cancellationToken = default)
     {
-        return Task.FromResult(GetTestDataParties(GetCustomerPartiesPath()).Find(p => p.PartyUuid == partyUuId)!); // null when partyUuId is not in test data; IPartiesClient declares non-nullable
+        return Task.FromResult(GetTestDataParties(GetCustomerPartiesPath()).Find(p => p.PartyUuid == partyUuId));
     }
 
     public async Task<Result<bool>> CheckIfUserHasRelationToPartyUuid()


### PR DESCRIPTION
Part of #488. Third project in the leaf → root ratchet, after `Persistance` (#2106) and `Tests` (#2121).

Clears `Integration`'s 7 remaining warnings and locks the project with `TreatWarningsAsErrors`.

## The 7 warnings were one root cause

Three `IPartiesClient` methods and `IAccessManagementClient.GetAccessPackage` declared **non-nullable** returns (`Task<Party>`, `Task<Package>`), while the implementations `return null` when Register / Access Management answer non-OK. The signatures were lying.

Making them honest matches the nullable methods already on the same interface — `GetOrganizationAsync` and `GetPartyIdentifiersAndUsernameByPersonIdentifier` are already `Task<T?>` with an explicit "or null if not found" doc.

- `IPartiesClient`: `GetPartyAsync` / `GetPartyByOrgNo` / `GetPartyByUuId` → `Task<Party?>` (clears 6× CS8603)
- `IAccessManagementClient`: `GetAccessPackage` → `Task<Package?>` (clears 1× CS8613 — the implementation already returned `Task<Package?>`)

## ⚠️ This surfaced 4 latent NullReferenceExceptions in the host

Most callers already null-checked. Four dereferenced the result directly, so a non-OK response from Register / AM would throw `NullReferenceException` instead of returning an error. Each fix is minimal and turns the NRE into the error the surrounding code **already intended** to return:

| Site | Before | After | Now returns |
|---|---|---|---|
| `ChangeRequestSystemUserService.cs:906` | `!party.PartyUuid.HasValue` | `party?.PartyUuid is null` | `Reportee_Orgno_NotFound` |
| `RequestSystemUserService.cs:917` | `!party.PartyUuid.HasValue` | `party?.PartyUuid is null` | `Reportee_Orgno_NotFound` |
| `SystemUserService.cs:1039` | `party.PartyUuid != facilitator` | `party?.PartyUuid != facilitator` | `AgentSystemUser_DelegationNotFound` |
| `SystemUserService.cs:716` | `!package.IsDelegable` / `!package.IsAssignable` | guarded with `package is null` | package treated as not delegable |

The last one is worth a look: `SystemRegisterService.cs:195` already handled the *same* `GetAccessPackage` call with `if (package == null || !package.IsDelegable)`. So this was an inconsistency, not a deliberate design.

The other 17 host call sites already null-checked and only needed `Party` → `Party?`; the existing checks narrow the type.

## Test mocks

Removes three `!` operators whose comments explicitly blamed the non-nullable interface (*"null when partyId is not in test data; IPartiesClient declares non-nullable"*). Now that the interface tells the truth, the mocks can too — including `PartiesClientMock.GetPartyByOrgNo`, which deliberately returns null for orgNo `123447789` to drive the "System Owner not Found" tests.

## Verification

- Full suite green locally: **494 passed, 0 failed, 2 skipped**.
- Clean `Debug` solution rebuild: **0 errors**.
- Unique warning counts: `Integration` **7 → 0**, host 266 → 260, `Core` 187 → 184. No warnings pushed up into unratcheted projects.

## Note on the warning numbers in #488

A Debug build **emits every warning twice**, so the raw counts tracked in #488 are 2× inflated (host reports 532 raw / 266 unique; `Core` 374 raw / 187 unique). The remaining work is about half what the issue states. Correcting this on #488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
