### PR TITLE
chore(core): clear nullable warnings in ConnectionsDtos (#488, Core iteration 1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,17 @@
   -->
   <PropertyGroup>
     <NoWarn>$(NoWarn);NU1510</NoWarn>
+
+    <!--
+      NuGet security-audit advisories (NU1901-NU1904) are kept as warnings but NOT promoted
+      to errors by <TreatWarningsAsErrors>. Otherwise a newly-published CVE against any
+      transitive dependency red-walls every build - main and all PRs - with no code change
+      (e.g. SSH.NET via Testcontainers, and System.Security.Cryptography.Xml from the net10.0
+      framework, both flagged 2026-08). The advisories still surface as warnings so a
+      dedicated dependency-bump pass can act on them; they just don't break unrelated builds.
+      See #488.
+    -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/Authentication/Helpers/DelegationHelper.cs
+++ b/src/Authentication/Helpers/DelegationHelper.cs
@@ -385,7 +385,10 @@ public class DelegationHelper(
             if (rightCheckDto.Result)
             {
                 canDelegate = true;
-                rightKeys.Add(rightCheckDto.Right.Key);
+                if (rightCheckDto.Right.Key is not null)
+                {
+                    rightKeys.Add(rightCheckDto.Right.Key);
+                }
             }
 
             if (!rightCheckDto.Result)

--- a/src/Authentication/Services/SystemUserService.cs
+++ b/src/Authentication/Services/SystemUserService.cs
@@ -908,7 +908,7 @@ namespace Altinn.Platform.Authentication.Services
                         List<string> clientAccessPackages = [];
                         foreach (var package in access.Packages)
                         {
-                            if (packageUrns.Contains(package.Urn))
+                            if (package.Urn is not null && packageUrns.Contains(package.Urn))
                             {
                                 clientAccessPackages.Add(package.Urn);
                                 outerValidationSet[packages.FindIndex(p => p.Urn == package.Urn)] = true;
@@ -919,7 +919,7 @@ namespace Altinn.Platform.Authentication.Services
                         {
                             var roleAccess = new RoleAccessPackagesPrimitive()
                             {
-                                Role = access.Role.Urn,
+                                Role = access.Role.Urn ?? string.Empty,
                                 Packages = clientAccessPackages
                             };
                             clientAccessPrimitive.Add(roleAccess);
@@ -1135,7 +1135,7 @@ namespace Altinn.Platform.Authentication.Services
                 if (packages is not null && packages.Count > 0)
                 {
                     // If a list of packages to filter on is provided, filter the clients based on those packages before converting to DTOs
-                    var filtered = res.Value.Where(client => client.Access.Any(access => access.Packages.Any(p => packages.Contains(p.Urn)))).ToList();
+                    var filtered = res.Value.Where(client => client.Access.Any(access => access.Packages.Any(p => p.Urn is not null && packages.Contains(p.Urn)))).ToList();
                 }
 
                 return ConvertConnectionDTOToClient(res.Value);
@@ -1251,7 +1251,7 @@ namespace Altinn.Platform.Authentication.Services
             {
                 var newCustomer = new ExternalClientDto()
                 {
-                    DisplayName = item.Client.Name,
+                    DisplayName = item.Client.Name ?? string.Empty,
                     OrganizationIdentifier = item.Client.OrganizationIdentifier ?? string.Empty,
                     PartyUuid = item.Client.Id,
                     Access = ConvertAccessToPrimitive(item.Access)
@@ -1288,8 +1288,8 @@ namespace Altinn.Platform.Authentication.Services
             {
                 RoleAccessPackagesPrimitive primitive = new()
                 {
-                    Role = item.Role.Urn,
-                    Packages = [.. item.Packages.Select(p => p.Urn!)]
+                    Role = item.Role.Urn ?? string.Empty,
+                    Packages = [.. item.Packages.Select(p => p.Urn ?? string.Empty)]
                 };
                 primitiveList.Add(primitive);
             }

--- a/src/Core/Models/Rights/ConnectionsDtos/AgentDelegationDto.cs
+++ b/src/Core/Models/Rights/ConnectionsDtos/AgentDelegationDto.cs
@@ -11,7 +11,7 @@ public class AgentDelegationDto
     /// Gets or sets the party
     /// </summary>
     [JsonPropertyName("agent")]
-    public CompactEntityDto Agent { get; set; }
+    public CompactEntityDto Agent { get; set; } = null!; // Access Management always carries the agent on an agent-delegation record
 
     /// <summary>
     /// Gets or sets a collection of all access information for the client 

--- a/src/Core/Models/Rights/ConnectionsDtos/AttributeDto.cs
+++ b/src/Core/Models/Rights/ConnectionsDtos/AttributeDto.cs
@@ -30,13 +30,13 @@ public class AttributeDto
     /// Gets or sets the attribute id for the match
     /// </summary>
     [JsonPropertyName("type")]
-    public string Type { get; set; }
+    public string? Type { get; set; }
 
     /// <summary>
     /// Gets or sets the attribute value for the match
     /// </summary>
     [JsonPropertyName("value")]
-    public string Value { get; set; }
+    public string? Value { get; set; }
 
     /// <summary>
     /// returns the type and value as a urn in the format '{type}:{value}'

--- a/src/Core/Models/Rights/ConnectionsDtos/ClientDelegationDto.cs
+++ b/src/Core/Models/Rights/ConnectionsDtos/ClientDelegationDto.cs
@@ -14,7 +14,7 @@ public class ClientDelegationDto
     /// Gets or sets the party
     /// </summary>
     [JsonPropertyName("client")]
-    public CompactEntityDto Client { get; set; }
+    public CompactEntityDto Client { get; set; } = null!; // Access Management always carries the client on a client-delegation record
 
     /// <summary>
     /// Gets or sets a collection of all access information for the client 

--- a/src/Core/Models/Rights/ConnectionsDtos/CompactEntityDto.cs
+++ b/src/Core/Models/Rights/ConnectionsDtos/CompactEntityDto.cs
@@ -19,31 +19,31 @@ public class CompactEntityDto
     /// Name
     /// </summary>
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     /// <summary>
     /// Type
     /// </summary>
     [JsonPropertyName("type")]
-    public string Type { get; set; }
+    public string? Type { get; set; }
 
     /// <summary>
     /// Variant
     /// </summary>
     [JsonPropertyName("variant")]
-    public string Variant { get; set; }
+    public string? Variant { get; set; }
 
     /// <summary>
     /// Parent
     /// </summary>
     [JsonPropertyName("parent")]
-    public CompactEntityDto Parent { get; set; }
+    public CompactEntityDto? Parent { get; set; }
 
     /// <summary>
     /// Children
     /// </summary>
     [JsonPropertyName("children")]
-    public List<CompactEntityDto> Children { get; set; }
+    public List<CompactEntityDto>? Children { get; set; }
 
     /// <summary>
     /// PartyId

--- a/src/Core/Models/Rights/ConnectionsDtos/CompactPackageDto.cs
+++ b/src/Core/Models/Rights/ConnectionsDtos/CompactPackageDto.cs
@@ -19,7 +19,7 @@ public class CompactPackageDto
     /// Urn
     /// </summary>
     [JsonPropertyName("urn")]
-    public string Urn { get; set; }
+    public string? Urn { get; set; }
 
     /// <summary>
     /// AreaId

--- a/src/Core/Models/Rights/ConnectionsDtos/CompactRoleDto.cs
+++ b/src/Core/Models/Rights/ConnectionsDtos/CompactRoleDto.cs
@@ -19,23 +19,23 @@ public class CompactRoleDto
     /// Value
     /// </summary>
     [JsonPropertyName("code")]
-    public string Code { get; set; }
+    public string? Code { get; set; }
 
     /// <summary>
     /// Value
     /// </summary>
     [JsonPropertyName("urn")]
-    public string Urn { get; set; }
+    public string? Urn { get; set; }
 
     /// <summary>
     /// Value
     /// </summary>
     [JsonPropertyName("legacyurn ")]
-    public string LegacyUrn { get; set; }
+    public string? LegacyUrn { get; set; }
 
     /// <summary>
     /// Children
     /// </summary>
     [JsonPropertyName("children")]
-    public List<CompactRoleDto> Children { get; set; }
+    public List<CompactRoleDto>? Children { get; set; }
 }

--- a/src/Core/Models/Rights/ConnectionsDtos/PermissionsDto.cs
+++ b/src/Core/Models/Rights/ConnectionsDtos/PermissionsDto.cs
@@ -10,30 +10,30 @@ public class PermissionDto
     /// <summary>
     /// From party
     /// </summary>
-    public CompactEntityDto From { get; set; }
+    public CompactEntityDto? From { get; set; }
 
     /// <summary>
     /// To party
     /// </summary>
-    public CompactEntityDto To { get; set; }
+    public CompactEntityDto? To { get; set; }
 
     /// <summary>
     /// Via party
     /// </summary>
-    public CompactEntityDto Via { get; set; }
+    public CompactEntityDto? Via { get; set; }
 
     /// <summary>
     /// Role
     /// </summary>
-    public CompactRoleDto Role { get; set; }
+    public CompactRoleDto? Role { get; set; }
 
     /// <summary>
     /// Via role
     /// </summary>
-    public CompactRoleDto ViaRole { get; set; }
+    public CompactRoleDto? ViaRole { get; set; }
 
     /// <summary>
     /// Reason
     /// </summary>
-    public AccessReason Reason { get; set; }
+    public AccessReason? Reason { get; set; }
 }

--- a/src/Core/Models/Rights/ConnectionsDtos/ProviderDto.cs
+++ b/src/Core/Models/Rights/ConnectionsDtos/ProviderDto.cs
@@ -16,22 +16,22 @@ public class ProviderDto
     /// <summary>
     /// Name
     /// </summary>
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     /// <summary>
     /// Reference Identifier (e.g. OrgNo)
     /// </summary>
-    public string RefId { get; set; }
+    public string? RefId { get; set; }
 
     /// <summary>
     /// Logo url
     /// </summary>
-    public string LogoUrl { get; set; }
+    public string? LogoUrl { get; set; }
 
     /// <summary>
     /// Provider code (e.g ttd, brg, skd)
     /// </summary>
-    public string Code { get; set; }
+    public string? Code { get; set; }
 
     /// <summary>
     /// The type of provider
@@ -41,5 +41,5 @@ public class ProviderDto
     /// <summary>
     /// The type of provider
     /// </summary>
-    public TypeDto Type { get; set; }
+    public TypeDto? Type { get; set; }
 }

--- a/src/Core/Models/Rights/ConnectionsDtos/ResourceDto.cs
+++ b/src/Core/Models/Rights/ConnectionsDtos/ResourceDto.cs
@@ -26,25 +26,25 @@ public class ResourceDto
     /// <summary>
     /// Name
     /// </summary>
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     /// <summary>
     /// Description
     /// </summary>
-    public string Description { get; set; }
+    public string? Description { get; set; }
 
     /// <summary>
     /// Reference identifier
     /// </summary>
-    public string RefId { get; set; }
+    public string? RefId { get; set; }
 
     /// <summary>
     /// Provider
     /// </summary>
-    public ProviderDto Provider { get; set; }
+    public ProviderDto? Provider { get; set; }
 
     /// <summary>
     /// Type
     /// </summary>
-    public TypeDto Type { get; set; }
+    public TypeDto? Type { get; set; }
 }

--- a/src/Core/Models/Rights/ConnectionsDtos/ResourceDtoCheck.cs
+++ b/src/Core/Models/Rights/ConnectionsDtos/ResourceDtoCheck.cs
@@ -13,7 +13,7 @@ public class ResourceDtoCheck
     /// <summary>
     /// Resource actions
     /// </summary>
-    public List<string> Actions { get; set; }
+    public List<string>? Actions { get; set; }
 
     /// <summary>
     /// Result of the delegation check.

--- a/src/Core/Models/Rights/ConnectionsDtos/ResourcePermissionDto.cs
+++ b/src/Core/Models/Rights/ConnectionsDtos/ResourcePermissionDto.cs
@@ -10,11 +10,11 @@ public class ResourcePermissionDto
     /// <summary>
     /// Resource the permissions are for
     /// </summary>
-    public ResourceDto Resource { get; set; }
+    public ResourceDto? Resource { get; set; }
 
     /// <summary>
     /// Parties with permissions
     /// </summary>
-    public IEnumerable<PermissionDto> Permissions { get; set; }
+    public IEnumerable<PermissionDto>? Permissions { get; set; }
 }
 

--- a/src/Core/Models/Rights/ConnectionsDtos/RightDto.cs
+++ b/src/Core/Models/Rights/ConnectionsDtos/RightDto.cs
@@ -8,20 +8,20 @@ public class RightDto
     /// <summary>
     /// Unique key for action
     /// </summary>
-    public string Key { get; set; }
+    public string? Key { get; set; }
 
     /// <summary>
     /// Name of the action to present in frontend
     /// </summary>
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     /// <summary>
     /// Concatenated key for subresources from policy rule
     /// </summary>
-    public IEnumerable<AttributeDto> Resource { get; set; }
+    public IEnumerable<AttributeDto>? Resource { get; set; }
 
     /// <summary>
     /// Action
     /// </summary>
-    public AttributeDto Action { get; set; }
+    public AttributeDto? Action { get; set; }
 }

--- a/src/Core/Models/Rights/ConnectionsDtos/RoleAccessPackages.cs
+++ b/src/Core/Models/Rights/ConnectionsDtos/RoleAccessPackages.cs
@@ -14,13 +14,13 @@ public class RoleAccessPackages
     /// Roles
     /// </summary>
     [JsonPropertyName("role")]
-    public CompactRoleDto Role { get; set; }
+    public CompactRoleDto Role { get; set; } = null!; // an access entry from Access Management always carries its role
 
     /// <summary>
     /// Packages
     /// </summary>
     [JsonPropertyName("packages")]
-    public CompactPackageDto[] Packages { get; set; }
+    public CompactPackageDto[] Packages { get; set; } = []; // an access entry from Access Management always carries its packages
 }
 
 
