### PR TITLE
Use of clientdelegation V2 api with feature flag

### DIFF
--- a/src/Authentication/appsettings.Development.json
+++ b/src/Authentication/appsettings.Development.json
@@ -45,7 +45,8 @@
   },
   "FeatureManagement": {
     "AuditLog": true,
-    "SystemUser": true
+    "SystemUser": true,
+    "ClientDelegationApiV2": false
   },
   "PostgreSQLSettings": {
     "EnableDBConnection": true,

--- a/src/Authentication/appsettings.json
+++ b/src/Authentication/appsettings.json
@@ -55,7 +55,8 @@
   },
   "FeatureManagement": {
     "AuditLog": false,
-    "SystemUser": true
+    "SystemUser": true,
+    "ClientDelegationApiV2": false
   },
   "PostgreSQLSettings": {
     "EnableDBConnection": true,

--- a/src/Integration/AccessManagement/AccessManagementClient.cs
+++ b/src/Integration/AccessManagement/AccessManagementClient.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
@@ -47,6 +48,14 @@ public class AccessManagementClient : IAccessManagementClient
         new() { PropertyNameCaseInsensitive = true };
     private readonly IWebHostEnvironment _env;
     private readonly IAccessTokenGenerator _accessTokenGenerator;
+    private readonly IFeatureManager _featureManager;
+
+    /// <summary>
+    /// Absolute base URL for the client-delegation endpoints on the Access Management v2 API, derived
+    /// from the configured (v1) endpoint. Only used when the <see cref="AccessManagementFeatureFlags.ClientDelegationApiV2"/>
+    /// feature flag is enabled.
+    /// </summary>
+    private readonly string _clientDelegationsBaseUrlV2;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LookupClient"/> class
@@ -62,7 +71,8 @@ public class AccessManagementClient : IAccessManagementClient
         IOptions<AccessManagementSettings> accessManagementSettings,
         IOptions<PlatformSettings> platformSettings,
         IWebHostEnvironment env,
-        IAccessTokenGenerator accessTokenGenerator)
+        IAccessTokenGenerator accessTokenGenerator,
+        IFeatureManager featureManager)
     {
         _logger = logger;
         _httpContextAccessor = httpContextAccessor;
@@ -73,6 +83,28 @@ public class AccessManagementClient : IAccessManagementClient
         _serializerOptions.Converters.Add(new JsonStringEnumConverter());
         _env = env;
         _accessTokenGenerator = accessTokenGenerator;
+        _featureManager = featureManager;
+
+        // The configured endpoint targets api/v1/ (e.g. ".../accessmanagement/api/v1/"). Resolve the
+        // sibling v2 client-delegations base once so the version bump is a pure prefix swap at call time.
+        _clientDelegationsBaseUrlV2 = new Uri(_client.BaseAddress!, "../v2/enduser/clientdelegations").ToString();
+    }
+
+    /// <summary>
+    /// Resolves the client-delegation route for the current request based on the
+    /// <see cref="AccessManagementFeatureFlags.ClientDelegationApiV2"/> feature flag.
+    /// v2 both moves the endpoints under api/v2 and renames the <c>from</c>/<c>to</c> query parameters
+    /// to <c>client</c>/<c>agent</c>.
+    /// </summary>
+    /// <returns>
+    /// The endpoint base path plus the version-specific query-parameter names for the client and agent parties.
+    /// </returns>
+    private async Task<(string BasePath, string ClientParam, string AgentParam)> ResolveClientDelegationRouteAsync()
+    {
+        bool useV2 = await _featureManager.IsEnabledAsync(AccessManagementFeatureFlags.ClientDelegationApiV2);
+        return useV2
+            ? (_clientDelegationsBaseUrlV2, "client", "agent")
+            : ("enduser/clientdelegations", "from", "to");
     }
 
     /// <inheritdoc/>
@@ -283,7 +315,8 @@ public class AccessManagementClient : IAccessManagementClient
     {
         try
         {
-            string endpointUrl = $"enduser/clientdelegations/agents?party={partyUuId}&to={systemUserId}&cascade={cascade}";
+            var (basePath, _, agentParam) = await ResolveClientDelegationRouteAsync();
+            string endpointUrl = $"{basePath}/agents?party={partyUuId}&{agentParam}={systemUserId}&cascade={cascade}";
 
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext!, _platformSettings.JwtCookieName!)!;
             HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl, null);
