### PR TITLE
fix systemuser client admin error

### DIFF
--- a/src/Authentication/Controllers/SystemUserClientDelegationController.cs
+++ b/src/Authentication/Controllers/SystemUserClientDelegationController.cs
@@ -136,7 +136,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 return Forbid();
             }
 
-            var result = await SystemUserService.GetListOfDelegationsForAgentSystemUser(party.PartyId, party.PartyUuid.Value, agent);
+            var result = await SystemUserService.GetListOfDelegationsForAgentSystemUser(party.PartyUuid.Value, agent);
 
             // If the result is a problem (not 200 OK), return it directly
             if (result.IsProblem)
@@ -297,6 +297,11 @@ namespace Altinn.Platform.Authentication.Controllers
                     Detail = $"No associated party information found for organisation {party}",
                     Status = 404
                 });
+            }
+
+            if (!partyInfo.PartyUuid.HasValue)
+            {
+                return Unauthorized();
             }
 
             bool isAuthorized = await AuthorizeResourceAccess(ClientDelegationResource, partyInfo.PartyUuid.Value, User, "read");

--- a/src/Authentication/Controllers/SystemUserController.cs
+++ b/src/Authentication/Controllers/SystemUserController.cs
@@ -106,7 +106,16 @@ public class SystemUserController : ControllerBase
     public async Task<ActionResult<List<DelegationResponse>>> GetListOfDelegationsForAgentSystemUser(int party, Guid facilitator, Guid systemUserId)
     {
         List<DelegationResponse> ret = [];
-        var result = await _systemUserService.GetListOfDelegationsForAgentSystemUser(party, facilitator, systemUserId);
+
+        // This endpoint is authorized on the {party} route value, but the delegations are looked up
+        // by facilitator partyUuid. Verify the two identify the same party before returning any data.
+        Result<bool> partyMatch = await _systemUserService.VerifyFacilitatorMatchesParty(party, facilitator);
+        if (partyMatch.IsProblem)
+        {
+            return Ok(ret);
+        }
+
+        var result = await _systemUserService.GetListOfDelegationsForAgentSystemUser(facilitator, systemUserId);
         if (result.IsSuccess)
         {
             ret = result.Value;

--- a/src/Authentication/Services/Interfaces/ISystemUserService.cs
+++ b/src/Authentication/Services/Interfaces/ISystemUserService.cs
@@ -139,12 +139,25 @@ public interface ISystemUserService
     /// Returns a list of the Delegations (of clients) to an Agent SystemUser,
     /// retrieved in turn from the AccessManagement db.
     /// </summary>
-    /// <param name="party">int party</param>
-    /// <param name="facilitator">the guid id of the logged in user, representing the Facilitator</param>
+    /// <param name="facilitator">the partyUuid of the Facilitator</param>
     /// <param name="systemUserId">The Guid for the Agent SystemUser</param>
     /// <param name="client">The Guid for the client</param>
     /// <returns>List of Client Delegations</returns>
-    Task<Result<List<DelegationResponse>>> GetListOfDelegationsForAgentSystemUser(int party, Guid facilitator, Guid systemUserId, Guid? client = null);
+    Task<Result<List<DelegationResponse>>> GetListOfDelegationsForAgentSystemUser(Guid facilitator, Guid systemUserId, Guid? client = null);
+
+    /// <summary>
+    /// Verifies that the given facilitator partyUuid identifies the same party as the given partyId.
+    /// </summary>
+    /// <remarks>
+    /// Only needed where partyId and facilitator arrive as independent inputs. Endpoints that resolve
+    /// both from the same party lookup do not need this, and callers holding only the partyUuid must
+    /// not use it: the lookup by partyId requires a user context and is unavailable to system users.
+    /// </remarks>
+    /// <param name="partyId">The party id the caller was authorized on.</param>
+    /// <param name="facilitator">The partyUuid the delegations will be looked up by.</param>
+    /// <param name="cancellationToken">CancellationToken</param>
+    /// <returns>True when both identify the same party.</returns>
+    Task<Result<bool>> VerifyFacilitatorMatchesParty(int partyId, Guid facilitator, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Revokes a client/customer from an Agent SystemUser.

--- a/src/Authentication/Services/SystemUserService.cs
+++ b/src/Authentication/Services/SystemUserService.cs
@@ -1057,15 +1057,22 @@ namespace Altinn.Platform.Authentication.Services
         }
 
         /// <inheritdoc/>
-        public async Task<Result<List<DelegationResponse>>> GetListOfDelegationsForAgentSystemUser(int partyId, Guid facilitator, Guid systemUserId, Guid? client = null)
+        public async Task<Result<bool>> VerifyFacilitatorMatchesParty(int partyId, Guid facilitator, CancellationToken cancellationToken = default)
         {
-            Party? party = await _partiesClient.GetPartyAsync(partyId);
-            List<DelegationResponse> found = [];
+            Party? party = await _partiesClient.GetPartyAsync(partyId, cancellationToken);
 
             if (party?.PartyUuid != facilitator)
             {
                 return Problem.AgentSystemUser_DelegationNotFound;
             }
+
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public async Task<Result<List<DelegationResponse>>> GetListOfDelegationsForAgentSystemUser(Guid facilitator, Guid systemUserId, Guid? client = null)
+        {
+            List<DelegationResponse> found = [];
 
             var res = await _accessManagementClient.GetClientDelegationsForAgent(systemUserId, facilitator);
             if (res.IsSuccess)

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserClientDelegationControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemUserClientDelegationControllerTest.cs
@@ -346,6 +346,90 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             Assert.True(result.Links.Next is null);
         }
 
+        /// <summary>
+        /// Regression test for #1916.
+        /// </summary>
+        /// <remarks>
+        /// System user 65055192 is owned by org 123357789, which resolves by org number to partyId 700000 —
+        /// a party that deliberately does not exist in parties.json, so the lookup by partyId returns null.
+        /// That models production, where the lookup by partyId hits an endpoint requiring a user context and
+        /// fails for system users while the lookup by org number succeeds. The endpoint must not depend on it.
+        /// </remarks>
+        [Fact]
+        public async Task GetClientsDelegatedToSystemUser_PartyNotResolvableById_ReturnsOk()
+        {
+            // Arrange
+            HttpClient client = CreateClient();
+
+            HttpRequestMessage clientListRequest = new(HttpMethod.Get, $"/authentication/api/v1/enduser/systemuser/clients/?agent=65055192-f4a9-4b47-bc24-46c4b97081c1");
+            clientListRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetClientDelegationToken(1337, null, "altinn:clientdelegations.read", 3, TestTime));
+            HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
+            ClientInfoPaginated<ClientInfo>? result = JsonSerializer.Deserialize<ClientInfoPaginated<ClientInfo>>(await clientListResponse.Content.ReadAsStringAsync(), _options);
+
+            Assert.Equal(HttpStatusCode.OK, clientListResponse.StatusCode);
+            Assert.NotNull(result);
+            Assert.True(result.Items.Count() > 0);
+        }
+
+        /// <summary>
+        /// Regression test for #1916: the reported repro used a Maskinporten system user token exchanged for
+        /// an Altinn token. Such a principal has no userid claim, so nothing on this path may require one.
+        /// </summary>
+        [Fact]
+        public async Task GetClientsDelegatedToSystemUser_SystemUserToken_ReturnsOk()
+        {
+            // Arrange
+            HttpClient client = CreateClient();
+
+            Guid callingSystemUser = new("2ee2e3c0-3f2a-4a37-a5b2-1c9d4e6f8a01");
+
+            HttpRequestMessage clientListRequest = new(HttpMethod.Get, $"/authentication/api/v1/enduser/systemuser/clients/?agent=b8d4d4d9-680b-4905-90c1-47ac5ff0c0a4");
+            clientListRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetSystemUserToken(callingSystemUser, "altinn:clientdelegations.read", now: TestTime));
+            HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
+            ClientInfoPaginated<ClientInfo>? result = JsonSerializer.Deserialize<ClientInfoPaginated<ClientInfo>>(await clientListResponse.Content.ReadAsStringAsync(), _options);
+
+            Assert.Equal(HttpStatusCode.OK, clientListResponse.StatusCode);
+            Assert.NotNull(result);
+            Assert.True(result.Items.Count() > 0);
+        }
+
+        /// <summary>
+        /// Regression test for #1916: the DELETE endpoint was reported alongside GET and must also work
+        /// without a user context.
+        /// </summary>
+        [Fact]
+        public async Task RemoveClientFromSystemUser_SystemUserToken_ReturnsOk()
+        {
+            // Arrange
+            HttpClient client = CreateClient();
+
+            Guid callingSystemUser = new("2ee2e3c0-3f2a-4a37-a5b2-1c9d4e6f8a01");
+            Guid clientId = new("fd9d93c7-1dd7-45bc-9772-6ba977b3cd36");
+
+            HttpRequestMessage clientListRequest = new(HttpMethod.Delete, $"/authentication/api/v1/enduser/systemuser/clients/?agent=b8d4d4d9-680b-4905-90c1-47ac5ff0c0a4&client={clientId}");
+            clientListRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetSystemUserToken(callingSystemUser, "altinn:clientdelegations.write", now: TestTime));
+            HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
+
+            Assert.Equal(HttpStatusCode.OK, clientListResponse.StatusCode);
+        }
+
+        /// <summary>
+        /// The agents endpoint dereferenced PartyUuid without checking it was set. Org 123557789 resolves to a
+        /// party that has no PartyUuid, which must be rejected rather than throwing.
+        /// </summary>
+        [Fact]
+        public async Task GetAllAgentSystemUsersForParty_PartyWithoutUuid_ReturnsUnauthorized()
+        {
+            // Arrange
+            HttpClient client = CreateClient();
+
+            HttpRequestMessage clientListRequest = new(HttpMethod.Get, $"/authentication/api/v1/enduser/systemuser/agents?party=123557789");
+            clientListRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetClientDelegationToken(1337, null, "altinn:clientdelegations.read", 3, TestTime));
+            HttpResponseMessage clientListResponse = await client.SendAsync(clientListRequest, HttpCompletionOption.ResponseContentRead);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, clientListResponse.StatusCode);
+        }
+
         [Fact]
         public async Task GetClientsDelegatedToSystemUser_ValidRequest_Returns_NoClients()
         {

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/PartiesClientMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/PartiesClientMock.cs
@@ -88,6 +88,14 @@ public class PartiesClientMock : IPartiesClient
             party.PartyUuid = new Guid("7bb78d06-70b2-45f6-85bc-19ca7b4d34d8");
         }
 
