### PR TITLE
chore(core): clear nullable warnings in ResourceRegistry (#488, Core iteration 5)

### DIFF
--- a/src/Core/Models/ResourceRegistry/AuthorizationReferenceAttribute.cs
+++ b/src/Core/Models/ResourceRegistry/AuthorizationReferenceAttribute.cs
@@ -1,26 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.Platform.Authentication.Core.Models.ResourceRegistry
 {
     /// <summary>
-    /// The reference
+    /// The reference.
     /// </summary>
+    /// <remarks>
+    /// Every observed authorizationReference entry carries both members, hence <c>null!</c>
+    /// rather than nullable - nothing in this service reads either of them.
+    /// </remarks>
     [ExcludeFromCodeCoverage]
     public class AuthorizationReferenceAttribute
     {
         /// <summary>
         /// The key for authorization reference. Used for authorization api related to resource
         /// </summary>
-        public string Id { get; set; }
+        public string Id { get; set; } = null!;
 
         /// <summary>
         /// The value for authorization reference. Used for authorization api related to resource
         /// </summary>
-        public string Value { get; set; }
+        public string Value { get; set; } = null!;
     }
 }

--- a/src/Core/Models/ResourceRegistry/CompetentAuthority.cs
+++ b/src/Core/Models/ResourceRegistry/CompetentAuthority.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Altinn.Platform.Authentication.Core.Models.ResourceRegistry
+﻿namespace Altinn.Platform.Authentication.Core.Models.ResourceRegistry
 {
     /// <summary>
     /// Model representation of Competent Authority part of the ServiceResource model
@@ -12,18 +6,19 @@ namespace Altinn.Platform.Authentication.Core.Models.ResourceRegistry
     public class CompetentAuthority
     {
         /// <summary>
-        /// The organization number
+        /// The organization number. Present on every observed competent authority.
         /// </summary>
-        public string Organization { get; set; }
+        public string Organization { get; set; } = null!;
 
         /// <summary>
-        /// The organization code
+        /// The organization code. Present on every observed competent authority.
         /// </summary>
-        public string Orgcode { get; set; }
+        public string Orgcode { get; set; } = null!;
 
         /// <summary>
-        /// The organization name. If not set it will be retrived from register based on Organization number
+        /// The organization name. If not set it will be retrieved from register based on the
+        /// organization number - and it is genuinely absent from some resource payloads.
         /// </summary>
-        public Dictionary<string, string> Name { get; set; }
+        public Dictionary<string, string>? Name { get; set; }
     }
 }

--- a/src/Core/Models/ResourceRegistry/ContactPoint.cs
+++ b/src/Core/Models/ResourceRegistry/ContactPoint.cs
@@ -1,34 +1,32 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Altinn.Platform.Authentication.Core.Models.ResourceRegistry
+﻿namespace Altinn.Platform.Authentication.Core.Models.ResourceRegistry
 {
     /// <summary>
-    /// Defines a contact point
+    /// Defines a contact point.
     /// </summary>
+    /// <remarks>
+    /// Nothing in this service reads a contact point, and no observed resource payload has
+    /// bound one, so every member is nullable.
+    /// </remarks>
     public class ContactPoint
     {
         /// <summary>
         /// The type of contact point, phone, email ++
         /// </summary>
-        public string Category { get; set; }
+        public string? Category { get; set; }
 
         /// <summary>
         /// The contact details. The actual phone number, email adress
         /// </summary>
-        public string Email { get; set; }
+        public string? Email { get; set; }
 
         /// <summary>
         /// Phone details
         /// </summary>
-        public string Telephone { get; set; }
+        public string? Telephone { get; set; }
 
         /// <summary>
         /// Contact page
         /// </summary>
-        public string ContactPage { get; set; }
+        public string? ContactPage { get; set; }
     }
 }

--- a/src/Core/Models/ResourceRegistry/Keyword.cs
+++ b/src/Core/Models/ResourceRegistry/Keyword.cs
@@ -1,24 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Altinn.Platform.Authentication.Core.Models.ResourceRegistry
+﻿namespace Altinn.Platform.Authentication.Core.Models.ResourceRegistry
 {
     /// <summary>
-    /// Model for defining keywords
+    /// Model for defining keywords.
     /// </summary>
+    /// <remarks>
+    /// Nothing in this service reads a keyword, and the only observed payload carrying the
+    /// property had an empty array, so neither member can be claimed non-null.
+    /// </remarks>
     public class Keyword
     {
         /// <summary>
         /// The key word
         /// </summary>
-        public string Word { get; set; } 
+        public string? Word { get; set; }
 
         /// <summary>
         /// Language of the key word
         /// </summary>
-        public string Language { get; set; }
+        public string? Language { get; set; }
     }
 }

--- a/src/Core/Models/ResourceRegistry/ServiceResource.cs
+++ b/src/Core/Models/ResourceRegistry/ServiceResource.cs
@@ -1,20 +1,25 @@
-﻿#nullable enable
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
-using Altinn.Platform.Authentication.Core.Models.ResourceRegistry;
 
 namespace Altinn.Platform.Authentication.Core.Models.ResourceRegistry
 {
     /// <summary>
-    /// Model describing a complete resource from the resrouce registry
+    /// Model describing a complete resource from the resource registry.
     /// </summary>
+    /// <remarks>
+    /// A partial mirror of the Resource Registry contract. This service reads only
+    /// <see cref="ResourceType"/> and whether the lookup returned anything at all, so the
+    /// nullability below is taken from the payloads themselves (see the fixtures under
+    /// test/../Data/ResourceRegistry): a member is non-nullable only where every observed
+    /// resource carries it.
+    /// </remarks>
     [ExcludeFromCodeCoverage]
     public class ServiceResource
     {
         /// <summary>
-        /// The identifier of the resource
+        /// The identifier of the resource. Present on every observed resource.
         /// </summary>
-        public string Identifier { get; set; }
+        public string Identifier { get; set; } = null!;
 
         /// <summary>
         /// The version of the resource
@@ -22,19 +27,20 @@ namespace Altinn.Platform.Authentication.Core.Models.ResourceRegistry
         public string? Version { get; set; }
 
         /// <summary>
-        /// The title of service
+        /// The title of service. Present on every observed resource.
         /// </summary>
-        public Dictionary<string, string> Title { get; set; }
+        public Dictionary<string, string> Title { get; set; } = null!;
 
         /// <summary>
-        /// Description
+        /// Description. Omitted for some resources, for instance Altinn apps.
         /// </summary>
-        public Dictionary<string, string> Description { get; set; }
+        public Dictionary<string, string>? Description { get; set; }
 
         /// <summary>
-        /// Description explaining the rights a recipient will receive if given access to the resource
+        /// Description explaining the rights a recipient will receive if given access to the
+        /// resource. Only set on some resources.
         /// </summary>
-        public Dictionary<string, string> RightDescription { get; set;  }
+        public Dictionary<string, string>? RightDescription { get; set; }
 
         /// <summary>
         /// The homepage
@@ -42,9 +48,9 @@ namespace Altinn.Platform.Authentication.Core.Models.ResourceRegistry
         public string? Homepage { get; set; }    
 
         /// <summary>
-        /// The status
+        /// The status. Omitted for some resources, for instance Altinn apps.
         /// </summary>
-        public string Status { get; set; }
+        public string? Status { get; set; }
 
         /// <summary>
         /// spatial coverage
@@ -53,9 +59,9 @@ namespace Altinn.Platform.Authentication.Core.Models.ResourceRegistry
         public List<string>? Spatial { get; set;  }
 
         /// <summary>
-        /// List of possible contact points
+        /// List of possible contact points. Never observed on a resource payload.
         /// </summary>
-        public List<ContactPoint> ContactPoints { get; set; }
+        public List<ContactPoint>? ContactPoints { get; set; }
 
         /// <summary>
         /// Linkes to the outcome of a public service
@@ -88,9 +94,9 @@ namespace Altinn.Platform.Authentication.Core.Models.ResourceRegistry
         public bool Visible { get; set; } = true; 
 
         /// <summary>
-        /// HasCompetentAuthority
+        /// The authority responsible for the resource. Present on every observed resource.
         /// </summary>
-        public CompetentAuthority HasCompetentAuthority { get; set; }
+        public CompetentAuthority HasCompetentAuthority { get; set; } = null!;
 
         /// <summary>
         /// Keywords


### PR DESCRIPTION
Fifth slice of the `Core` warnings cleanup for #488, following iterations 1 (#2136), 2 (#2141), 3 (#2143) and 4 (#2152). Clears all **18** CS8618 warnings in `Core/Models/ResourceRegistry`: **Core 48 → 30**.

## Why this one annotates instead of deleting

Worth recording, since the last three iterations all deleted dead code instead.

All eleven files in the folder arrived in a single commit (#776, *"Input validation for invalid resource id"*) and none has been touched since — except `ResourceType`, which is the one thing the service actually reads. Across the whole codebase `ServiceResource` is consumed in exactly two ways: whether `GetResource` returned null, and `resource.ResourceType` against `WhitelistedResourceTypes`. `ContactPoint`, `CompetentAuthority`, `Keyword`, `AuthorizationReferenceAttribute`, `ResourceReference` and `ResourceSearch` have **no references outside the folder at all** — they are reachable only through `ServiceResource` members nothing reads.

That makes the folder a candidate for deletion rather than annotation. But it is a partial mirror of a published external contract, #2150 is actively building on this area, and removing properties is not something to do quietly in a chore PR. **Annotated instead — the deletion question is worth deciding separately, and I'm happy to do it as a follow-up if you want it.**

## Nullability comes from the payloads, not from guesswork

The three resource fixtures under `test/…/Data/ResourceRegistry` disagree with the current types in five places. The rule applied: non-nullable only where **every** observed resource carries the member; nullable where at least one omits it, or where it was never observed at all.

| Member | Evidence | Result |
|---|---|---|
| `ServiceResource.Description` | missing from `app_endringavnavnv2` | `?` |
| `ServiceResource.RightDescription` | missing from two of three | `?` |
| `ServiceResource.Status` | missing from `app_endringavnavnv2` | `?` |
| `ServiceResource.ContactPoints` | payload key and shape never matched this model | `?` |
| `CompetentAuthority.Name` | absent from `kravogbetaling.json` | `?` |
| `Identifier`, `Title`, `HasCompetentAuthority`, `CompetentAuthority.Organization`/`Orgcode`, both `AuthorizationReferenceAttribute` members | present on every observed instance | `= null!` + reason |
| four `ContactPoint` members, both `Keyword` members | never bound by any observed payload | `?` |

`CompetentAuthority.Name` is the nicest one: the doc comment already said it may be unset and retrieved from Register instead, while the type claimed it was always there.

**No `required` anywhere in this folder** — these are inbound foreign payloads that nothing reads, so a missing property should not throw and take resource validation down with it. That is the opposite call from `AttributePair` in iteration 4, which is our own contract, carries `[Required]`, and is constructed in-process.

## Drive-by, same files

A redundant `#nullable enable` and a self-referential `using` dropped from `ServiceResource`, the unused template usings (`System`, `System.Linq`, `System.Text`, …) dropped from the four sub-models, and a `resrouce` typo fixed.

## Verification

- Clean Debug `-t:Rebuild` of the solution: **0 errors**.
- **Core 48 → 30** unique warnings; `Models/ResourceRegistry` is now empty.
- **Host unchanged at 256** — the full before/after warning sets are byte-identical.
- Locked projects still clean.
- Suite: **531 passed, 2 skipped**, plus one pre-existing environment failure — `SigningKeysRetriever_Ok` calls the live `platform.at22.altinn.cloud` well-known endpoint and fails identically on a clean `main` from this machine. CI has network to at22, so it should be green there.

These are annotation-only edits plus `= null!` initializers that assign the value the field already had, so runtime behaviour is unchanged. No `docs/` or ADR update.

## Next

`Core` iteration 6 = `Models/Rights` (15). Then `Models/Profile` 10, `Helpers` 3, `Models/Oidc` 2, and `TreatWarningsAsErrors` to lock `Core` in the last one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