@@ -555,7 +588,8 @@ public class AccessManagementClient : IAccessManagementClient
         
         try
         {
-            string endpointUrl = $"enduser/clientdelegations/agents/accesspackages?party={provider}&from={client}&to={systemUser}";
+            var (basePath, clientParam, agentParam) = await ResolveClientDelegationRouteAsync();
+            string endpointUrl = $"{basePath}/agents/accesspackages?party={provider}&{clientParam}={client}&{agentParam}={systemUser}";
             HttpResponseMessage response = await _client.PostAsync(token, endpointUrl, JsonContent.Create(batch));
 
             if (response.IsSuccessStatusCode && response.StatusCode == HttpStatusCode.OK)
@@ -584,7 +618,8 @@ public class AccessManagementClient : IAccessManagementClient
 
         try
         {
-            string endpointUrl = $"enduser/clientdelegations/agents/clients?party={provider}&from={client}&to={systemuser}&cascade=true";
+            var (basePath, clientParam, agentParam) = await ResolveClientDelegationRouteAsync();
+            string endpointUrl = $"{basePath}/agents/clients?party={provider}&{clientParam}={client}&{agentParam}={systemuser}&cascade=true";
             HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl);
 
             if (response.IsSuccessStatusCode)
@@ -607,7 +642,8 @@ public class AccessManagementClient : IAccessManagementClient
     {
         try
         {
-            string endpointUrl = $"enduser/clientdelegations/agents?party={HttpUtility.UrlEncode(facilitatorId.ToString())}&to={HttpUtility.UrlEncode(systemUserId.ToString())}&cascade=true";
+            var (basePath, _, agentParam) = await ResolveClientDelegationRouteAsync();
+            string endpointUrl = $"{basePath}/agents?party={HttpUtility.UrlEncode(facilitatorId.ToString())}&{agentParam}={HttpUtility.UrlEncode(systemUserId.ToString())}&cascade=true";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext!, _platformSettings.JwtCookieName!)!;
             HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl);
 
@@ -702,7 +738,8 @@ public class AccessManagementClient : IAccessManagementClient
             return Problem.Reportee_Orgno_NotFound;
         }
 
-        string endpointUrl = $"enduser/clientdelegations/clients?party={facilitatorId}";
+        var (basePath, _, _) = await ResolveClientDelegationRouteAsync();
+        string endpointUrl = $"{basePath}/clients?party={facilitatorId}";
 
         if (packages != null && packages.Count > 0)
         {
@@ -756,8 +793,9 @@ public class AccessManagementClient : IAccessManagementClient
     /// <inheritdoc />
     public async Task<Result<List<ClientDelegationDto>>> GetClientDelegationsForAgent(Guid systemUserId, Guid provider, CancellationToken cancellationToken = default)
     {
-        string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext!, _platformSettings.JwtCookieName!)!;        
-        string endpointUrl = $"enduser/clientdelegations/agents/accesspackages?party={provider}&to={systemUserId}";
+        string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext!, _platformSettings.JwtCookieName!)!;
+        var (basePath, _, agentParam) = await ResolveClientDelegationRouteAsync();
+        string endpointUrl = $"{basePath}/agents/accesspackages?party={provider}&{agentParam}={systemUserId}";
 
         try
         {

--- a/src/Integration/AccessManagement/AccessManagementClient.cs
+++ b/src/Integration/AccessManagement/AccessManagementClient.cs
@@ -87,7 +87,16 @@ public class AccessManagementClient : IAccessManagementClient
 
         // The configured endpoint targets api/v1/ (e.g. ".../accessmanagement/api/v1/"). Resolve the
         // sibling v2 client-delegations base once so the version bump is a pure prefix swap at call time.
-        _clientDelegationsBaseUrlV2 = new Uri(_client.BaseAddress!, "../v2/enduser/clientdelegations").ToString();
+        // The "../v2/" relative resolution only lands on the right path when the base ends in "/v1/"
+        // (the trailing slash makes "v1" a segment we can step out of), so guard the assumption.
+        if (!_client.BaseAddress!.AbsolutePath.EndsWith("/v1/", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"{nameof(AccessManagementSettings.ApiAccessManagementEndpoint)} must end with '/v1/' " +
+                $"for the client-delegation v2 route to be derived correctly, but was '{_client.BaseAddress}'.");
+        }
+
+        _clientDelegationsBaseUrlV2 = new Uri(_client.BaseAddress, "../v2/enduser/clientdelegations").ToString();
     }
 
     /// <summary>