+        if (!string.IsNullOrEmpty(orgNo) && orgNo == "123557789")
+        {
+            // deliberately without a PartyUuid: tests use orgNo 123557789 to cover callers that must
+            // reject an unusable party rather than dereference it
+            party.PartyId = 800000;
+            party.PartyUuid = null;
+        }
+
         if (!string.IsNullOrEmpty(orgNo) && orgNo == "123447789")
         {
             party = null; // deliberately null: tests use orgNo 123447789 to trigger "System Owner not Found"

--- a/test/Altinn.Platform.Authentication.Tests/Utils/PrincipalUtil.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Utils/PrincipalUtil.cs
@@ -164,9 +164,44 @@ namespace Altinn.Platform.Authentication.Tests.Utils
             return token;
         }
 
+        /// <summary>
+        /// Builds a token equivalent to a Maskinporten system user token exchanged for an Altinn token.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately carries no <c>urn:altinn:userid</c> and no <c>urn:altinn:org</c> claim: a system user
+        /// is not a person and not a service owner. Anything downstream that needs a user context is
+        /// therefore unavailable to this principal, which is exactly what these tokens must exercise.
+        /// </remarks>
+        public static string GetSystemUserToken(Guid systemUserId, string scopes, string orgNumber = "910493357", DateTimeOffset? now = null)
+        {
+            now ??= DateTimeOffset.UtcNow;
+
+            string issuer = "www.altinn.no";
+
+            List<Claim> claims =
+            [
+                new Claim("authorization_details", GetSystemUserObject(systemUserId, orgNumber), ClaimValueTypes.String, "maskinporten"),
+                new Claim("consumer", GetOrgNoObject(orgNumber), ClaimValueTypes.String, "maskinporten"),
+                new Claim(AuthzConstants.CLAIM_SCOPE, scopes, ClaimValueTypes.String, "maskinporten"),
+                new Claim(AltinnCoreClaimTypes.OrgNumber, orgNumber, ClaimValueTypes.Integer32, issuer),
+                new Claim(AltinnCoreClaimTypes.AuthenticateMethod, "maskinporten", ClaimValueTypes.String, issuer),
+                new Claim(AltinnCoreClaimTypes.AuthenticationLevel, "3", ClaimValueTypes.Integer32, issuer),
+            ];
+
+            ClaimsIdentity identity = new("mock-systemuser");
+            identity.AddClaims(claims);
+
+            return JwtTokenMock.GenerateToken(new ClaimsPrincipal(identity), new TimeSpan(1, 1, 1), now);
+        }
+
         private static string GetOrgNoObject(string orgNo)
         {
             return $"{{ \"authority\":\"iso6523-actorid-upis\", \"ID\":\"0192:{orgNo}\"}}";
+        }
+
+        private static string GetSystemUserObject(Guid systemUserId, string orgNo)
+        {
+            return $"{{ \"type\":\"urn:altinn:systemuser\", \"systemuser_org\":{GetOrgNoObject(orgNo)}, \"systemuser_id\":[\"{systemUserId}\"], \"system_id\":\"mock_system\"}}";
         }
     }
 }


### PR DESCRIPTION
a systemuser with client admin should work

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved system-user delegation lookups across supported authentication scenarios.
  - Requests now safely reject parties missing required identity information with `401 Unauthorized`.
  - Delegation results are protected by verifying the facilitator matches the requested party.
  - System-user token flows now return successful responses when user context is unavailable.

- **Tests**
  - Added regression coverage for delegation, authorization, and system-user token scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->