### PR TITLE
chore(core): clear nullable warnings in SystemUsers (#488, Core iteration 3)

### DIFF
--- a/src/Authentication/Services/SystemUserService.cs
+++ b/src/Authentication/Services/SystemUserService.cs
@@ -1249,24 +1249,6 @@ namespace Altinn.Platform.Authentication.Services
             return rights;
         }
 
-        private static Result<List<Customer>> OldConvertConnectionDTOToClient(List<ClientDto> value)
-        {
-            List<Customer> result = [];
-            foreach (var item in value)
-            {
-                var newCustomer = new Customer()
-                {
-                    DisplayName = item.Party.Name,
-                    OrganizationIdentifier = item.Party.OrganizationNumber,
-                    PartyUuid = item.Party.Id,
-                    Access = item.Access
-                };
-                result.Add(newCustomer);
-            }
-
-            return result;
-        }
-
         private static Result<List<ExternalClientDto>> ConvertConnectionDTOToClient(List<ClientDelegationDto> value)
         {
             List<ExternalClientDto> result = [];

--- a/src/Core/Models/SystemUsers/AgentRequestSystemResponse.cs
+++ b/src/Core/Models/SystemUsers/AgentRequestSystemResponse.cs
@@ -41,7 +41,7 @@ public class AgentRequestSystemResponse()
     /// </summary>
     [Required]
     [JsonPropertyName("systemId")]
-    public string SystemId { get; set; }
+    public required string SystemId { get; set; }
 
     /// <summary>
     /// The organisation number for the SystemUser's Party ( the customer that delegates rights to the systemuser).
@@ -49,7 +49,7 @@ public class AgentRequestSystemResponse()
     /// </summary>
     [Required]
     [JsonPropertyName("partyOrgNo")]
-    public string PartyOrgNo { get; set; }
+    public required string PartyOrgNo { get; set; }
 
     /// <summary>
     /// The set of Rights requested for this system user. Must be equal to or less than the set defined in the Registered System.
@@ -57,7 +57,7 @@ public class AgentRequestSystemResponse()
     /// </summary>
     [Required]
     [JsonPropertyName("accessPackages")]
-    public List<AccessPackage> AccessPackages { get; set; }
+    public List<AccessPackage> AccessPackages { get; set; } = [];
 
     /// <summary>
     /// Initially the request is "new", 
@@ -65,7 +65,7 @@ public class AgentRequestSystemResponse()
     /// </summary>
     [Required]
     [JsonPropertyName("status")]
-    public string Status { get; set; }
+    public required string Status { get; set; }
 
     /// <summary>
     /// Optional redirect URL to navigate to after the customer has accepted/denied the Request

--- a/src/Core/Models/SystemUsers/ChangeRequestResponse.cs
+++ b/src/Core/Models/SystemUsers/ChangeRequestResponse.cs
@@ -32,7 +32,7 @@ public class ChangeRequestResponse()
     /// </summary>
     [Required]
     [JsonPropertyName("systemId")]
-    public string SystemId { get; set; }
+    public required string SystemId { get; set; }
 
     [Required]
     [JsonPropertyName("systemUserId")]
@@ -44,7 +44,7 @@ public class ChangeRequestResponse()
     /// </summary>
     [Required]
     [JsonPropertyName("partyOrgNo")]
-    public string PartyOrgNo { get; set; }
+    public required string PartyOrgNo { get; set; }
 
     /// <summary>
     /// The set of Rights requested as Required for this system user. 
@@ -90,7 +90,7 @@ public class ChangeRequestResponse()
     /// </summary>
     [Required]
     [JsonPropertyName("status")]
-    public string Status { get; set; }
+    public required string Status { get; set; }
 
     /// <summary>
     /// Optional redirect URL to navigate to after the customer has accepted/denied the Request

--- a/src/Core/Models/SystemUsers/ChangeRequestResponseInternal.cs
+++ b/src/Core/Models/SystemUsers/ChangeRequestResponseInternal.cs
@@ -32,7 +32,7 @@ public class ChangeRequestResponseInternal()
     /// </summary>
     [Required]
     [JsonPropertyName("systemId")]
-    public string SystemId { get; set; }
+    public required string SystemId { get; set; }
 
     [Required]
     [JsonPropertyName("systemUserId")]
@@ -44,7 +44,7 @@ public class ChangeRequestResponseInternal()
     /// </summary>
     [Required]
     [JsonPropertyName("partyOrgNo")]
-    public string PartyOrgNo { get; set; }
+    public required string PartyOrgNo { get; set; }
 
     /// <summary>
     /// The partyId for the reportee
@@ -106,7 +106,7 @@ public class ChangeRequestResponseInternal()
     /// </summary>
     [Required]
     [JsonPropertyName("status")]
-    public string Status { get; set; }
+    public required string Status { get; set; }
 
     /// <summary>
     /// Optional redirect URL to navigate to after the customer has accepted/denied the Request

--- a/src/Core/Models/SystemUsers/ClientDto.cs
+++ b/src/Core/Models/SystemUsers/ClientDto.cs
@@ -1,98 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Altinn.Platform.Authentication.Core.Models.SystemUsers
+﻿namespace Altinn.Platform.Authentication.Core.Models.SystemUsers
 {
     /// <summary>
-    /// Model representing a connected client party, meaning a party which has been authorized for one or more accesses, either directly or through role(s), access packages, resources or resource instances.
-    /// Model can be used both to represent a connection received from another party or a connection provided to another party.
+    /// Container for <see cref="ClientRoleAccessPackages"/>, which callers reach through
+    /// "using static ... ClientDto;". The client-party model that used to live alongside it was
+    /// removed once the v2 client-delegation payload (ClientDelegationDto) replaced that path.
     /// </summary>
     public class ClientDto
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ClientDto"/> class.
-        /// </summary>
-        public ClientDto()
-        {
-        }
-
-        /// <summary>
-        /// Gets or sets the party
-        /// </summary>
-        public ClientParty Party { get; set; }
-
-        /// <summary>
-        /// Gets or sets a collection of all access information for the client 
-        /// </summary>
-        public List<ClientRoleAccessPackages> Access { get; set; } = [];
-
-        /// <summary>
-        /// Composite Key instances
-        /// </summary>
-        public class ClientParty
-        {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="ClientParty"/> class.
-            /// </summary>
-            public ClientParty()
-            {
-            }
-
-            /// <summary>
-            /// Gets or sets the universally unique identifier of the party
-            /// </summary>
-            public Guid Id { get; set; }
-
-            /// <summary>
-            /// Gets or sets the name of the party
-            /// </summary>
-            public string Name { get; set; }
-
-            /// <summary>
-            /// Gets the organization number if the party is an organization
-            /// </summary>
-            public string OrganizationNumber { get; set; }
-
-            /// <summary>
-            /// Gets or sets the unit type if the party is an organization
-            /// </summary>
-            public string UnitType { get; set; }
-
-            /* ToBe Added in the future maybe
-            /// <summary>
-            /// Gets or sets the type of party
-            /// </summary>
-            public string Type { get; set; }
-
-            /// <summary>
-            /// Gets or sets whether this party is marked as deleted in the Central Coordinating Register for Legal Entities
-            /// </summary>
-            public bool IsDeleted { get; set; }
-
-            /// <summary>
-            /// Gets or sets a set of subunits of this party, which the authorized subject also has some access to.
-            /// </summary>
-            public List<ClientParty> Subunits { get; set; } = [];
-            */
-        }
-
-        /// <summary>
-        /// Composite Key instances
+        /// The role a client is accessed through, and the access packages held via that role
         /// </summary>
         public class ClientRoleAccessPackages
         {
             /// <summary>
             /// Role
             /// </summary>
-            public string Role { get; set; }
+            public required string Role { get; set; }
 
             /// <summary>
             /// Packages
             /// </summary>
-            public string[] Packages { get; set; }
+            public required string[] Packages { get; set; }
         }
     }
 }