--- a/src/Integration/AccessManagement/AccessManagementFeatureFlags.cs
+++ b/src/Integration/AccessManagement/AccessManagementFeatureFlags.cs
@@ -1,0 +1,16 @@
+namespace Altinn.Platform.Authentication.Integration.AccessManagement;
+
+/// <summary>
+/// Feature flags controlling how the <see cref="AccessManagementClient"/> talks to Access Management.
+/// The flag names must match the entries under the "FeatureManagement" section in appsettings.
+/// </summary>
+public static class AccessManagementFeatureFlags
+{
+    /// <summary>
+    /// When enabled, the client-delegation endpoints are called on the Access Management v2 API
+    /// (<c>accessmanagement/api/v2/enduser/clientdelegations</c>) instead of v1. In addition to the
+    /// version segment, v2 renames the query parameters <c>from</c> to <c>client</c> and <c>to</c> to
+    /// <c>agent</c>. Defaults to disabled (v1) when the flag is absent from configuration.
+    /// </summary>
+    public const string ClientDelegationApiV2 = "ClientDelegationApiV2";
+}

--- a/src/Integration/Altinn.Platform.Authentication.Integration.csproj
+++ b/src/Integration/Altinn.Platform.Authentication.Integration.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.Register.Contracts" Version="1.7.0" />
+    <PackageReference Include="Microsoft.FeatureManagement" Version="4.5.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
   </ItemGroup>
 

--- a/test/Altinn.Platform.Authentication.Tests/Clients/AccessManagementClientTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Clients/AccessManagementClientTests.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement;
 using Moq;
 using Moq.Protected;
 using Xunit;
@@ -126,7 +127,169 @@ namespace Altinn.Platform.Authentication.Tests.Clients
             VerifyErrorLogged("ServiceUnavailable", responseBody);
         }
 