@@ -32,8 +32,8 @@ public class RoleAccessPackages
 public class RoleAccessPackagesPrimitive
 {
     [JsonPropertyName("role")]
-    public string Role { get; set; }
+    public required string Role { get; set; }
 
     [JsonPropertyName("packages")]
-    public List<string> Packages { get; set; }
+    public required List<string> Packages { get; set; }
 }

--- a/src/Core/Models/Rights/ConnectionsDtos/TypeDto.cs
+++ b/src/Core/Models/Rights/ConnectionsDtos/TypeDto.cs
@@ -16,5 +16,5 @@ public class TypeDto
     /// <summary>
     /// Name
     /// </summary>
-    public string Name { get; set; }
+    public string? Name { get; set; }
 }

--- a/src/Integration/AccessManagement/AccessManagementClient.cs
+++ b/src/Integration/AccessManagement/AccessManagementClient.cs
@@ -668,9 +668,9 @@ public class AccessManagementClient : IAccessManagementClient
             List<AttributeMatchExternal> toList = [];
             List<AttributeMatchExternal> resourceList = [];
 
-            if (r.Resource == null || r.Permissions == null)
+            if (r.Resource?.RefId == null || r.Permissions == null)
             {
-                throw new InvalidOperationException("Received invalid data from Access Management API: Resource or Permissions is null.");
+                throw new InvalidOperationException("Received invalid data from Access Management API: Resource, Resource.RefId or Permissions is null.");
             }
 
             // there is only one resource per resource, the old DTO needs a list though