--- a/src/Core/Models/SystemUsers/CreateAgentRequestSystemUser.cs
+++ b/src/Core/Models/SystemUsers/CreateAgentRequestSystemUser.cs
@@ -30,7 +30,7 @@ public class CreateAgentRequestSystemUser()
     /// </summary>
     [Required]
     [JsonPropertyName("systemId")]
-    public string SystemId { get; set; }
+    public required string SystemId { get; set; }
 
     /// <summary>
     /// The organisation number for the SystemUser's Party 
@@ -38,7 +38,7 @@ public class CreateAgentRequestSystemUser()
     /// </summary>
     [Required]
     [JsonPropertyName("partyOrgNo")]
-    public string PartyOrgNo { get; set; }
+    public required string PartyOrgNo { get; set; }
 
     /// <summary>
     /// The set of Rights requested for this system user. 
@@ -47,7 +47,7 @@ public class CreateAgentRequestSystemUser()
     /// </summary>
     [Required]
     [JsonPropertyName("accessPackages")]
-    public List<AccessPackage> AccessPackages { get; set; }
+    public required List<AccessPackage> AccessPackages { get; set; }
 
     /// <summary>
     /// Optional redirect URL to navigate to after the customer has accepted/denied the Request

--- a/src/Core/Models/SystemUsers/RequestSystemResponse.cs
+++ b/src/Core/Models/SystemUsers/RequestSystemResponse.cs
@@ -38,7 +38,7 @@ public class RequestSystemResponse()
     /// </summary>
     [Required]
     [JsonPropertyName("systemId")]