-        private static HttpClient CreateHttpClient(HttpStatusCode statusCode, string responseBody, string mediaType = "application/json")
+        [Fact]
+        public async Task RevokeClientFromAgentSystemUser_FlagOff_UsesV1RouteAndFromToParams()
+        {
+            // Arrange
+            HttpRequestMessage? captured = null;
+            var client = CreateClient(CreateHttpClient(HttpStatusCode.OK, string.Empty, capture: r => captured = r));
+            Guid provider = Guid.NewGuid(), agent = Guid.NewGuid(), systemuser = Guid.NewGuid();
+
+            // Act
+            await client.RevokeClientFromAgentSystemUser(provider, agent, systemuser, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(captured);
+            string url = captured!.RequestUri!.ToString();
+            Assert.Contains("/accessmanagement/api/v1/enduser/clientdelegations/agents/clients", url);
+            Assert.Contains($"from={agent}", url);
+            Assert.Contains($"to={systemuser}", url);
+        }
+
+        [Fact]
+        public async Task RevokeClientFromAgentSystemUser_FlagOn_UsesV2RouteAndClientAgentParams()
+        {
+            // Arrange
+            HttpRequestMessage? captured = null;
+            var client = CreateClient(CreateHttpClient(HttpStatusCode.OK, string.Empty, capture: r => captured = r), clientDelegationV2: true);
+            Guid provider = Guid.NewGuid(), agent = Guid.NewGuid(), systemuser = Guid.NewGuid();
+
+            // Act
+            await client.RevokeClientFromAgentSystemUser(provider, agent, systemuser, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(captured);
+            string url = captured!.RequestUri!.ToString();
+            Assert.Contains("/accessmanagement/api/v2/enduser/clientdelegations/agents/clients", url);
+            Assert.Contains($"client={agent}", url);
+            Assert.Contains($"agent={systemuser}", url);
+            Assert.DoesNotContain("/api/v1/", url);
+        }
+
+        [Theory]
+        [InlineData(false, "v1", "to")]
+        [InlineData(true, "v2", "agent")]
+        public async Task RevokeSystemUserAsAgent_UsesVersionedRouteAndAgentParam(bool useV2, string version, string agentParam)
+        {
+            HttpRequestMessage? captured = null;
+            var client = CreateClient(CreateHttpClient(HttpStatusCode.OK, string.Empty, capture: r => captured = r), clientDelegationV2: useV2);
+            Guid party = Guid.NewGuid(), systemUser = Guid.NewGuid();
+
+            await client.RevokeSystemUserAsAgent(party, systemUser, cascade: true, CancellationToken.None);
+
+            string url = captured!.RequestUri!.ToString();
+            Assert.Contains($"/accessmanagement/api/{version}/enduser/clientdelegations/agents?", url);
+            Assert.Contains($"{agentParam}={systemUser}", url);
+        }
+
+        [Theory]
+        [InlineData(false, "v1", "to")]
+        [InlineData(true, "v2", "agent")]
+        public async Task DeleteSystemUserAssignment_UsesVersionedRouteAndAgentParam(bool useV2, string version, string agentParam)
+        {
+            HttpRequestMessage? captured = null;
+            var client = CreateClient(CreateHttpClient(HttpStatusCode.OK, string.Empty, capture: r => captured = r), clientDelegationV2: useV2);
+            Guid facilitator = Guid.NewGuid(), systemUser = Guid.NewGuid();
+
+            await client.DeleteSystemUserAssignment(facilitator, systemUser, CancellationToken.None);
+
+            string url = captured!.RequestUri!.ToString();
+            Assert.Contains($"/accessmanagement/api/{version}/enduser/clientdelegations/agents?", url);
+            Assert.Contains($"{agentParam}={systemUser}", url);
+        }
+
+        [Theory]
+        [InlineData(false, "v1", "to")]
+        [InlineData(true, "v2", "agent")]
+        public async Task GetClientDelegationsForAgent_UsesVersionedRouteAndAgentParam(bool useV2, string version, string agentParam)
+        {
+            HttpRequestMessage? captured = null;
+            var client = CreateClient(CreateHttpClient(HttpStatusCode.OK, "{\"data\":[]}", capture: r => captured = r), clientDelegationV2: useV2);
+            Guid provider = Guid.NewGuid(), systemUser = Guid.NewGuid();
+
+            await client.GetClientDelegationsForAgent(systemUser, provider, CancellationToken.None);
+
+            string url = captured!.RequestUri!.ToString();
+            Assert.Contains($"/accessmanagement/api/{version}/enduser/clientdelegations/agents/accesspackages?", url);
+            Assert.Contains($"party={provider}", url);
+            Assert.Contains($"{agentParam}={systemUser}", url);
+        }
+
+        [Theory]
+        [InlineData(false, "v1", "from", "to")]
+        [InlineData(true, "v2", "client", "agent")]
+        public async Task DelegateCustomerToAgentSystemUser_RenamesFromAndToParams(bool useV2, string version, string clientParam, string agentParam)
+        {
+            HttpRequestMessage? captured = null;
+            var client = CreateClient(CreateHttpClient(HttpStatusCode.OK, "[]", capture: r => captured = r), clientDelegationV2: useV2);
+            Guid provider = Guid.NewGuid(), agentClient = Guid.NewGuid(), systemUser = Guid.NewGuid();
+
+            await client.DelegateCustomerToAgentSystemUser(systemUser, new DelegationBatchInputDto(), provider, agentClient, CancellationToken.None);
+
+            string url = captured!.RequestUri!.ToString();
+            Assert.Contains($"/accessmanagement/api/{version}/enduser/clientdelegations/agents/accesspackages?", url);
+            Assert.Contains($"party={provider}", url);
+            Assert.Contains($"{clientParam}={agentClient}", url);
+            Assert.Contains($"{agentParam}={systemUser}", url);
+        }
+
+        [Theory]
+        [InlineData(false, "v1")]
+        [InlineData(true, "v2")]
+        public async Task GetClientsForFacilitator_UsesVersionedRoute_WithoutRenamingParams(bool useV2, string version)
+        {
+            HttpRequestMessage? captured = null;
+            var client = CreateClient(CreateHttpClient(HttpStatusCode.OK, "{\"data\":[]}", capture: r => captured = r), clientDelegationV2: useV2);
+            Guid facilitator = Guid.NewGuid();
+
+            await client.GetClientsForFacilitator(facilitator, ["urn:altinn:accesspackage:skattnaering"], CancellationToken.None);
+
+            string url = captured!.RequestUri!.ToString();
+            Assert.Contains($"/accessmanagement/api/{version}/enduser/clientdelegations/clients?", url);
+            Assert.Contains($"party={facilitator}", url);
+            Assert.Contains("packages=urn:altinn:accesspackage:skattnaering", url);
+
+            // 'clients' takes party/packages only - the from/to -> client/agent rename must NOT apply here.
+            Assert.DoesNotContain("from=", url);
+            Assert.DoesNotContain("to=", url);
+            Assert.DoesNotContain("agent=", url);
+        }
+
+        [Fact]
+        public async Task GetClientsForFacilitator_FlagOn_ParsesV2PayloadIncludingNewResourcesField()
+        {
+            // v2 ClientDto adds a 'resources' array per access entry that the authentication DTO does not
+            // model. This verifies the extra field is ignored and the consumed fields still deserialize.
+            Guid clientId = Guid.NewGuid();
+            string body = $$"""
+            {
+              "links": { "next": null },
+              "data": [
+                {
+                  "client": { "id": "{{clientId}}", "name": "Acme AS", "type": "Organisasjon" },
+                  "access": [
+                    {
+                      "role": { "urn": "urn:altinn:external-role:ccr:regnskapsforer" },
+                      "packages": [ { "urn": "urn:altinn:accesspackage:skattnaering" } ],
+                      "resources": [ { "urn": "urn:altinn:resource:some-resource" } ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """;
+            var client = CreateClient(CreateHttpClient(HttpStatusCode.OK, body), clientDelegationV2: true);
+
+            var result = await client.GetClientsForFacilitator(Guid.NewGuid(), [], CancellationToken.None);
+
+            Assert.False(result.IsProblem);
+            var single = Assert.Single(result.Value);
+            Assert.Equal(clientId, single.Client.Id);
+            var access = Assert.Single(single.Access);
+            Assert.Equal("urn:altinn:accesspackage:skattnaering", Assert.Single(access.Packages).Urn);
+        }
+
+        private static HttpClient CreateHttpClient(HttpStatusCode statusCode, string responseBody, string mediaType = "application/json", Action<HttpRequestMessage>? capture = null)
         {
             Mock<HttpMessageHandler> handlerMock = new();
             handlerMock
@@ -135,6 +298,7 @@ namespace Altinn.Platform.Authentication.Tests.Clients
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((request, _) => capture?.Invoke(request))
                 .ReturnsAsync(new HttpResponseMessage(statusCode)
                 {
                     Content = new StringContent(responseBody, Encoding.UTF8, mediaType)
@@ -143,7 +307,7 @@ namespace Altinn.Platform.Authentication.Tests.Clients
             return new HttpClient(handlerMock.Object);
         }
 
-        private AccessManagementClient CreateClient(HttpClient httpClient)
+        private AccessManagementClient CreateClient(HttpClient httpClient, bool clientDelegationV2 = false)
         {
             DefaultHttpContext httpContext = new();
             httpContext.Request.Headers.Authorization = "Bearer unittest-token";
@@ -161,6 +325,11 @@ namespace Altinn.Platform.Authentication.Tests.Clients
                 JwtCookieName = "AltinnStudioRuntime"
             });
 
+            Mock<IFeatureManager> featureManagerMock = new();
+            featureManagerMock
+                .Setup(f => f.IsEnabledAsync(AccessManagementFeatureFlags.ClientDelegationApiV2))
+                .ReturnsAsync(clientDelegationV2);
+
             return new AccessManagementClient(
                 httpClient,
                 _loggerMock.Object,
@@ -168,7 +337,8 @@ namespace Altinn.Platform.Authentication.Tests.Clients
                 accessManagementSettings,
                 platformSettings,
                 new Mock<IWebHostEnvironment>().Object,
-                new Mock<IAccessTokenGenerator>().Object);
+                new Mock<IAccessTokenGenerator>().Object,
+                featureManagerMock.Object);
         }
 
         private void VerifyErrorLogged(params string[] expectedFragments)

--- a/test/Altinn.Platform.Authentication.Tests/Clients/AccessManagementClientTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Clients/AccessManagementClientTests.cs
@@ -255,6 +255,16 @@ namespace Altinn.Platform.Authentication.Tests.Clients
             Assert.DoesNotContain("agent=", url);
         }
 
