### PR TITLE
Early error/information message on notdelegable resources

### DIFF
--- a/src/Authentication/Controllers/SystemRegisterController.cs
+++ b/src/Authentication/Controllers/SystemRegisterController.cs
@@ -470,11 +470,12 @@ public class SystemRegisterController : ControllerBase
     {
         ValidationProblemBuilder errors = default;
 
-        var (invalidFormatResourceIds, notFoundResourceIds, notDelegableResourceIds) = await _systemRegisterService.GetInvalidResourceIdsDetailed(rights, cancellationToken);
+        var (invalidFormatResourceIds, notFoundResourceIds, unsupportedResourceTypeIds, notDelegableResourceIds) = await _systemRegisterService.GetInvalidResourceIdsDetailed(rights, cancellationToken);
 
         errors = AddErrorIfAny(errors, invalidFormatResourceIds, ValidationErrors.SystemRegister_ResourceId_InvalidFormat, "Invalid Resource Id Details : ");
         errors = AddErrorIfAny(errors, notFoundResourceIds, ValidationErrors.SystemRegister_ResourceId_DoesNotExist, "ResourceIds Not Found : ");
-        errors = AddErrorIfAny(errors, notDelegableResourceIds, ValidationErrors.SystemRegister_ResourceId_NotDelegable, "ResourceIds Not Delegable : ");
+        errors = AddErrorIfAny(errors, unsupportedResourceTypeIds, ValidationErrors.SystemRegister_ResourceId_NotDelegable, "ResourceIds Not Delegable : ");
+        errors = AddErrorIfAny(errors, notDelegableResourceIds, ValidationErrors.SystemRegister_ResourceId_ResourceNotDelegable, "Resources Not Delegable : ");
 
         if (AuthenticationHelper.HasDuplicateRights(rights))
         {

--- a/src/Authentication/Services/ChangeRequestSystemUserService.cs
+++ b/src/Authentication/Services/ChangeRequestSystemUserService.cs
@@ -554,7 +554,7 @@ public class ChangeRequestSystemUserService(
 
         if (validateSet.RequiredRights is not null && validateSet.RequiredRights.Count > 0)
         {
-            Result<bool> valRights = systemUserService.ValidateRights(validateSet.RequiredRights, systemInfo);
+            Result<bool> valRights = await systemUserService.ValidateRights(validateSet.RequiredRights, systemInfo);
             if (valRights.IsProblem)
             {
                 return valRights.Problem;

--- a/src/Authentication/Services/Interfaces/ISystemRegisterService.cs
+++ b/src/Authentication/Services/Interfaces/ISystemRegisterService.cs
@@ -158,17 +158,19 @@ namespace Altinn.Platform.Authentication.Services.Interfaces
         Task<IList<SystemChangeLog>> GetChangeLogAsync(Guid systemInternalId, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Identifies resource IDs in the given rights that have invalid format, are not found, or are not delegable.
+        /// Identifies resource IDs in the given rights that have invalid format, are not found, are of an unsupported
+        /// resource type, or are marked as not delegable in the resource registry.
         /// </summary>
         /// <remarks>
         /// Each resource attribute is checked for correct ID format, then looked up in the resource registry.
         /// Resources whose <see cref="ServiceResource.ResourceType"/> is not in <see cref="WhitelistedResourceTypes"/>
-        /// are treated as not delegable.</remarks>
+        /// are reported as unsupported resource types; resources the resource registry has flagged with delegable false
+        /// are reported as not delegable.</remarks>
         /// <param name="rights">A list of rights to be validated.</param>
         /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-        /// <returns>A tuple containing three lists: <see cref="List{T}"/> of rights that are not in valid format, <see cref="List{T}"/> of rights that are not found and  <see cref="List{T}"/>
-        /// of rights that are not delegable.</returns>
-        Task<(List<string> InvalidFormatResourceIds, List<string> NotFoundResourceIds, List<string> NotDelegableResourceIds)>
+        /// <returns>A tuple containing four lists: <see cref="List{T}"/> of rights that are not in valid format, <see cref="List{T}"/> of rights that are not found,
+        /// <see cref="List{T}"/> of rights whose resource type is not supported and <see cref="List{T}"/> of rights whose resource is not delegable.</returns>
+        Task<(List<string> InvalidFormatResourceIds, List<string> NotFoundResourceIds, List<string> UnsupportedResourceTypeIds, List<string> NotDelegableResourceIds)>
             GetInvalidResourceIdsDetailed(List<Right> rights, CancellationToken cancellationToken);
     }
 }

--- a/src/Authentication/Services/Interfaces/ISystemUserService.cs
+++ b/src/Authentication/Services/Interfaces/ISystemUserService.cs
@@ -212,11 +212,14 @@ public interface ISystemUserService
     /// <summary>
     /// Validate that the Rights is both a subset of the Default Rights registered on the System, and at least one Right is selected.
     /// Also ensure that if any of the new Rights have sub-resources, that the sub-resources are equal to the registered Rights.
+    /// Finally ensure the resources are still usable in the resource registry: present, of a supported resource type
+    /// and delegable.
     /// </summary>
     /// <param name="rights">the Rights chosen for the Request</param>
     /// <param name="systemInfo">The Vendor's Registered System</param>
+    /// <param name="cancellationToken">the cancellation token</param>
     /// <returns>Result or Problem</returns>
-    Result<bool> ValidateRights(List<Right> rights, RegisteredSystemResponse systemInfo);
+    Task<Result<bool>> ValidateRights(List<Right> rights, RegisteredSystemResponse systemInfo, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Validate that the Package is both a subset of the Default Packages registered on the System, and at least one Package is selected.

--- a/src/Authentication/Services/RequestSystemUserService.cs
+++ b/src/Authentication/Services/RequestSystemUserService.cs
@@ -120,7 +120,7 @@ public class RequestSystemUserService(
 
         if (createRequest.Rights is not null && createRequest.Rights.Count > 0)
         {
-            Result<bool> valRights = systemUserService.ValidateRights(createRequest.Rights, systemInfo);
+            Result<bool> valRights = await systemUserService.ValidateRights(createRequest.Rights, systemInfo);
             if (valRights.IsProblem)
             {
                 return valRights.Problem;

--- a/src/Authentication/Services/SystemRegisterService.cs
+++ b/src/Authentication/Services/SystemRegisterService.cs
@@ -151,11 +151,12 @@ namespace Altinn.Platform.Authentication.Services
         }
 
         /// <inheritdoc/>
-        public async Task<(List<string> InvalidFormatResourceIds, List<string> NotFoundResourceIds, List<string> NotDelegableResourceIds)> GetInvalidResourceIdsDetailed(List<Right> rights, CancellationToken cancellationToken)
+        public async Task<(List<string> InvalidFormatResourceIds, List<string> NotFoundResourceIds, List<string> UnsupportedResourceTypeIds, List<string> NotDelegableResourceIds)> GetInvalidResourceIdsDetailed(List<Right> rights, CancellationToken cancellationToken)
         {
             ServiceResource? resource = null;
             var invalidFormatResourceIds = new List<string>();
             var notFoundResourceIds = new List<string>();
+            var unsupportedResourceTypeIds = new List<string>();
             var notDelegableResourceIds = new List<string>();
             foreach (Right right in rights)
             {
@@ -175,13 +176,17 @@ namespace Altinn.Platform.Authentication.Services
                         }
                         else if (!WhitelistedResourceTypes.Contains(resource.ResourceType))
                         {
+                            unsupportedResourceTypeIds.Add(resourceId.Value);
+                        }
+                        else if (!resource.Delegable)
+                        {
                             notDelegableResourceIds.Add(resourceId.Value);
                         }
                     }
                 }
             }
 
-            return (invalidFormatResourceIds, notFoundResourceIds, notDelegableResourceIds);
+            return (invalidFormatResourceIds, notFoundResourceIds, unsupportedResourceTypeIds, notDelegableResourceIds);
         }
 
         /// <inheritdoc/>

--- a/src/Authentication/Services/SystemUserService.cs
+++ b/src/Authentication/Services/SystemUserService.cs
@@ -457,7 +457,7 @@ namespace Altinn.Platform.Authentication.Services
 
             if (rights is not null && rights.Count > 0)
             {
-                Result<bool> validatedRequestedRights = ValidateRights(rights, regSystem);
+                Result<bool> validatedRequestedRights = await ValidateRights(rights, regSystem, cancellationToken);
                 if (validatedRequestedRights.IsProblem)
                 {
                     validationProblems.Add(validatedRequestedRights.Problem);
@@ -673,7 +673,7 @@ namespace Altinn.Platform.Authentication.Services
         }
 
         /// <inheritdoc/>
-        public Result<bool> ValidateRights(List<Right> rights, RegisteredSystemResponse systemInfo)
+        public async Task<Result<bool>> ValidateRights(List<Right> rights, RegisteredSystemResponse systemInfo, CancellationToken cancellationToken = default)
         {
             if ((rights.Count > 0 && systemInfo.Rights is null) || (rights.Count > systemInfo.Rights!.Count))
             {
@@ -708,7 +708,37 @@ namespace Altinn.Platform.Authentication.Services
                 }
             }
 
-            return true;
+            // The rights match the registered system, but the resources themselves can have been deleted, changed
+            // type or turned non-delegable in the resource registry after the system was registered. Catch that here
+            // instead of at the customer's approval.
+            var invalidResourceIds = await systemRegisterService.GetInvalidResourceIdsDetailed(rights, cancellationToken);
+
+            List<KeyValuePair<string, string>> invalidResourceDetails = [];
+            AddResourceIdsIfAny(invalidResourceDetails, "InvalidFormatResources", invalidResourceIds.InvalidFormatResourceIds);
+            AddResourceIdsIfAny(invalidResourceDetails, "NotFoundResources", invalidResourceIds.NotFoundResourceIds);
+            AddResourceIdsIfAny(invalidResourceDetails, "UnsupportedResourceTypes", invalidResourceIds.UnsupportedResourceTypeIds);
+            AddResourceIdsIfAny(invalidResourceDetails, "NotDelegableResources", invalidResourceIds.NotDelegableResourceIds);
+
+            if (invalidResourceDetails.Count == 0)
+            {
+                return true;
+            }
+
+            ProblemExtensionData extensionData = ProblemExtensionData.Create(invalidResourceDetails.ToArray());
+
+            // Report the precise problem when the delegable flag is the only thing standing in the way; the other
+            // categories mean the resource is missing or unusable rather than merely non-delegable.
+            return invalidResourceIds.NotDelegableResourceIds.Count > 0 && invalidResourceDetails.Count == 1
+                ? Problem.Rights_ResourceNotDelegable.Create(extensionData)
+                : Problem.Rights_NotFound_Or_NotDelegable.Create(extensionData);
+        }
+
+        private static void AddResourceIdsIfAny(List<KeyValuePair<string, string>> details, string key, List<string> resourceIds)
+        {
+            if (resourceIds.Count > 0)
+            {
+                details.Add(new KeyValuePair<string, string>(key, string.Join(", ", resourceIds)));
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Core/Errors/ValidationErrors.cs
+++ b/src/Core/Errors/ValidationErrors.cs
@@ -126,4 +126,10 @@ public static class ValidationErrors
     /// </summary>
     public static ValidationErrorDescriptor SystemRegister_IsVisible_With_NonAssignable_AccessPackage { get; }
         = _factory.Create(18, "Access packages meant for system user for client relations can't be used in combination with the flag isVisible: true");
+
+    /// <summary>
+    /// Gets a validation error descriptor if the resource is marked as not delegable in the resource registry
+    /// </summary>
+    public static ValidationErrorDescriptor SystemRegister_ResourceId_ResourceNotDelegable { get; }
+        = _factory.Create(19, "One or more resources specified in rights is marked as not delegable in the resource registry.");
 }

--- a/src/Core/Problems/Problem.cs
+++ b/src/Core/Problems/Problem.cs
@@ -502,4 +502,10 @@ public static class Problem
     /// </summary>
     public static ProblemDescriptor SystemIsDeleted { get; }
         = _factory.Create(81, HttpStatusCode.BadRequest, "The Registered System is deleted and cannot be used to create new requests.");
+
+    /// <summary>
+    /// One or more of the requested single rights refer to a resource the resource registry has marked as not delegable.
+    /// </summary>
+    public static ProblemDescriptor Rights_ResourceNotDelegable { get; }
+        = _factory.Create(82, HttpStatusCode.BadRequest, "One or more resources specified in rights is marked as not delegable in the resource registry.");
 }

--- a/test/Altinn.Platform.Authentication.Tests/Altinn.Platform.Authentication.Tests.csproj
+++ b/test/Altinn.Platform.Authentication.Tests/Altinn.Platform.Authentication.Tests.csproj
@@ -128,6 +128,12 @@
     <None Update="Data\SystemRegister\Json\SystemRegisterInvalidResourceType.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Data\SystemRegister\Json\SystemRegisterNotDelegableResource.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Data\SystemRegister\Json\UpdateRightNotDelegableResource.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Data\SystemRegister\Json\SystemRegister_altinn.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -180,6 +186,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Data\ResourceRegistry\app_endringavnavnv2.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Data\ResourceRegistry\app_a1nondelegable.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Data\ResourceRegistry\kravogbetaling.json">

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/ChangeRequestControllerTest.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/ChangeRequestControllerTest.cs
@@ -64,6 +64,7 @@ public class ChangeRequestControllerTest(
     private readonly Mock<IGuidService> guidService = new();
     private readonly Mock<IEventsQueueClient> _eventQueue = new();
     private readonly Mock<IPDP> _pdpMock = new();
+    private readonly ResourceRegistryClientMock _resourceRegistryClient = new();
     private int _paginationSize;
 
     protected override void ConfigureServices(IServiceCollection services)
@@ -109,7 +110,7 @@ public class ChangeRequestControllerTest(
         services.AddSingleton<ISystemRegisterService, SystemRegisterService>();
         services.AddSingleton<IRequestSystemUser, RequestSystemUserService>();
         services.AddSingleton<IAccessManagementClient, AccessManagementClientMock>();
-        services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
+        services.AddSingleton<IResourceRegistryClient>(_resourceRegistryClient);
         services.AddSingleton<IRequestRepository, RequestRepository>();
         services.AddSingleton<ISystemUserRepository, SystemUserRepository>();
         services.AddSingleton<IChangeRequestRepository, ChangeRequestRepository>();
@@ -360,6 +361,115 @@ public class ChangeRequestControllerTest(
         ProblemDetails? problemDetails = await createdResponseMessage.Content.ReadFromJsonAsync<ProblemDetails>();
         Assert.NotNull(problemDetails);
         Assert.Equal(Problem.SystemIsDeleted.Title, problemDetails.Title);
+    }
+
+    [Fact]
+    public async Task ChangeRequest_Create_Fails_When_Resource_Turned_NotDelegable()
+    {
+        List<XacmlJsonResult> xacmlJsonResults = GetDecisionResultSingle();
+
+        _pdpMock.Setup(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).ReturnsAsync(new XacmlJsonResponse
+        {
+            Response = xacmlJsonResults
+        });
+
+        // Create System used for test
+        string dataFileName = "Data/SystemRegister/Json/SystemRegister2Rights.json";
+        HttpResponseMessage response = await CreateSystemRegister(dataFileName);
+
+        HttpClient client = CreateClient();
+        string token = AddSystemUserRequestWriteTestTokenToClient(client);
+        string endpoint = $"/authentication/api/v1/systemuser/request/vendor";
+
+        Right right = new()
+        {
+            Resource =
+            [
+                new AttributePair()
+                {
+                    Id = "urn:altinn:resource",
+                    Value = "ske-krav-og-betalinger"
+                }
+            ]
+        };
+
+        Right right2 = new()
+        {
+            Resource =
+            [
+                new AttributePair()
+                {
+                    Id = "urn:altinn:resource",
+                    Value = "ske-krav-og-betalinger-2"
+                }
+            ]
+        };
+
+        string systemId = "991825827_the_matrix";
+
+        // Arrange
+        CreateRequestSystemUser req = new()
+        {
+            ExternalRef = "external",
+            SystemId = systemId,
+            PartyOrgNo = "910493353",
+            Rights = [right]
+        };
+
+        HttpRequestMessage request = new(HttpMethod.Post, endpoint)
+        {
+            Content = JsonContent.Create(req)
+        };
+        HttpResponseMessage message = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+        Assert.Equal(HttpStatusCode.Created, message.StatusCode);
+
+        RequestSystemResponse? res = await message.Content.ReadFromJsonAsync<RequestSystemResponse>();
+        Assert.NotNull(res);
+
+        // Party approves the original request, so there is a system user to change
+        HttpClient client2 = CreateClient();
+        client2.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1337, null, 3, true, now: TestTime));
+
+        int partyId = 500000;
+
+        string approveEndpoint = $"/authentication/api/v1/systemuser/request/{partyId}/{res.Id}/approve";
+        HttpRequestMessage approveRequestMessage = new(HttpMethod.Post, approveEndpoint);
+        HttpResponseMessage approveResponseMessage = await client2.SendAsync(approveRequestMessage, HttpCompletionOption.ResponseHeadersRead);
+        Assert.Equal(HttpStatusCode.OK, approveResponseMessage.StatusCode);
+
+        string getEndpoint = $"/authentication/api/v1/systemuser/vendor/byquery?system-id={systemId}&orgno={req.PartyOrgNo}&external-ref={req.ExternalRef}";
+        HttpRequestMessage getRequestMessage = new(HttpMethod.Get, getEndpoint);
+        HttpResponseMessage getResponseMessage = await client.SendAsync(getRequestMessage, HttpCompletionOption.ResponseHeadersRead);
+        Assert.Equal(HttpStatusCode.OK, getResponseMessage.StatusCode);
+
+        SystemUserDetailExternalDTO? systemuser = await getResponseMessage.Content.ReadFromJsonAsync<SystemUserDetailExternalDTO>();
+        Assert.NotNull(systemuser);
+
+        // The resource the change request asks for is turned non-delegable after the system was registered
+        _resourceRegistryClient.NotDelegableResourceIds.Add("ske-krav-og-betalinger-2");
+
+        Guid id = Guid.NewGuid();
+
+        string createChangeRequestEndpoint = $"/authentication/api/v1/systemuser/changerequest/vendor?correlation-id={id}&system-user-id={systemuser.Id}";
+
+        ChangeRequestSystemUser change = new()
+        {
+            RequiredRights = [right2],
+            UnwantedRights = []
+        };
+
+        HttpRequestMessage createChangeRequestMessage = new(HttpMethod.Post, createChangeRequestEndpoint)
+        {
+            Content = JsonContent.Create(change)
+        };
+        HttpResponseMessage createdResponseMessage = await client.SendAsync(createChangeRequestMessage, HttpCompletionOption.ResponseHeadersRead);
+
+        Assert.Equal(HttpStatusCode.BadRequest, createdResponseMessage.StatusCode);
+        ProblemDetails? problemDetails = await createdResponseMessage.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problemDetails);
+        Assert.Equal(Problem.Rights_ResourceNotDelegable.Title, problemDetails.Title);
+        Assert.Equal("ske-krav-og-betalinger-2", problemDetails.Extensions["NotDelegableResources"]?.ToString());
     }
 
     /// <summary>

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/RequestControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/RequestControllerTests.cs
@@ -61,6 +61,7 @@ public class RequestControllerTests(
     private readonly FakeTimeProvider timeProvider = new();
     private readonly Mock<IGuidService> guidService = new();
     private readonly Mock<IEventsQueueClient> _eventQueue = new();
+    private readonly ResourceRegistryClientMock _resourceRegistryClient = new();
     private static readonly DateTimeOffset TestTime = new(2025, 05, 15, 02, 05, 00, TimeSpan.Zero);
     private int _paginationSize;
 
@@ -103,7 +104,7 @@ public class RequestControllerTests(
         services.AddSingleton<ISystemRegisterService, SystemRegisterService>();
         services.AddSingleton<IRequestSystemUser, RequestSystemUserService>();
         services.AddSingleton<IAccessManagementClient, AccessManagementClientMock>();
-        services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
+        services.AddSingleton<IResourceRegistryClient>(_resourceRegistryClient);
         services.AddSingleton<IRequestRepository, RequestRepository>();
 
         // SetupDateTimeMock();
@@ -259,6 +260,55 @@ public class RequestControllerTests(
         HttpResponseMessage message = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
 
         Assert.Equal(HttpStatusCode.BadRequest, message.StatusCode);                
+    }
+
+    [Fact]
+    public async Task Request_Create_ResourceTurnedNotDelegable_BadRequest()
+    {
+        string dataFileName = "Data/SystemRegister/Json/SystemRegister.json";
+        HttpResponseMessage response = await CreateSystemRegister(dataFileName);
+        Assert.True(response.IsSuccessStatusCode);
+
+        // The resource was delegable when the vendor registered the system, and is turned non-delegable afterwards.
+        _resourceRegistryClient.NotDelegableResourceIds.Add("ske-krav-og-betalinger");
+
+        HttpClient client = CreateClient();
+        string token = AddSystemUserRequestWriteTestTokenToClient(client);
+        string endpoint = $"/authentication/api/v1/systemuser/request/vendor";
+
+        Right right = new()
+        {
+            Resource =
+            [
+                new AttributePair()
+                {
+                    Id = "urn:altinn:resource",
+                    Value = "ske-krav-og-betalinger"
+                }
+            ]
+        };
+
+        // Arrange
+        CreateRequestSystemUser req = new()
+        {
+            ExternalRef = "external",
+            SystemId = "991825827_the_matrix",
+            PartyOrgNo = "910493353",
+            Rights = [right],
+            AccessPackages = []
+        };
+
+        HttpRequestMessage request = new(HttpMethod.Post, endpoint)
+        {
+            Content = JsonContent.Create(req)
+        };
+        HttpResponseMessage message = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+        Assert.Equal(HttpStatusCode.BadRequest, message.StatusCode);
+        ProblemDetails? problemDetails = await message.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problemDetails);
+        Assert.Equal(Problem.Rights_ResourceNotDelegable.Title, problemDetails.Title);
+        Assert.Equal("ske-krav-og-betalinger", problemDetails.Extensions["NotDelegableResources"]?.ToString());
     }
 
     [Fact]

--- a/test/Altinn.Platform.Authentication.Tests/Controllers/SystemRegisterControllerTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Controllers/SystemRegisterControllerTests.cs
@@ -264,6 +264,52 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
         }
 
         [Fact]
+        public async Task SystemRegister_Create_NotDelegableResource_BadRequest()
+        {
+            // Arrange
+            string dataFileName = "Data/SystemRegister/Json/SystemRegisterNotDelegableResource.json";
+            HttpClient client = GetAuthenticatedClient(Admin, ValidOrg);
+            HttpResponseMessage response = await SystemRegisterTestHelper.CreateSystemRegister(client, dataFileName);
+            Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+            AltinnValidationProblemDetails? problemDetails = await response.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            Assert.NotNull(problemDetails);
+            Assert.Single(problemDetails.Errors);
+            AltinnValidationError error = problemDetails.Errors.Single(e => e.ErrorCode == ValidationErrors.SystemRegister_ResourceId_ResourceNotDelegable.ErrorCode);
+            Assert.Equal("/registersystemrequest/rights/resource", error.Paths.Single(p => p.Equals("/registersystemrequest/rights/resource")));
+            Assert.Equal(ValidationErrors.SystemRegister_ResourceId_ResourceNotDelegable.Title, error.Title);
+            string? notDelegableExtensionValue = error.Extensions["Resources Not Delegable : "]?.ToString();
+            Assert.Equal("app_ttd_a1-nondelegable", notDelegableExtensionValue);
+        }
+
+        [Fact]
+        public async Task SystemRegister_Update_NotDelegableResource_BadRequest()
+        {
+            string dataFileName = "Data/SystemRegister/Json/SystemRegister.json";
+            HttpClient createClient = GetAuthenticatedClient(Admin, ValidOrg);
+            HttpResponseMessage response = await SystemRegisterTestHelper.CreateSystemRegister(createClient, dataFileName);
+            Assert.True(response.IsSuccessStatusCode);
+
+            HttpClient client = GetAuthenticatedClient(Admin, ValidOrg);
+
+            // Arrange
+            Stream dataStream = File.OpenRead("Data/SystemRegister/Json/UpdateRightNotDelegableResource.json");
+            StreamContent content = new StreamContent(dataStream);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+            string systemID = "991825827_the_matrix";
+            HttpRequestMessage request = new(HttpMethod.Put, $"/authentication/api/v1/systemregister/vendor/{systemID}/rights");
+            request.Content = content;
+            HttpResponseMessage updateResponse = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+            Assert.Equal(System.Net.HttpStatusCode.BadRequest, updateResponse.StatusCode);
+            AltinnValidationProblemDetails? problemDetails = await updateResponse.Content.ReadFromJsonAsync<AltinnValidationProblemDetails>();
+            Assert.NotNull(problemDetails);
+            AltinnValidationError error = problemDetails.Errors.Single(e => e.ErrorCode == ValidationErrors.SystemRegister_ResourceId_ResourceNotDelegable.ErrorCode);
+            Assert.Equal("/registersystemrequest/rights/resource", error.Paths.Single(p => p.Equals("/registersystemrequest/rights/resource")));
+            Assert.Equal(ValidationErrors.SystemRegister_ResourceId_ResourceNotDelegable.Title, error.Title);
+        }
+
+        [Fact]
         public async Task SystemRegister_Create_InvalidAccessPackages_BadRequest()
         {
             // Arrange

--- a/test/Altinn.Platform.Authentication.Tests/Data/ResourceRegistry/app_a1nondelegable.json
+++ b/test/Altinn.Platform.Authentication.Tests/Data/ResourceRegistry/app_a1nondelegable.json
@@ -1,0 +1,40 @@
+{
+  "identifier": "app_ttd_a1-nondelegable",
+  "title": {
+    "en": "Migrated Altinn 2 service",
+    "nb": "Migrert Altinn 2-tjeneste",
+    "nn": "Migrert Altinn 2-teneste"
+  },
+  "resourceReferences": [
+    {
+      "referenceSource": "Altinn3",
+      "reference": "ttd/a1-nondelegable",
+      "referenceType": "ApplicationId"
+    }
+  ],
+  "delegable": false,
+  "visible": false,
+  "hasCompetentAuthority": {
+    "name": {
+      "en": "Test Ministry",
+      "nn": "Testdepartementet",
+      "nb": "Testdepartementet"
+    },
+    "organization": "991825827",
+    "orgcode": "ttd"
+  },
+  "accessListMode": "Disabled",
+  "selfIdentifiedUserEnabled": false,
+  "enterpriseUserEnabled": false,
+  "resourceType": "AltinnApp",
+  "authorizationReference": [
+    {
+      "id": "urn:altinn:org",
+      "value": "ttd"
+    },
+    {
+      "id": "urn:altinn:app",
+      "value": "a1-nondelegable"
+    }
+  ]
+}

--- a/test/Altinn.Platform.Authentication.Tests/Data/SystemRegister/Json/SystemRegisterNotDelegableResource.json
+++ b/test/Altinn.Platform.Authentication.Tests/Data/SystemRegister/Json/SystemRegisterNotDelegableResource.json
@@ -1,0 +1,36 @@
+{
+  "id": "991825827_the_matrix",
+  "vendor": {
+    "authority": "iso6523-actorid-upis",
+    "ID": "0192:991825827"
+  },
+  "name": {
+    "nb": "The Matrix",
+    "en": "The Matrix",
+    "nn": "The Matrix"
+  },
+  "description": {
+    "nb": "Test system",
+    "en": "Test system",
+    "nn": "Test system"
+  },
+  "rights": [
+    {
+      "resource": [
+        {
+          "id": "urn:altinn:resource",
+          "value": "app_ttd_a1-nondelegable"
+        }
+      ]
+    }
+  ],
+  "softDeleted": false,
+  "clientId": [
+    "32ef65ac-6e62-498d-880f-76c85c2052ae"
+  ],
+  "allowedredirecturls": [
+    "https://vg.no",
+    "https://nrk.no"
+  ],
+  "isVisible": true
+}

--- a/test/Altinn.Platform.Authentication.Tests/Data/SystemRegister/Json/UpdateRightNotDelegableResource.json
+++ b/test/Altinn.Platform.Authentication.Tests/Data/SystemRegister/Json/UpdateRightNotDelegableResource.json
@@ -1,0 +1,10 @@
+[
+  {
+    "resource": [
+      {
+        "id": "urn:altinn:resource",
+        "value": "app_ttd_a1-nondelegable"
+      }
+    ]
+  }
+]

--- a/test/Altinn.Platform.Authentication.Tests/Mocks/ResourceRegistryClientMock.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Mocks/ResourceRegistryClientMock.cs
@@ -11,6 +11,12 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
 {
     public class ResourceRegistryClientMock : IResourceRegistryClient
     {
+        /// <summary>
+        /// Resource ids the mock reports as not delegable, whatever their data file says. Lets a test register a
+        /// system while the resource is still delegable and turn it non-delegable afterwards.
+        /// </summary>
+        public HashSet<string> NotDelegableResourceIds { get; } = [];
+
         public async Task<ServiceResource?> GetResource(string resourceId)
         {
             string dataFileName = string.Empty;
@@ -44,10 +50,21 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
                 dataFileName = "Data/ResourceRegistry/ttd-am-k6.json";
             }
 
+            if (resourceId == "app_ttd_a1-nondelegable")
+            {
+                dataFileName = "Data/ResourceRegistry/app_a1nondelegable.json";
+            }
+
             if (dataFileName != string.Empty)
             {
                 string content = File.ReadAllText(dataFileName);
-                return JsonSerializer.Deserialize<ServiceResource>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                ServiceResource? resource = JsonSerializer.Deserialize<ServiceResource>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                if (resource is not null && NotDelegableResourceIds.Contains(resourceId))
+                {
+                    resource.Delegable = false;
+                }
+
+                return resource;
             }
 
             return null;

--- a/test/Altinn.Platform.Authentication.Tests/Services/SystemRegisterServiceTests.cs
+++ b/test/Altinn.Platform.Authentication.Tests/Services/SystemRegisterServiceTests.cs
@@ -1,0 +1,115 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Altinn.Platform.Authentication.Core.Models;
+using Altinn.Platform.Authentication.Core.Models.Rights;
+using Altinn.Platform.Authentication.Core.RepositoryInterfaces;
+using Altinn.Platform.Authentication.Integration.AccessManagement;
+using Altinn.Platform.Authentication.Services;
+using Altinn.Platform.Authentication.Tests.Mocks;
+
+using Moq;
+using Xunit;
+
+namespace Altinn.Platform.Authentication.Tests.Services
+{
+    /// <summary>
+    /// Tests the resource validation in the system register service.
+    /// </summary>
+    public class SystemRegisterServiceTests
+    {
+        private readonly ResourceRegistryClientMock _resourceRegistryClient = new();
+
+        private SystemRegisterService CreateService() => new(
+            new Mock<ISystemRegisterRepository>().Object,
+            _resourceRegistryClient,
+            new Mock<IAccessManagementClient>().Object,
+            new Mock<ISystemChangeLogRepository>().Object);
+
+        [Fact]
+        public async Task GetInvalidResourceIdsDetailed_ResourceMarkedNotDelegable_ReportedAsNotDelegable()
+        {
+            SystemRegisterService service = CreateService();
+            List<Right> rights = [CreateRight("app_ttd_a1-nondelegable")];
+
+            var (invalidFormat, notFound, unsupportedResourceType, notDelegable) =
+                await service.GetInvalidResourceIdsDetailed(rights, CancellationToken.None);
+
+            Assert.Empty(invalidFormat);
+            Assert.Empty(notFound);
+            Assert.Empty(unsupportedResourceType);
+            Assert.Equal("app_ttd_a1-nondelegable", Assert.Single(notDelegable));
+        }
+
+        [Fact]
+        public async Task GetInvalidResourceIdsDetailed_DelegableResource_NoErrors()
+        {
+            SystemRegisterService service = CreateService();
+            List<Right> rights = [CreateRight("ske-krav-og-betalinger")];
+
+            var (invalidFormat, notFound, unsupportedResourceType, notDelegable) =
+                await service.GetInvalidResourceIdsDetailed(rights, CancellationToken.None);
+
+            Assert.Empty(invalidFormat);
+            Assert.Empty(notFound);
+            Assert.Empty(unsupportedResourceType);
+            Assert.Empty(notDelegable);
+        }
+
+        [Fact]
+        public async Task GetInvalidResourceIdsDetailed_UnsupportedResourceType_NotReportedAsNotDelegable()
+        {
+            SystemRegisterService service = CreateService();
+
+            // ttd-am-k6 is a MaskinportenSchema, which is not a supported resource type for a system user.
+            List<Right> rights = [CreateRight("ttd-am-k6")];
+
+            var (invalidFormat, notFound, unsupportedResourceType, notDelegable) =
+                await service.GetInvalidResourceIdsDetailed(rights, CancellationToken.None);
+
+            Assert.Empty(invalidFormat);
+            Assert.Empty(notFound);
+            Assert.Equal("ttd-am-k6", Assert.Single(unsupportedResourceType));
+            Assert.Empty(notDelegable);
+        }
+
+        [Fact]
+        public async Task GetInvalidResourceIdsDetailed_ResourceTurnedNotDelegable_ReportedAsNotDelegable()
+        {
+            SystemRegisterService service = CreateService();
+            List<Right> rights = [CreateRight("ske-krav-og-betalinger")];
+
+            Assert.Empty((await service.GetInvalidResourceIdsDetailed(rights, CancellationToken.None)).NotDelegableResourceIds);
+
+            _resourceRegistryClient.NotDelegableResourceIds.Add("ske-krav-og-betalinger");
+
+            var invalidResourceIds = await service.GetInvalidResourceIdsDetailed(rights, CancellationToken.None);
+            Assert.Equal("ske-krav-og-betalinger", Assert.Single(invalidResourceIds.NotDelegableResourceIds));
+        }
+
+        [Fact]
+        public async Task GetInvalidResourceIdsDetailed_ResourceNotInResourceRegistry_ReportedAsNotFound()
+        {
+            SystemRegisterService service = CreateService();
+            List<Right> rights = [CreateRight("ske-krav-og-betalinger-deleted")];
+
+            var invalidResourceIds = await service.GetInvalidResourceIdsDetailed(rights, CancellationToken.None);
+
+            Assert.Equal("ske-krav-og-betalinger-deleted", Assert.Single(invalidResourceIds.NotFoundResourceIds));
+            Assert.Empty(invalidResourceIds.NotDelegableResourceIds);
+        }
+
+        private static Right CreateRight(string resourceId) => new()
+        {
+            Resource =
+            [
+                new AttributePair
+                {
+                    Id = "urn:altinn:resource",
+                    Value = resourceId
+                }
+            ]
+        };
+    }
+}


### PR DESCRIPTION
early error/info message on notdelegable resoruces during system creation and request creation

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