-    public string SystemId { get; set; }
+    public required string SystemId { get; set; }
 
     /// <summary>
     /// The organisation number for the SystemUser's Party ( the customer that delegates rights to the systemuser).
@@ -46,7 +46,7 @@ public class RequestSystemResponse()
     /// </summary>
     [Required]
     [JsonPropertyName("partyOrgNo")]
-    public string PartyOrgNo { get; set; }
+    public required string PartyOrgNo { get; set; }
 
     /// <summary>
     /// The set of Rights requested for this system user. Must be equal to or less than the set defined in the Registered System.
@@ -70,7 +70,7 @@ public class RequestSystemResponse()
     /// </summary>
     [Required]
     [JsonPropertyName("status")]
-    public string Status { get; set; }
+    public required string Status { get; set; }
 
     /// <summary>
     /// Optional redirect URL to navigate to after the customer has accepted/denied the Request

--- a/src/Core/Models/SystemUsers/RequestSystemResponseInternal.cs
+++ b/src/Core/Models/SystemUsers/RequestSystemResponseInternal.cs
@@ -38,7 +38,7 @@ public class RequestSystemResponseInternal()
     /// </summary>
     [Required]
     [JsonPropertyName("systemId")]
-    public string SystemId { get; set; }
+    public required string SystemId { get; set; }
 
     /// <summary>
     /// The organisation number for the SystemUser's Party ( the customer that delegates rights to the systemuser).
@@ -46,7 +46,7 @@ public class RequestSystemResponseInternal()
     /// </summary>
     [Required]
     [JsonPropertyName("partyOrgNo")]
-    public string PartyOrgNo { get; set; }
+    public required string PartyOrgNo { get; set; }
 
     /// <summary>
     /// The old int partyId, used internally
@@ -66,7 +66,7 @@ public class RequestSystemResponseInternal()
     /// </summary>
     [Required]
     [JsonPropertyName("rights")]
-    public List<Right> Rights { get; set; }
+    public List<Right> Rights { get; set; } = [];
 
     /// <summary>
     /// The set of Accesspackages requested for this system user. Must be equal to or less than the set defined in the Registered System.
@@ -74,7 +74,7 @@ public class RequestSystemResponseInternal()
     /// </summary>
     [Required]
     [JsonPropertyName("accessPackages")]
-    public List<AccessPackage> AccessPackages { get; set; }
+    public List<AccessPackage> AccessPackages { get; set; } = [];
 
     /// <summary>
     /// Initially the request is "new", 
@@ -82,7 +82,7 @@ public class RequestSystemResponseInternal()
     /// </summary>
     [Required]
     [JsonPropertyName("status")]
-    public string Status { get; set; }
+    public required string Status { get; set; }
 
     /// <summary>
     /// Optional redirect URL to navigate to after the customer has accepted/denied the Request
@@ -122,8 +122,11 @@ public class RequestSystemResponseInternal()
     public DateTime Created { get; set; }
 
     /// <summary>
-    /// Either Agent or Default
+    /// Either Agent or Default.
+    /// Null on the standard-request path: CheckUserAuthorizationAndGetRequest builds this
+    /// response from a RequestSystemResponse, which carries no user type, while the agent
+    /// variant sets it from the request. See the note in the PR for #488, Core iteration 3.
     /// </summary>
     [JsonPropertyName("systemUserType")]
-    public string SystemUserType { get; set; }
+    public string? SystemUserType { get; set; }
 }