### PR DESCRIPTION
Part of #488. **Core iteration 1** — the first slice of the `Core` cleanup, following `Integration` (#2126).

Clears the 41 `CS8618` warnings in `Core/Models/Rights/ConnectionsDtos/`. These DTOs deserialize Access Management connection/delegation responses. `Core` isn't locked yet — that comes in the final iteration once all its warnings are gone — but this batch pushes **zero** warnings up into the already-locked `Integration` and `Tests` projects.

## Convention

Chosen from what the AM test data (`Data/Customers/systemusercustomerlist.json`) actually contains, not from guesswork:

- **`?` on leaf values the data proves are nullable.** The AM payloads carry explicit `"parent": null`, `"children": null`, and null urns, and System.Text.Json *overwrites* property initializers with null on deserialization — so a non-null annotation (or `= []`) would be a claim the data disproves.
- **`= null!` (with a justifying comment) on container references** that are structurally always present on a record — `ClientDelegationDto.Client`, `AgentDelegationDto.Agent`, `RoleAccessPackages.Role`/`Packages`.
- **`required`** on `RoleAccessPackagesPrimitive.Role`/`Packages`, which is only ever constructed in-process (serialized *out* to the batch delegation endpoint), never deserialized.

This mirrors the guidance already on #488: `= null!` only for members always set post-construction, each with a comment; `required` for genuinely-required fields; `?` otherwise.

