### PR TITLE
docs: Podman is a supported container runtime for the integration tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ Altinn Platform Authentication — an ASP.NET Core (.NET 10) service that authen
 # Build
 dotnet build Altinn.Platform.Authentication.sln
 
-# Test (Docker MUST be running — Testcontainers PostgreSQL)
+# Test (a container runtime MUST be running — Testcontainers PostgreSQL).
+# Podman works as a drop-in for Docker; if it fails to connect, try `podman machine start`.
 dotnet test test/Altinn.Platform.Authentication.Tests/Altinn.Platform.Authentication.Tests.csproj
 
 # Compile-only check of one project (fast)
@@ -21,7 +22,7 @@ dotnet build src/Authentication/Altinn.Platform.Authentication.csproj -clp:Error
 
 ## Critical workflow rules
 
-- **A green local `dotnet build` is NOT sufficient.** The integration tests need Docker, and compilation passing says nothing about them. The authoritative gate is the CI **Build and Test** job. If you can't run Docker, push and watch CI before claiming done.
+- **A green local `dotnet build` is NOT sufficient.** The integration tests need a container runtime (Docker *or* Podman — see [development.md](docs/development.md#container-runtime)), and compilation passing says nothing about them. The authoritative gate is the CI **Build and Test** job. Before concluding you can't run them locally, check `podman machine list` / `docker info`; a stopped Podman machine looks exactly like "no container runtime installed". If you genuinely can't run them, push and watch CI before claiming done.
 - **Branch per change; never commit to `main`.** Commit/push only when asked.
 - Update the relevant [`docs/`](docs/README.md) page or ADR **in the same PR** as a behaviour change.
 - Respond to CodeRabbit/CodeQL review comments; don't silently ignore them.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In-repo documentation lives in **[`docs/`](docs/README.md)**:
 ### Prerequisites
 
 1. [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
-2. [Docker](https://www.docker.com/get-docker) — required to run the integration tests
+2. A container runtime — required to run the integration tests: [Docker](https://www.docker.com/get-docker) or [Podman](https://podman.io/)
 3. Newest [Git](https://git-scm.com/downloads)
 4. A code editor / IDE of your choice
 
@@ -53,10 +53,10 @@ Swagger UI is then available under `http://localhost:<port>/authentication/swagg
 
 ```bash
 dotnet build Altinn.Platform.Authentication.sln
-dotnet test test/Altinn.Platform.Authentication.Tests/Altinn.Platform.Authentication.Tests.csproj   # needs Docker
+dotnet test test/Altinn.Platform.Authentication.Tests/Altinn.Platform.Authentication.Tests.csproj   # needs a container runtime
 ```
 
-See [docs/development.md](docs/development.md) for details — note that a passing local build does **not** substitute for the Docker-backed test suite.
+See [docs/development.md](docs/development.md) for details — note that a passing local build does **not** substitute for the container-backed test suite.
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ These docs are written for **both humans and AI coding agents** — the conceptu
 | [flows/sessions-and-cookies.md](flows/sessions-and-cookies.md) | Sessions, the cookie model, refresh, and logout |
 | [flows/system-user.md](flows/system-user.md) | System users (Systembruker): system register, request/approval, agent delegation |
 | [operations.md](operations.md) | Configuration, feature flags, secrets, health, observability, runbook |
-| [development.md](development.md) | Local setup, build, run, and the (Docker-backed) test strategy |
+| [development.md](development.md) | Local setup, build, run, and the (container-backed) test strategy |
 | [adr/](adr/) | Architecture Decision Records — the **why** behind the design |
 
 ## Where to start

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
-- [Docker](https://www.docker.com/get-docker) — **required for the integration tests** (they spin up PostgreSQL via Testcontainers).
+- A container runtime — **required for the integration tests** (they spin up PostgreSQL via Testcontainers). Either [Docker](https://www.docker.com/get-docker) or [Podman](https://podman.io/) works; see [Container runtime](#container-runtime) below.
 - Git, and a code editor / IDE.
 
 ## Build & run
@@ -23,12 +23,27 @@ Local runtime config comes from `appsettings.Development.json`; secrets should c
 ## Tests
 
 ```bash
-# Unit + integration tests (Docker MUST be running)
+# Unit + integration tests (a container runtime MUST be running)
 dotnet test test/Altinn.Platform.Authentication.Tests/Altinn.Platform.Authentication.Tests.csproj
 ```
 
-- **Integration tests need Docker.** Most controller tests run through a `WebApplicationFixture` backed by a Testcontainers PostgreSQL instance, applying migrations on startup. They are slow but cover real request/DB behaviour.
-- **A green local `dotnet build` is not enough.** Compilation passing does not mean the tests pass. The authoritative signal is the CI **Build and Test** job (it runs the Docker-backed suite). When you can't run Docker locally, push and watch CI.
+- **Integration tests need a container runtime.** Most controller tests run through a `WebApplicationFixture` backed by a Testcontainers PostgreSQL instance, applying migrations on startup. They are slow but cover real request/DB behaviour.
+- **A green local `dotnet build` is not enough.** Compilation passing does not mean the tests pass. The authoritative signal is the CI **Build and Test** job (it runs the container-backed suite). When you can't run containers locally, push and watch CI.
+
+### Container runtime
+
+**Podman works as a drop-in for Docker** — Testcontainers talks to its Docker-compatible API, and no Docker CLI is needed. The usual failure is simply that the machine is not running:
+
+```bash
+podman machine list     # is there a machine, and is it up?
+podman machine start
+```
+
+On Windows and macOS, `podman machine start` sets up Docker API forwarding (on Windows, `npipe:////./pipe/docker_engine`) and Testcontainers picks it up with no further configuration — rootless mode is fine, including the Ryuk resource reaper. On Linux, point Testcontainers at Podman's socket:
+
+```bash
+export DOCKER_HOST="unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')"
+```
 - `test/.../SystemIntegrationTests` and `.../PerformanceTests` are **opt-in** suites that hit deployed environments / load — not part of the normal loop.
 
 ### Testing patterns

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -54,4 +54,4 @@ The SBL-decommission flags (`EnterpriseUserAuthenticationDisabled`, `CookieTicke
 
 ## CI/CD
 
-GitHub Actions: **Build and Test** (Docker-backed integration tests), **Analyze**/**Analyze (csharp)** (CodeQL), **SonarCloud**, **CodeRabbit**, and **scan** (container scan). The Docker-backed *Build and Test* job is the authoritative gate — a green local `dotnet build` is **not** sufficient (see [development.md](development.md)).
+GitHub Actions: **Build and Test** (container-backed integration tests), **Analyze**/**Analyze (csharp)** (CodeQL), **SonarCloud**, **CodeRabbit**, and **scan** (container scan). The container-backed *Build and Test* job is the authoritative gate — a green local `dotnet build` is **not** sufficient (see [development.md](development.md)).


### PR DESCRIPTION
## Why

The docs state that Docker is required for the integration tests. Podman works as a drop-in — Testcontainers talks to its Docker-compatible API, and no Docker CLI is involved.

The practical trap is that a **stopped `podman machine` is indistinguishable from "no container runtime installed"**: `docker info` fails, `which docker` finds nothing, and the reasonable conclusion is that the Testcontainers suite can't be run locally. It can — the machine just needs starting. I hit exactly this while working on [#2154](https://github.com/Altinn/altinn-authentication/pull/2154) and skipped the container-backed tests on that basis; they run fine once `podman machine start` has been issued.

## What

- `docs/development.md`: prerequisite is now "a container runtime (Docker or Podman)", plus a short **Container runtime** section with the `podman machine list` / `podman machine start` check and the `DOCKER_HOST` override needed on Linux.
- `AGENTS.md`: same correction, and the "if you can't run Docker, push and watch CI" rule now says to verify with `podman machine list` / `docker info` first, since that is the failure mode.
- `README.md`, `docs/README.md`, `docs/operations.md`: "Docker-backed" → "container-backed".

Docs only — no code, no behaviour change.

## Verified

On Windows with Podman 5.8.3: `podman machine start` reports API forwarding on `npipe:////./pipe/docker_engine`, and the full Testcontainers suite then runs with no configuration at all — rootless mode included, Ryuk (`WithCleanUp(true)` in `DbFixture`) included.

The Linux `DOCKER_HOST` line is the standard Podman setup rather than something I verified on this machine, so treat that one as a pointer, not a tested recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