### PR DESCRIPTION
Part of #488. **Core iteration 3** — the third slice of the `Core` cleanup, following iteration 1 (#2136) and iteration 2 (#2141).

Clears all **28** `CS8618` warnings in `Core/Models/SystemUsers/`. `Core` isn't locked yet — that comes in the final iteration once all its warnings are gone — but this batch pushes **zero** warnings up into the already-locked `Integration` and `Tests` projects.

## Dead code first, as in iteration 2

`ClientDto.Party` and the nested `ClientParty` had exactly one reader: `OldConvertConnectionDTOToClient` in `SystemUserService`. Nothing calls that method — `IAccessManagementClient.GetClientsForFacilitator` returns `List<ClientDelegationDto>` (the v2 payload) and the live conversion is `ConvertConnectionDTOToClient`. Method and model are deleted, which takes 4 of the 28 warnings with them.

`ClientDto` itself stays, because nine call sites reach its nested `ClientRoleAccessPackages` through `using static ... ClientDto;`. Promoting that nested type to its own file would let the shell go too, but it touches every `using static` and belongs in its own PR rather than here.

## Convention for the remaining 24

This folder is request/response DTOs rather than upstream payloads, so the evidence is the **clean files sitting next to them** — `CreateRequestSystemUser`, `SystemUserRegisterDTO`, `PartyRecord`, `AgentDelegation` — not the AM test JSON used in the previous iterations:

- **`required` on the identity fields** `SystemId`, `PartyOrgNo`, `Status` across the five request/response DTOs. The sibling `CreateRequestSystemUser` already carries `required` on `SystemId`/`PartyOrgNo` in production, so this makes the agent and standard request models behave identically instead of differing by accident.
- **`= []` on the `Rights` / `AccessPackages` lists**, exactly as `RequestSystemResponse` already did for its own two.
- **`required` on `CreateAgentRequestSystemUser.AccessPackages`** — both `[Required]` and the doc comment state a missing or empty list is an error, so the model should not quietly accept its absence.
- **`required` on `ClientRoleAccessPackages.Role`/`Packages`**, which every construction site already sets.

## One real gap surfaced

`required` turned up a build error at `RequestSystemUserService.cs:980`: **`RequestSystemResponseInternal.SystemUserType` is never set on the standard-request path.** `CheckUserAuthorizationAndGetRequest` builds the response from a `RequestSystemResponse`, which carries no user type, while the agent variant one method up sets `request.UserType.ToString()`. That endpoint therefore returns `"systemUserType": null` today.

It is annotated `string?` with the reason in the doc comment rather than quietly fixed. The likely one-liner is `SystemUserType = SystemUserType.Standard.ToString()`, but that changes what the API returns and deserves its own issue and review — flagging here rather than smuggling it into a cleanup PR.

## Verification

- Unique warning counts: **`Core` 99 → 71**, host **unchanged at 254** (no warnings pushed up), `Integration` / `Tests` / `Persistance` / `SystemIntegrationTests` still **0**.
- Clean `-t:Rebuild` of the solution in Debug: **0 errors**.
- Full suite: **517 passed, 0 failed, 2 skipped**. That matters more than usual here: `required` also applies when System.Text.Json deserializes, and these response models are read back from JSON at 134 test sites — none of them broke.

Remaining in `Core` for later iterations: `Models` 25, `Models/ResourceRegistry` 18, `Models/Rights` 15, `Models/Profile` 10, `Helpers` 3, `Models/Oidc` 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Swagger impact (checked, not assumed)

The generated OpenAPI document was dumped from the test host on `main` and on this branch and diffed. **The entire difference is four lines**: the `ClientRoleAccessPackages` schema gains

```json
"required": [ "packages", "role" ]
```

It is reached from `GET /authentication/api/v1/systemuser/agent/{party}/clients` via the `Customer` schema.

Nothing else moves, for two reasons:

- The identity fields on the five request/response DTOs already carried `[Required]`, so they were **already** in their schemas' `required` lists — the C# `required` modifier adds no new information there.
- `AddSwaggerGen` is not configured with `SupportNonNullableReferenceTypes()`, so nullable reference annotations do not reach the document at all. That is why `RequestSystemResponseInternal.SystemUserType` going from `string` to `string?` is invisible in the spec, and why the two newly-required properties above are still emitted as `nullable: true`.

No spec file is committed to the repo and no CI job validates one, so this is a runtime-generated change only.