+        [Theory]
+        [InlineData("http://localhost:5117/accessmanagement/api/v2/")]
+        [InlineData("http://localhost:5117/accessmanagement/api/v1")]
+        public void Constructor_EndpointNotEndingInV1Slash_Throws(string apiEndpoint)
+        {
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                () => CreateClient(CreateHttpClient(HttpStatusCode.OK, string.Empty), apiEndpoint: apiEndpoint));
+            Assert.Contains("/v1/", ex.Message);
+        }
+
         [Fact]
         public async Task GetClientsForFacilitator_FlagOn_ParsesV2PayloadIncludingNewResourcesField()
         {
@@ -307,7 +317,7 @@ namespace Altinn.Platform.Authentication.Tests.Clients
             return new HttpClient(handlerMock.Object);
         }
 
-        private AccessManagementClient CreateClient(HttpClient httpClient, bool clientDelegationV2 = false)
+        private AccessManagementClient CreateClient(HttpClient httpClient, bool clientDelegationV2 = false, string apiEndpoint = "http://localhost:5117/accessmanagement/api/v1/")
         {
             DefaultHttpContext httpContext = new();
             httpContext.Request.Headers.Authorization = "Bearer unittest-token";
@@ -317,7 +327,7 @@ namespace Altinn.Platform.Authentication.Tests.Clients
 
             IOptions<AccessManagementSettings> accessManagementSettings = Options.Create(new AccessManagementSettings
             {
-                ApiAccessManagementEndpoint = "http://localhost:5117/accessmanagement/api/v1/"
+                ApiAccessManagementEndpoint = apiEndpoint
             });
 
             IOptions<PlatformSettings> platformSettings = Options.Create(new PlatformSettings

--- a/test/Altinn.Platform.Authentication.Tests/Clients/AccessManagementClientTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Clients/AccessManagementClientTests.cs
@@ -132,17 +132,17 @@ namespace Altinn.Platform.Authentication.Tests.Clients
         {
             // Arrange
             HttpRequestMessage? captured = null;
-            var client = CreateClient(CreateHttpClient(HttpStatusCode.OK, string.Empty, capture: r => captured = r));
-            Guid provider = Guid.NewGuid(), agent = Guid.NewGuid(), systemuser = Guid.NewGuid();
+            var sut = CreateClient(CreateHttpClient(HttpStatusCode.OK, string.Empty, capture: r => captured = r));
+            Guid provider = Guid.NewGuid(), client = Guid.NewGuid(), systemuser = Guid.NewGuid();
 
             // Act
-            await client.RevokeClientFromAgentSystemUser(provider, agent, systemuser, CancellationToken.None);
+            await sut.RevokeClientFromAgentSystemUser(provider, client, systemuser, CancellationToken.None);
 
             // Assert
             Assert.NotNull(captured);
             string url = captured!.RequestUri!.ToString();
             Assert.Contains("/accessmanagement/api/v1/enduser/clientdelegations/agents/clients", url);
-            Assert.Contains($"from={agent}", url);
+            Assert.Contains($"from={client}", url);
             Assert.Contains($"to={systemuser}", url);
         }
 
@@ -151,17 +151,17 @@ namespace Altinn.Platform.Authentication.Tests.Clients
         {
             // Arrange
             HttpRequestMessage? captured = null;
-            var client = CreateClient(CreateHttpClient(HttpStatusCode.OK, string.Empty, capture: r => captured = r), clientDelegationV2: true);
-            Guid provider = Guid.NewGuid(), agent = Guid.NewGuid(), systemuser = Guid.NewGuid();
+            var sut = CreateClient(CreateHttpClient(HttpStatusCode.OK, string.Empty, capture: r => captured = r), clientDelegationV2: true);
+            Guid provider = Guid.NewGuid(), client = Guid.NewGuid(), systemuser = Guid.NewGuid();
 
             // Act
-            await client.RevokeClientFromAgentSystemUser(provider, agent, systemuser, CancellationToken.None);
+            await sut.RevokeClientFromAgentSystemUser(provider, client, systemuser, CancellationToken.None);
 
             // Assert
             Assert.NotNull(captured);
             string url = captured!.RequestUri!.ToString();
             Assert.Contains("/accessmanagement/api/v2/enduser/clientdelegations/agents/clients", url);
-            Assert.Contains($"client={agent}", url);
+            Assert.Contains($"client={client}", url);
             Assert.Contains($"agent={systemuser}", url);
             Assert.DoesNotContain("/api/v1/", url);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Access Management client-delegation API v2.
  * Added a feature flag to enable v2 routing while preserving v1 compatibility.
  * Updated delegation requests to use the appropriate endpoint and parameter formats.
  * Development environments can enable v2 independently when ready.

* **Bug Fixes**
  * Improved handling of v2 delegation responses by safely ignoring unsupported resource fields.
  * Added validation to prevent incorrectly configured delegation endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->