## Fallout, handled in the same PR

Because `Integration` and `Tests` are locked with `TreatWarningsAsErrors`, Core's signature changes surface there as **build errors**, not warnings — so they're fixed here:

- **`AccessManagementClient.cs`** — `ResourceDto.RefId` is now `string?`, breaking an assignment to a non-nullable field. Widened the **existing** `"Received invalid data from Access Management"` guard to also reject a null `Resource.RefId`, matching the intent already expressed one line up.
- **`DelegationHelper.cs` / `SystemUserService.cs`** — four identity fields (`RightDto.Key`, `CompactPackageDto.Urn`, `CompactRoleDto.Urn`) became `string?`. Fixed honestly at the use site — skip a null right-key rather than emit it into `DirectRightKeys`; `?? string.Empty` when projecting into the primitive DTO — rather than papering over with `!` in the model.

## Verification

- Unique warning counts: **`Core` 184 → 143**, host **unchanged at 266** (no warnings pushed up), `Integration` still **0**.
- Clean Debug solution rebuild: **0 errors**.
- Full suite: **494 passed, 0 failed, 2 skipped**.

Next Core iterations will take the remaining folders (`AccessPackages` 44, `SystemUsers` 26, `Models` 25, `ResourceRegistry` 18, `Rights` 15, `Profile` 10). The model-binding audit from #488 lands with whichever iteration covers the request-bound types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Added: unblock CI (`build:` commit)

While this PR was in review, CI started failing on **all** PRs and `main` — not from this diff. NuGet published new `NU1903` security advisories against transitive dependencies (`SSH.NET 2025.1.0` via Testcontainers, and `System.Security.Cryptography.Xml 10.0.7` from the net10.0 framework), and the ratchet-locked projects' `TreatWarningsAsErrors` promoted them to build errors. Version bumps cascade (SSH.NET → the Xml package → five more advisories), and the Xml package is framework-provided with no clean fix yet.

The second commit scopes `NU1901`–`NU1904` out of error promotion in the root `Directory.Build.props` via `WarningsNotAsErrors`, mirroring the existing central `NU1510` suppression. Audit stays on — advisories still print as warnings for a dedicated dependency-bump pass — they just no longer break unrelated builds. Folded in here (per discussion) so this PR can go green; it independently unblocks `main`.
